### PR TITLE
Add random_bipartition_shuffle

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ tlx_build_only(cmdline_parser_example)
 
 tlx_build_test(algorithm_test)
 tlx_build_test(algorithm_multiway_merge_test)
+tlx_build_test(algorithm_random_bipartition_shuffle)
 tlx_build_test(backtrace_test)
 tlx_build_test(btree_test)
 tlx_build_test(cmdline_parser_test)

--- a/tests/algorithm_random_bipartition_shuffle.cpp
+++ b/tests/algorithm_random_bipartition_shuffle.cpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * tests/algorithm_random_bipartition_shuffle.cpp
+ *
+ * Part of tlx - http://panthema.net/tlx
+ *
+ * Copyright (C) 2018 Manuel Penschuck <tlx@manuel.jetzt>
+ *
+ * All rights reserved. Published under the Boost Software License, Version 1.0
+ ******************************************************************************/
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+#include <tlx/algorithm/random_bipartition_shuffle.hpp>
+#include <tlx/die.hpp>
+
+// This unit test performs a large number (10000) of random_shuffles, each
+// time classifying 100 elements into two groups of varying size. We then
+// test, that the number of classifications matches the theoretical predictions
+// (the number of times each element is put into a partition is distributed
+// binomially) within a large coinfidence interval.
+\
+    std::vector<unsigned> compute_histogram(unsigned size,
+                                            unsigned size_left_part,
+                                            unsigned iterations,
+                                            std::mt19937_64& prng
+                                            ) {
+    // compute histogram
+    std::vector<unsigned> counts(size, 0);
+    {
+        std::vector<unsigned> data(size);
+
+        for (unsigned iteration = 0; iteration < iterations; iteration++) {
+            // initialize data as increasing range
+            for (size_t i = 0; i < size; i++) data[i] = i;
+
+            tlx::random_bipartition_shuffle(data.begin(), data.end(),
+                                            size_left_part, prng);
+
+            // increase counter of all elements in left partition
+            for (size_t i = 0; i < size_left_part; i++)
+                counts[data[i]]++;
+        }
+    }
+
+    return counts;
+    }
+
+void check_with_100elements(unsigned left_size, unsigned confidence, std::mt19937_64& prng) {
+    auto counts = compute_histogram(100, left_size, 10000, prng);
+    unsigned lb = 100 * left_size - confidence;
+    unsigned ub = 100 * left_size + confidence;
+
+    for (unsigned c : counts) {
+        die_unless(lb < c && c < ub);
+    }
+
+    if (left_size < 50)
+        check_with_100elements(100 - left_size, confidence, prng);
+}
+
+int main() {
+    std::mt19937_64 prng(1);
+
+    // confidence intervals are selected that the error prob for
+    // each element is less than 1e-6; using a union bound, the
+    // error probability for each test is less than 0.1%
+    for (int i = 0; i < 10; i++) {
+        check_with_100elements(1, 45, prng);
+        check_with_100elements(2, 80, prng);
+        check_with_100elements(5, 110, prng);
+        check_with_100elements(10, 145, prng);
+        check_with_100elements(20, 190, prng);
+    }
+
+    return 0;
+}
+
+/******************************************************************************/

--- a/tlx/algorithm.hpp
+++ b/tlx/algorithm.hpp
@@ -26,6 +26,7 @@ print "#include <$_>\n" foreach sort glob("tlx/algorithm/"."*.hpp");
 #include <tlx/algorithm/multiway_merge.hpp>
 #include <tlx/algorithm/multiway_merge_splitting.hpp>
 #include <tlx/algorithm/parallel_multiway_merge.hpp>
+#include <tlx/algorithm/random_bipartition_shuffle.hpp>
 // [[[end]]]
 
 #endif // !TLX_ALGORITHM_HEADER

