### PR TITLE
Power to the

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ tlx is a collection of C++ helpers and extensions universally needed, but not fo
 - Data Structures : `RingBuffer`, `SimpleVector`, B+ Trees, Loser Trees, `RadixHeap`, `(Addressable) D-Ary Heap`
 - Defines and Macros : `TLX_LIKELY`, `TLX_UNLIKELY`, `TLX_ATTRIBUTE_PACKED`, `TLX_ATTRIBUTE_ALWAYS_INLINE`, `TLX_ATTRIBUTE_FORMAT_PRINTF`, `TLX_DEPRECATED_FUNC_DEF`.
 - Message Digests : `MD5`, `md5_hex()`, `SHA1`, `sha1_hex()`, `SHA256`, `sha256_hex()`, `SHA512`, `sha512_hex()`.
-- Math Functions : `integer_log2_floor()`, `is_power_of_two()`, `round_up_to_power_of_two()`, `round_down_to_power_of_two()`, `ffs()`, `clz()`, `abs_diff()`, `bswap32()`, `bswap64()`, `popcount()`, `Aggregate`, `PolynomialRegression`.
+- Math Functions : `integer_log2_floor()`, `is_power_of_two()`, `round_up_to_power_of_two()`, `round_down_to_power_of_two()`, `ffs()`, `clz()`, `abs_diff()`, `bswap32()`, `bswap64()`, `popcount()`, `power_to_the`, `Aggregate`, `PolynomialRegression`.
 - String Algorithms : `starts_with()`, `ends_with()`, `contains()`, `contains_word()`, `trim()`, `replace_all()`, `erase_all()`, `join()`, `split()`, `split_words()`, `union_words()`, `split_quoted()`, `join_quoted()`, `to_lower()`, `hexdump()`, `bitdump_le8()`, `word_wrap()`, `escape_html()`, `parse_si_iec_units()`, `format_iec_units()`, `ssprintf()`, `expand_environment_variables()`, `levenshtein()`, `hash_djb2()`, `hash_sdbm()`.
 - Meta-Template Programming : `call_foreach()`, `apply_tuple()`, `vmap_foreach()`, `Log2Floor`, `FunctionChain`, `FunctionStack`, `is_std_pair`, `is_std_tuple`, `is_std_vector`, `is_std_array`, `TLX_MAKE_HAS_MEMBER`.
 - Sorting Algorithms : `sort_strings()` (using radix sort and multikey quicksort), `parallel_mergesort()` (experimental parallel mergesort from MCSTL).

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <random>
 #include <vector>
 
 #include <tlx/die.hpp>
@@ -188,6 +189,45 @@ static void test_popcount() {
     }
 }
 
+template <unsigned D = 7>
+static void test_power_to_the_real() {
+    using T = double;
+    std::mt19937_64 prng(D);
+    std::uniform_real_distribution<T> dist(-1e2, 1e2);
+
+    for (int i = 0; i < 1000; ++i) {
+        const T x = dist(prng);
+        const auto tested = tlx::power_to_the<D>(x);
+
+        auto ref = T{ 1 };
+        for (int j = 0; j < static_cast<int>(D); ++j)
+            ref *= x;
+
+        die_unequal_eps(tested, ref, fabs(ref / 1e10));
+    }
+
+    if (D > 0)
+        test_power_to_the_real<(D > 0) ? D - 1 : 0>();
+}
+
+template <unsigned D = 7>
+static void test_power_to_the_int() {
+    using T = int64_t;
+
+    for (auto x = T{ -100 }; x < 100; ++x) {
+        const auto tested = tlx::power_to_the<D>(x);
+
+        auto ref = T{ 1 };
+        for (int j = 0; j < static_cast<int>(D); ++j)
+            ref *= x;
+
+        die_unequal(tested, ref);
+    }
+
+    if (D > 0)
+        test_power_to_the_real<(D > 0) ? D - 1 : 0>();
+}
+
 static void test_rol() {
     die_unequal(tlx::rol32_generic(0x12345678u, 1), 0x2468ACF0u);
     die_unequal(tlx::rol32(0x12345678u, 1), 0x2468ACF0u);
@@ -272,13 +312,14 @@ static void test_sgn() {
 }
 
 int main() {
-
     test_bswap();
     test_clz();
     test_ffs();
     test_integer_log2();
     test_is_power_of_two();
     test_popcount();
+    test_power_to_the_real<>();
+    test_power_to_the_int<>();
     test_rol();
     test_ror();
     test_round_to_power_of_two();

--- a/tlx/die/core.hpp
+++ b/tlx/die/core.hpp
@@ -12,6 +12,7 @@
 #define TLX_DIE_CORE_HEADER
 
 #include <cstring>
+#include <iomanip>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/tlx/math.hpp
+++ b/tlx/math.hpp
@@ -30,6 +30,7 @@ print "#include <$_>\n" foreach sort glob("tlx/math/"."*.hpp");
 #include <tlx/math/is_power_of_two.hpp>
 #include <tlx/math/polynomial_regression.hpp>
 #include <tlx/math/popcount.hpp>
+#include <tlx/math/power_to_the.hpp>
 #include <tlx/math/rol.hpp>
 #include <tlx/math/ror.hpp>
 #include <tlx/math/round_to_power_of_two.hpp>

--- a/tlx/math/power_to_the.hpp
+++ b/tlx/math/power_to_the.hpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * tlx/math/power_to_the.hpp
+ *
+ * power_to_the<D>(x) raises x to the D-th power using log(D) unrolled
+ * multiplications.
+ *
+ * Part of tlx - http://panthema.net/tlx
+ *
+ * Copyright (C) 2019 Manuel Penschuck <tlx@manuel.jetzt>
+ *
+ * All rights reserved. Published under the Boost Software License, Version 1.0
+ ******************************************************************************/
+
+#ifndef TLX_MATH_POWER_TO_THE_HEADER
+#define TLX_MATH_POWER_TO_THE_HEADER
+
+#include <tlx/math/div_ceil.hpp>
+
+namespace tlx {
+
+//! \addtogroup tlx_math
+//! \{
+
+/******************************************************************************/
+//! power_to_the<D>(x)
+
+//! returns x raised to the power of D using log(D) explicit multiplications.
+template <unsigned D, typename T>
+static inline constexpr
+T power_to_the(T x) {
+    // Compiler optimize two calls to the same recursion into one
+    // Tested with GCC 4+, Clang 3+, MSVC 15+
+    return D < 1 ? 1
+           : D == 1 ? x
+           : power_to_the<D / 2>(x) * power_to_the<div_ceil(D, 2)>(x);
+}
+
+//! \}
+
+} // namespace tlx
+
+#endif // !TLX_MATH_POWER_TO_THE_HEADER
+
+/******************************************************************************/


### PR DESCRIPTION
This PR adds the math function `power_to_the<k>(x)` which builds uses iterated pows to compute `pow(x, k)` using O(log k) multiplications. For small values of k this is much faster than `pow`.

The PR also adds a missing `iomanip` header to `die.hpp` needed for `std::setprecision` which is used by die_unless_eps.