### PR TITLE
Fix handles resize in heapify()

### DIFF
--- a/tests/container/d_ary_heap_test.cpp
+++ b/tests/container/d_ary_heap_test.cpp
@@ -100,6 +100,12 @@ void check_heap(DAryHeap& heap, Set& set) {
     }
 }
 
+template <typename DAryAddressableIntHeap, typename Set>
+void check_handles(DAryAddressableIntHeap& heap, Set& set) {
+    for (auto elem = set.begin(); elem != set.end(); ++elem)
+        die_unless(heap.contains(*elem));
+}
+
 template <typename DAryHeap, typename Set, typename KeysVector>
 void fill_heap_and_set(DAryHeap& heap, Set& set, KeysVector& keys) {
     for (const typename KeysVector::value_type& key : keys) {
@@ -166,6 +172,7 @@ void d_ary_addressable_int_heap_test(size_t size, uint32_t r_seed = 42) {
         x.pop();
         s.erase(s.begin());
         check_heap(x, s);
+        check_handles(x, s);
     }
 
     std::mt19937 gen(r_seed);
@@ -177,6 +184,7 @@ void d_ary_addressable_int_heap_test(size_t size, uint32_t r_seed = 42) {
         x.remove(key);
         s.erase(s.find(key));
         check_heap(x, s);
+        check_handles(x, s);
     }
 
     // Test build_heap().
@@ -184,13 +192,16 @@ void d_ary_addressable_int_heap_test(size_t size, uint32_t r_seed = 42) {
     x.clear();
     x.build_heap(keys);
     check_heap(x, s);
+    check_handles(x, s);
 
     tlx::DAryAddressableIntHeap<KeyType, Arity, Compare> y, z;
     y.build_heap(s.begin(), s.end());
     check_heap(y, s);
+    check_handles(y, s);
 
     z.build_heap(std::move(keys));
     check_heap(z, s);
+    check_handles(z, s);
 }
 
 //! Tests update().

--- a/tlx/container/d_ary_addressable_int_heap.hpp
+++ b/tlx/container/d_ary_addressable_int_heap.hpp
@@ -317,6 +317,7 @@ private:
 
     //! Reorganize heap_ into a heap.
     void heapify() {
+        key_type max_key = heap_.empty() ? 0 : heap_.front();
         if (heap_.size() >= 2) {
             // Iterate from the last internal node up to the root.
             size_t last_internal = (heap_.size() - 2) / arity;
@@ -324,15 +325,18 @@ private:
                 // Index of the current internal node.
                 size_t cur = i - 1;
                 key_type value = std::move(heap_[cur]);
+                max_key = std::max(max_key, value);
 
                 do {
                     size_t l = left(cur);
+                    max_key = std::max(max_key, heap_[l]);
                     // Find the minimum child of cur.
                     size_t min_elem = l;
                     for (size_t j = l + 1;
                          j - l < arity && j < heap_.size(); ++j) {
                         if (cmp_(heap_[j], heap_[min_elem]))
                             min_elem = j;
+                        max_key = std::max(max_key, heap_[j]);
                     }
 
                     // One of the children of cur is less then cur: swap and
@@ -348,7 +352,7 @@ private:
             }
         }
         // initialize handles_ vector
-        handles_.resize(heap_.size());
+        handles_.resize(std::max(handles_.size(), static_cast<size_t>(max_key) + 1), not_present());
         for (size_t i = 0; i < heap_.size(); ++i)
             handles_[heap_[i]] = i;
     }


### PR DESCRIPTION
If `update_all()` is called after some elements were removed from the heap, the handles are not updated correctly. This happens because the vector containing them is wrongly resized, and thus the heap does not work correctly anymore. To fix this issue, `heapify()` tracks the largest key in the heap, and avoids to shrink the size of the handles vector. This also includes a new test to check that the handles are updated correctly.