### PR TITLE
New method build_heap

### DIFF
--- a/tests/container/d_ary_heap_test.cpp
+++ b/tests/container/d_ary_heap_test.cpp
@@ -133,6 +133,19 @@ void d_ary_heap_test(size_t size, uint32_t r_seed = 42) {
     std::mt19937 gen(r_seed);
     std::shuffle(keys.begin(), keys.end(), gen);
     fill_heap_and_set(x, s, keys);
+
+    // Test build_heap().
+    x.clear();
+    x.build_heap(s.begin(), s.end());
+    check_heap(x, s);
+
+    tlx::DAryHeap<KeyType, Arity, Compare> y, z;
+    y.build_heap(keys);
+    check_heap(y, s);
+
+    z.build_heap(std::move(keys));
+    check_heap(z, s);
+
 }
 
 //! Basic APIs: push(), top(), pop(), and remove().
@@ -166,6 +179,19 @@ void d_ary_addressable_int_heap_test(size_t size, uint32_t r_seed = 42) {
         s.erase(s.find(key));
         check_heap(x, s);
     }
+
+    // Test build_heap().
+    fill_heap_and_set(x, s, keys);
+    x.clear();
+    x.build_heap(keys);
+    check_heap(x, s);
+
+    tlx::DAryAddressableIntHeap<KeyType, Arity, Compare> y, z;
+    y.build_heap(s.begin(), s.end());
+    check_heap(y, s);
+
+    z.build_heap(std::move(keys));
+    check_heap(z, s);
 }
 
 //! Tests update().
@@ -205,6 +231,16 @@ void d_ary_heap_test_update(size_t size, std::vector<double>& prio,
     s.clear();
     for (auto key : keys) {
         s.insert(key);
+    }
+    check_heap(x, s);
+
+    //! Test update_all().
+    std::shuffle(prio.begin(), prio.end(), gen);
+    x.update_all();
+
+    s.clear();
+    for (auto key : keys){
+      s.insert(key);
     }
     check_heap(x, s);
 

--- a/tlx/container/d_ary_addressable_int_heap.hpp
+++ b/tlx/container/d_ary_addressable_int_heap.hpp
@@ -171,6 +171,11 @@ public:
         return top_item;
     }
 
