### PR TITLE
Added macros TLX_DEPRECATED and TLX_DEPRECATED_FUNC_DEF to mark funct…

### DIFF
--- a/tests/deprecated_test.cpp
+++ b/tests/deprecated_test.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * tests/deprecated.cpp
+ *
+ * Part of tlx - http://panthema.net/tlx
+ *
+ * Copyright (C) 2018 Manuel Penschuck <tlx@manuel.jetzt>
+ *
+ * All rights reserved. Published under the Boost Software License, Version 1.0
+ ******************************************************************************/
+
+#include <iostream>
+#include <tlx/define.hpp>
+
+
+
+TLX_DEPRECATED(void do_not_use_me_anymore());
+void do_not_use_me_anymore() {}
+
+TLX_DEPRECATED_FUNC_DEF(int also_do_not_use()) {
+    return 0;
+}
+
+int main() {
+    do_not_use_me_anymore();
+    also_do_not_use();
+
+
+    std::cout << "This test takes place during compilation.\n"
+                 "Nothing to see here, move on!"
+              << std::endl;
+    return 0;
+}

--- a/tlx/define.hpp
+++ b/tlx/define.hpp
@@ -19,6 +19,7 @@ print "#include <$_>\n" foreach sort glob("tlx/define/"."*.hpp");
 #include <tlx/define/attribute_format_printf.hpp>
 #include <tlx/define/attribute_packed.hpp>
 #include <tlx/define/attribute_warn_unused_result.hpp>
+#include <tlx/define/deprecated.hpp>
 #include <tlx/define/likely.hpp>
 // [[[end]]]
 

--- a/tlx/define/deprecated.hpp
+++ b/tlx/define/deprecated.hpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * tlx/define/deprecated.hpp
+ *
+ * Part of tlx - http://panthema.net/tlx
+ *
+ * Copyright (C) 2008-2009 Andreas Beckmann <beckmann@cs.uni-frankfurt.de>
+ * Copyright (C) 2013 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018 Manuel Penschuck <tlx@manuel.jetzt>
+ *
+ * All rights reserved. Published under the Boost Software License, Version 1.0
+ ******************************************************************************/
+
+#ifndef TLX_DEFINE_DEPRECATED_HEADER
+#define TLX_DEFINE_DEPRECATED_HEADER
+
+#if TLX_NO_DEPRECATED
+  #define TLX_DEPRECATED(x) x
+#elif defined(_MSC_VER)
+  #define TLX_DEPRECATED(x) __declspec(deprecated) x
+#elif defined(__clang__) || defined(__GNUG__)
+  #define TLX_DEPRECATED(x) x __attribute__((deprecated))
+#endif
+
+#define TLX_DEPRECATED_FUNC_DEF(x) TLX_DEPRECATED(x); x
+
+#endif // !TLX_DEFINE_DEPRECATED_HEADER
+


### PR DESCRIPTION
…ions as deprecated. The first macro can be applied to function prototype declarations, while the second one is used where function definition and declaration shall co-incite. Does not work with templates

*The test case will not be build as we do not have an automatic infrastructure to check that the warning is indeed shown*