--- a/tlx/algorithm/random_bipartition_shuffle.hpp
+++ b/tlx/algorithm/random_bipartition_shuffle.hpp
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * tlx/algorithm/random_bipartition_shuffle.hpp
+ *
+ * Part of tlx - http://panthema.net/tlx
+ *
+ * Copyright (C) 2018 Manuel Penschuck <tlx@manuel.jetzt>
+ *
+ * All rights reserved. Published under the Boost Software License, Version 1.0
+ ******************************************************************************/
+
+#ifndef TLX_ALGORITHM_RANDOM_BIPARTITION_SHUFFLE_HEADER
+#define TLX_ALGORITHM_RANDOM_BIPARTITION_SHUFFLE_HEADER
+
+#include <cassert>
+#include <iterator>
+#include <random>
+
+namespace tlx {
+
+//! \addtogroup tlx_algorithm
+//! \{
+
+/*!
+ * Similarly to std::shuffle, but only generates a random bi-partition.
+ * In the result, the
+ *   the left  partition class is stored at positions 0 to size_left_partition-1
+ *   the right partition class is stored at positions size_left_partition to n
+ * where n = std::distance(begin, end).
+ *
+ * Each element is moved to the left partition with probability
+ * (size_left_partition / n). There are no guarantees on the order WITHIN a
+ * partition (which makes this function considerable faster than std::shuffle
+ * especially if partition sizes are unbalanced). The runtime complexity is
+ * linear in the size of the smaller partition class.
+ *
+ * \param begin                Iterator to the begin of the data frame
+ * \param end                  Iterator to the end of the data frame
+ * \param size_left_partition  Number of elements to be put into the left
+ *                             partition: 0 <= size_left_partition <= n
+ * \param urng                 Random number generator compatible with STL
+ *                             interface, e.g. std::mt19937
+ */
+template <typename RandomAccessIt, typename RandomBits>
+void random_bipartition_shuffle(RandomAccessIt begin, RandomAccessIt end,
+                                size_t size_left_partition, RandomBits& urng) {
+    const size_t size = std::distance(begin, end);
+    assert(size_left_partition <= size);
+
+    // ensure that both paritions are non-empty
+    const size_t size_right_partition = size - size_left_partition;
+    if (!size_left_partition || !size_right_partition) return;
+
+    // this idea is borrow from GNU stdlibc++ and generates two random
+    // variates uniform on [0, a) and [0, b) respectively.
+    auto two_random_variates =
+        [&urng](size_t a, size_t b) {
+            auto x = std::uniform_int_distribution<size_t>{ 0, (a * b) - 1 } (urng);
+            return std::make_pair(x / b, x % b);
+        };
+
+    using std::swap; // allow ADL
+
+    // Perform a Fisher-Yates shuffle, but iterate only over the positions
+    // of the smaller partition.
+    if (size_left_partition < size_right_partition) {
+        auto it = begin;
+
+        // To avoid wasted random bits, we draw two variates at once
+        // and shuffle two positions per iteration
+        for (size_t i = 1; i < size_left_partition; i += 2) {
+            auto rand = two_random_variates(size - i + 1, size - i);
+            swap(*it++, *std::next(begin, size - 1 - rand.first));
+            swap(*it++, *std::next(begin, size - 1 - rand.second));
+        }
+
+        // In case the partition contains an odd number of elements,
+        // there's a special case for the last element
+        if (size_left_partition % 2) {
+            auto x = std::uniform_int_distribution<size_t>{ size_left_partition - 1, size - 1 } (urng);
+            swap(*it, *std::next(begin, x));
+        }
+    }
+    else {
+        // Symmetric case to above, this time shuffling the right partition
+        auto it = std::next(begin, size - 1);
+
+        for (size_t i = size - 2; i >= size_left_partition; i -= 2) {
+            auto rand = two_random_variates(i + 2, i + 1);
+            swap(*it--, *std::next(begin, rand.first));
+            swap(*it--, *std::next(begin, rand.second));
+        }
+
+        if (size_right_partition % 2) {
+            auto x = std::uniform_int_distribution<size_t>{ 0, size_left_partition } (urng);
+            swap(*it--, *std::next(begin, x));
+        }
+    }
+}
+
+//! \}
+
+} // namespace tlx
+
+#endif // !TLX_ALGORITHM_RANDOM_BIPARTITION_SHUFFLE_HEADER
+/******************************************************************************/


### PR DESCRIPTION
This helper function is similar to std::shuffle, but does not generate a random permutation, but rather randomly put elements in one of two bi-partition classes. It uses a Fisher-Yates shuffle, but only performs shuffles linear in the size of the smaller bi-partition.

Especially in case of unbalanced bi-partitions this implementation gives a significant speed-up over std::shuffle. We used it in two different projects which only share tlx. So at least for me, adding it to TLX seems sensible.