+    //! Rebuilds the heap.
+    void update_all() {
+      heapify();
+    }
+
     /*!
      * Updates the priority queue after the priority associated to the item with
      * key \c key has been changed; if the key \c key is not present in the
@@ -195,6 +200,28 @@ public:
     //! Returns true if the key \c key is in the heap, false otherwise.
     bool contains(key_type key) const {
         return key < handles_.size() ? handles_[key] != not_present() : false;
+    }
+
+    //! Builds a heap from a container.
+    template <class InputIterator>
+    void build_heap(InputIterator first, InputIterator last) {
+        heap_.assign(first, last);
+        heapify();
+    }
+
+    //! Builds a heap from the vector \c keys. Items of \c keys are copied.
+    void build_heap(const std::vector<key_type> &keys) {
+        heap_.resize(keys.size());
+        std::copy(keys.begin(), keys.end(), heap_.begin());
+        heapify();
+    }
+
+    //! Builds a heap from the vector \c keys. Items of \c keys are moved.
+    void build_heap(std::vector<key_type> &&keys) {
+        if (!empty())
+            heap_.clear();
+        heap_ = std::move(keys);
+        heapify();
     }
 
     //! For debugging: runs a BFS from the root node and verifies that the heap
@@ -287,6 +314,51 @@ private:
         handles_[value] = k;
         heap_[k] = std::move(value);
     }
+
+    //! Reorganize heap_ into a heap.
+    void heapify() {
+        //! Initialize handles_ vector
+        auto assign_handles = [&]() {
+            handles_.resize(heap_.size());
+            for (size_t i = 0; i < heap_.size(); ++i)
+                handles_[heap_[i]] = i;
+        };
+
+        if (heap_.size() < 2) {
+            assign_handles();
+            return;
+        }
+
+        // Iterate from the last internal node up to the root.
+        size_t last_internal = (heap_.size() - 2) / arity;
+        for (size_t i = last_internal + 1; i; --i) {
+            // Index of the current internal node.
+            size_t cur = i - 1;
+            key_type value = std::move(heap_[cur]);
+
+            do {
+                size_t l = left(cur);
+                // Find the minimum child of cur.
+                size_t min_elem = l;
+                for (size_t j = l + 1; j - l < arity && j < heap_.size(); ++j) {
+                    if (cmp_(heap_[j], heap_[min_elem]))
+                        min_elem = j;
+                }
+
+                // One of the children of cur is less then cur: swap and
+                // do another iteration.
+                if (cmp_(heap_[min_elem], value)) {
+                    heap_[cur] = std::move(heap_[min_elem]);
+                    cur = min_elem;
+                }
+                else
+                    break;
+            } while (cur <= last_internal);
+            heap_[cur] = std::move(value);
+        }
+        assign_handles();
+    }
+
 };
 
 //! make template alias due to similarity with std::priority_queue

--- a/tlx/container/d_ary_heap.hpp
+++ b/tlx/container/d_ary_heap.hpp
@@ -119,6 +119,33 @@ public:
         return top_item;
     }
 
+    //! Rebuilds the heap.
+    void update_all() {
+      heapify();
+    }
+
+    //! Builds a heap from a container.
+    template <class InputIterator>
+    void build_heap(InputIterator first, InputIterator last) {
+        heap_.assign(first, last);
+        heapify();
+    }
+
+    //! Builds a heap from the vector \c keys. Items of \c keys are copied.
+    void build_heap(const std::vector<key_type> &keys) {
+        heap_.resize(keys.size());
+        std::copy(keys.begin(), keys.end(), heap_.begin());
+        heapify();
+    }
+
+    //! Builds a heap from the vector \c keys. Items of \c keys are moved.
+    void build_heap(std::vector<key_type> &&keys) {
+        if (!empty())
+            heap_.clear();
+        heap_ = std::move(keys);
+        heapify();
+    }
+
     //! For debugging: runs a BFS from the root node and verifies that the heap
     //! property is respected.
     bool sanity_check() {
@@ -191,6 +218,40 @@ private:
             k = c;
         }
         heap_[k] = std::move(value);
+    }
+
+    //! Reorganize heap_ into a heap.
+    void heapify() {
+        if (heap_.size() < 2)
+            return;
+
+        // Iterate from the last internal node up to the root.
+        size_t last_internal = (heap_.size() - 2) / arity;
+        for (size_t i = last_internal + 1; i; --i) {
+            // Index of the current internal node.
+            size_t cur = i - 1;
+            key_type value = std::move(heap_[cur]);
+
+            do {
+                size_t l = left(cur);
+                // Find the minimum child of cur.
+                size_t min_elem = l;
+                for (size_t j = l + 1; j - l < arity && j < heap_.size(); ++j) {
+                    if (cmp_(heap_[j], heap_[min_elem]))
+                        min_elem = j;
+                }
+
+                // One of the children of cur is less then cur: swap and
+                // do another iteration.
+                if (cmp_(heap_[min_elem], value)) {
+                    heap_[cur] = std::move(heap_[min_elem]);
+                    cur = min_elem;
+                }
+                else
+                    break;
+            } while (cur <= last_internal);
+            heap_[cur] = std::move(value);
+        }
     }
 };
 


### PR DESCRIPTION
`d_ary_(addressable_int_)heap` laks of an efficient method to build the heap starting from an existing set of keys. This provides a new `build_heap` method that builds a heap from a given set of keys in linear time, which is considerably faster than sequentially pushing new keys into an initially empty heap. For further efficiency, `build_heap` is overloaded to also accept an rvalue reference to a vector of keys.