### PR TITLE
logger: Add spaces after comma when printing containers

### DIFF
--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -45,19 +45,19 @@ int main() {
               sLOG1 << 42 << "abc";
           });
 
-    check("(42,abc)\n(42,abc)\n",
+    check("(42, abc)\n(42, abc)\n",
           []() {
               LOG1 << std::make_pair(42, "abc");
               sLOG1 << std::make_pair(42, "abc");
           });
 
-    check("(42,abc,5)\n(42,abc,5)\n",
+    check("(42, abc, 5)\n(42, abc, 5)\n",
           []() {
               LOG1 << std::make_tuple(42, "abc", 5);
               sLOG1 << std::make_tuple(42, "abc", 5);
           });
 
-    check("(42,abc)\n(42,abc)\n",
+    check("(42, abc)\n(42, abc)\n",
           []() {
               LOG1 << std::make_tuple(42, "abc");
               sLOG1 << std::make_tuple(42, "abc");
@@ -75,13 +75,13 @@ int main() {
               sLOG1 << std::make_tuple();
           });
 
-    check("(42,(abc,10),5)\n(42,(abc,10),5)\n",
+    check("(42, (abc, 10), 5)\n(42, (abc, 10), 5)\n",
           []() {
               LOG1 << std::make_tuple(42, std::make_pair("abc", 10), 5);
               sLOG1 << std::make_tuple(42, std::make_pair("abc", 10), 5);
           });
 
-    check("[42,5,31]\n[42,5,31]\n",
+    check("[42, 5, 31]\n[42, 5, 31]\n",
           []() {
               std::vector<int> v {
                   { 42, 5, 31 }
@@ -90,7 +90,7 @@ int main() {
               sLOG1 << v;
           });
 
-    check("[42,5,31]\n[42,5,31]\n",
+    check("[42, 5, 31]\n[42, 5, 31]\n",
           []() {
               std::array<int, 3> a {
                   { 42, 5, 31 }
@@ -99,7 +99,7 @@ int main() {
               sLOG1 << a;
           });
 
-    check("[42,5,31]\n[42,5,31]\n",
+    check("[42, 5, 31]\n[42, 5, 31]\n",
           []() {
               std::deque<int> d {
                   { 42, 5, 31 }
@@ -108,7 +108,7 @@ int main() {
               sLOG1 << d;
           });
 
-    check("{5,31,42}\n{5,31,42}\n",
+    check("{5, 31, 42}\n{5, 31, 42}\n",
           []() {
               std::set<int> s {
                   { 42, 5, 31 }
@@ -117,7 +117,7 @@ int main() {
               sLOG1 << s;
           });
 
-    check("{5,5,31,42}\n{5,5,31,42}\n",
+    check("{5, 5, 31, 42}\n{5, 5, 31, 42}\n",
           []() {
               std::multiset<int> s {
                   { 42, 5, 31, 5 }
@@ -126,7 +126,7 @@ int main() {
               sLOG1 << s;
           });
 
-    check("{5=b,31=c,42=a}\n{5=b,31=c,42=a}\n",
+    check("{5=b, 31=c, 42=a}\n{5=b, 31=c, 42=a}\n",
           []() {
               std::map<int, const char*> m {
                   { 42, "a" }, { 5, "b" }, { 31, "c" }
@@ -135,7 +135,7 @@ int main() {
               sLOG1 << m;
           });
 
-    check("{5=b,31=c,42=a}\n{5=b,31=c,42=a}\n",
+    check("{5=b, 31=c, 42=a}\n{5=b, 31=c, 42=a}\n",
           []() {
               std::multimap<int, const char*> m {
                   { 42, "a" }, { 5, "b" }, { 31, "c" }
@@ -151,7 +151,7 @@ int main() {
               sLOG1 << s;
           });
 
-    check("{42,42}\n{42,42}\n",
+    check("{42, 42}\n{42, 42}\n",
           []() {
               std::unordered_multiset<int> s { 42, 42 };
               LOG1 << s;

--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -45,19 +45,19 @@ int main() {
               sLOG1 << 42 << "abc";
           });
 
-    check("(42, abc)\n(42, abc)\n",
+    check("(42,abc)\n(42, abc)\n",
           []() {
               LOG1 << std::make_pair(42, "abc");
               sLOG1 << std::make_pair(42, "abc");
           });
 
-    check("(42, abc, 5)\n(42, abc, 5)\n",
+    check("(42,abc,5)\n(42, abc, 5)\n",
           []() {
               LOG1 << std::make_tuple(42, "abc", 5);
               sLOG1 << std::make_tuple(42, "abc", 5);
           });
 
-    check("(42, abc)\n(42, abc)\n",
+    check("(42,abc)\n(42, abc)\n",
           []() {
               LOG1 << std::make_tuple(42, "abc");
               sLOG1 << std::make_tuple(42, "abc");
@@ -75,13 +75,13 @@ int main() {
               sLOG1 << std::make_tuple();
           });
 
-    check("(42, (abc, 10), 5)\n(42, (abc, 10), 5)\n",
+    check("(42,(abc,10),5)\n(42, (abc, 10), 5)\n",
           []() {
               LOG1 << std::make_tuple(42, std::make_pair("abc", 10), 5);
               sLOG1 << std::make_tuple(42, std::make_pair("abc", 10), 5);
           });
 
-    check("[42, 5, 31]\n[42, 5, 31]\n",
+    check("[42,5,31]\n[42, 5, 31]\n",
           []() {
               std::vector<int> v {
                   { 42, 5, 31 }
@@ -90,7 +90,7 @@ int main() {
               sLOG1 << v;
           });
 
-    check("[42, 5, 31]\n[42, 5, 31]\n",
+    check("[42,5,31]\n[42, 5, 31]\n",
           []() {
               std::array<int, 3> a {
                   { 42, 5, 31 }
@@ -99,7 +99,7 @@ int main() {
               sLOG1 << a;
           });
 
-    check("[42, 5, 31]\n[42, 5, 31]\n",
+    check("[42,5,31]\n[42, 5, 31]\n",
           []() {
               std::deque<int> d {
                   { 42, 5, 31 }
@@ -108,7 +108,7 @@ int main() {
               sLOG1 << d;
           });
 
-    check("{5, 31, 42}\n{5, 31, 42}\n",
+    check("{5,31,42}\n{5, 31, 42}\n",
           []() {
               std::set<int> s {
                   { 42, 5, 31 }
@@ -117,7 +117,7 @@ int main() {
               sLOG1 << s;
           });
 
-    check("{5, 5, 31, 42}\n{5, 5, 31, 42}\n",
+    check("{5,5,31,42}\n{5, 5, 31, 42}\n",
           []() {
               std::multiset<int> s {
                   { 42, 5, 31, 5 }
@@ -126,7 +126,7 @@ int main() {
               sLOG1 << s;
           });
 
-    check("{5=b, 31=c, 42=a}\n{5=b, 31=c, 42=a}\n",
+    check("{5=b,31=c,42=a}\n{5=b, 31=c, 42=a}\n",
           []() {
               std::map<int, const char*> m {
                   { 42, "a" }, { 5, "b" }, { 31, "c" }
@@ -135,7 +135,7 @@ int main() {
               sLOG1 << m;
           });
 
-    check("{5=b, 31=c, 42=a}\n{5=b, 31=c, 42=a}\n",
+    check("{5=b,31=c,42=a}\n{5=b, 31=c, 42=a}\n",
           []() {
               std::multimap<int, const char*> m {
                   { 42, "a" }, { 5, "b" }, { 31, "c" }
@@ -151,7 +151,7 @@ int main() {
               sLOG1 << s;
           });
 
-    check("{42, 42}\n{42, 42}\n",
+    check("{42,42}\n{42, 42}\n",
           []() {
               std::unordered_multiset<int> s { 42, 42 };
               LOG1 << s;

--- a/tlx/logger/array.hpp
+++ b/tlx/logger/array.hpp
@@ -21,13 +21,14 @@ template <typename T, size_t N>
 class LoggerFormatter<std::array<T, N> >
 {
 public:
-    static void print(std::ostream& os, const std::array<T, N>& data) {
+    static void print(std::ostream& os, const std::array<T, N>& data, const bool addSpace) {
         os << '[';
         for (typename std::array<T, N>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<T>::print(os, *it);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<T>::print(os, *it, addSpace);
         }
         os << ']';
     }

--- a/tlx/logger/array.hpp
+++ b/tlx/logger/array.hpp
@@ -26,7 +26,7 @@ public:
         for (typename std::array<T, N>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<T>::print(os, *it);
         }
         os << ']';

--- a/tlx/logger/core.hpp
+++ b/tlx/logger/core.hpp
@@ -243,7 +243,7 @@ public:
     static void print(std::ostream& os, const std::pair<A, B>& p) {
         os << '(';
         LoggerFormatter<A>::print(os, p.first);
-        os << ',';
+        os << ", ";
         LoggerFormatter<B>::print(os, p.second);
         os << ')';
     }
@@ -258,7 +258,7 @@ public:
         for (typename std::vector<T>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<T>::print(os, *it);
         }
         os << ']';

--- a/tlx/logger/core.hpp
+++ b/tlx/logger/core.hpp
@@ -88,7 +88,7 @@ public:
     //! output any type, including io manipulators
     template <typename AnyType>
     Logger& operator << (const AnyType& at) {
-        LoggerFormatter<AnyType>::print(oss_, at);
+        LoggerFormatter<AnyType>::print(oss_, at, false);
         return *this;
     }
 
@@ -118,7 +118,7 @@ public:
     SpacingLogger& operator << (const AnyType& at) {
         if (!first_) oss_ << ' ';
         else first_ = false;
-        LoggerFormatter<AnyType>::print(oss_, at);
+        LoggerFormatter<AnyType>::print(oss_, at, true);
         return *this;
     }
 
@@ -231,7 +231,8 @@ template <typename AnyType>
 class LoggerFormatter<AnyType>
 {
 public:
-    static void print(std::ostream& os, const AnyType& t) {
+    static void print(std::ostream& os, const AnyType& t, const bool addSpace) {
+	(void)addSpace;
         os << t;
     }
 };
@@ -240,11 +241,12 @@ template <typename A, typename B>
 class LoggerFormatter<std::pair<A, B> >
 {
 public:
-    static void print(std::ostream& os, const std::pair<A, B>& p) {
+    static void print(std::ostream& os, const std::pair<A, B>& p, const bool addSpace) {
         os << '(';
-        LoggerFormatter<A>::print(os, p.first);
-        os << ", ";
-        LoggerFormatter<B>::print(os, p.second);
+        LoggerFormatter<A>::print(os, p.first, addSpace);
+        os << ',';
+	if (addSpace) os << ' ';
+        LoggerFormatter<B>::print(os, p.second, addSpace);
         os << ')';
     }
 };
@@ -253,13 +255,14 @@ template <typename T, class A>
 class LoggerFormatter<std::vector<T, A> >
 {
 public:
-    static void print(std::ostream& os, const std::vector<T, A>& data) {
+    static void print(std::ostream& os, const std::vector<T, A>& data, const bool addSpace) {
         os << '[';
         for (typename std::vector<T>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<T>::print(os, *it);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<T>::print(os, *it, addSpace);
         }
         os << ']';
     }

--- a/tlx/logger/deque.hpp
+++ b/tlx/logger/deque.hpp
@@ -21,13 +21,14 @@ template <typename T, typename A>
 class LoggerFormatter<std::deque<T, A> >
 {
 public:
-    static void print(std::ostream& os, const std::deque<T, A>& data) {
+    static void print(std::ostream& os, const std::deque<T, A>& data, const bool addSpace) {
         os << '[';
         for (typename std::deque<T, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<T>::print(os, *it);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<T>::print(os, *it, addSpace);
         }
         os << ']';
     }

--- a/tlx/logger/deque.hpp
+++ b/tlx/logger/deque.hpp
@@ -26,7 +26,7 @@ public:
         for (typename std::deque<T, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<T>::print(os, *it);
         }
         os << ']';

--- a/tlx/logger/map.hpp
+++ b/tlx/logger/map.hpp
@@ -26,7 +26,7 @@ public:
         for (typename std::map<K, V, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<K>::print(os, it->first);
             os << '=';
             LoggerFormatter<V>::print(os, it->second);
@@ -44,7 +44,7 @@ public:
         for (typename std::multimap<K, V, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<K>::print(os, it->first);
             os << '=';
             LoggerFormatter<V>::print(os, it->second);

--- a/tlx/logger/map.hpp
+++ b/tlx/logger/map.hpp
@@ -21,15 +21,16 @@ template <typename K, typename V, typename C, typename A>
 class LoggerFormatter<std::map<K, V, C, A> >
 {
 public:
-    static void print(std::ostream& os, const std::map<K, V, C, A>& data) {
+    static void print(std::ostream& os, const std::map<K, V, C, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::map<K, V, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<K>::print(os, it->first);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<K>::print(os, it->first, addSpace);
             os << '=';
-            LoggerFormatter<V>::print(os, it->second);
+            LoggerFormatter<V>::print(os, it->second, addSpace);
         }
         os << '}';
     }
@@ -39,15 +40,16 @@ template <typename K, typename V, typename C, typename A>
 class LoggerFormatter<std::multimap<K, V, C, A> >
 {
 public:
-    static void print(std::ostream& os, const std::multimap<K, V, C, A>& data) {
+    static void print(std::ostream& os, const std::multimap<K, V, C, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::multimap<K, V, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<K>::print(os, it->first);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<K>::print(os, it->first, addSpace);
             os << '=';
-            LoggerFormatter<V>::print(os, it->second);
+            LoggerFormatter<V>::print(os, it->second, addSpace);
         }
         os << '}';
     }

--- a/tlx/logger/set.hpp
+++ b/tlx/logger/set.hpp
@@ -21,13 +21,14 @@ template <typename T, typename C, typename A>
 class LoggerFormatter<std::set<T, C, A> >
 {
 public:
-    static void print(std::ostream& os, const std::set<T, C, A>& data) {
+    static void print(std::ostream& os, const std::set<T, C, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::set<T, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<T>::print(os, *it);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<T>::print(os, *it, addSpace);
         }
         os << '}';
     }
@@ -37,13 +38,14 @@ template <typename T, typename C, typename A>
 class LoggerFormatter<std::multiset<T, C, A> >
 {
 public:
-    static void print(std::ostream& os, const std::multiset<T, C, A>& data) {
+    static void print(std::ostream& os, const std::multiset<T, C, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::multiset<T, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<T>::print(os, *it);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<T>::print(os, *it, addSpace);
         }
         os << '}';
     }

--- a/tlx/logger/set.hpp
+++ b/tlx/logger/set.hpp
@@ -26,7 +26,7 @@ public:
         for (typename std::set<T, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<T>::print(os, *it);
         }
         os << '}';
@@ -42,7 +42,7 @@ public:
         for (typename std::multiset<T, C, A>::const_iterator it = data.begin();
              it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<T>::print(os, *it);
         }
         os << '}';

--- a/tlx/logger/tuple.hpp
+++ b/tlx/logger/tuple.hpp
@@ -24,7 +24,7 @@ public:
     explicit LoggerTupleFormatter(std::ostream& os) : os_(os) { }
     template <typename Index, typename Arg>
     void operator () (const Index&, const Arg& a) const {
-        if (Index::index != 0) os_ << ',';
+        if (Index::index != 0) os_ << ", ";
         LoggerFormatter<typename std::decay<Arg>::type>::print(os_, a);
     }
     std::ostream& os_;

--- a/tlx/logger/tuple.hpp
+++ b/tlx/logger/tuple.hpp
@@ -21,22 +21,25 @@ namespace tlx {
 class LoggerTupleFormatter
 {
 public:
-    explicit LoggerTupleFormatter(std::ostream& os) : os_(os) { }
+    explicit LoggerTupleFormatter(std::ostream& os, const bool addSpace) : os_(os), addSpace_(addSpace) { }
     template <typename Index, typename Arg>
     void operator () (const Index&, const Arg& a) const {
-        if (Index::index != 0) os_ << ", ";
-        LoggerFormatter<typename std::decay<Arg>::type>::print(os_, a);
+        if (Index::index != 0) os_ << ',';
+        if (Index::index != 0 && addSpace_) os_ << ' ';
+        LoggerFormatter<typename std::decay<Arg>::type>::print(os_, a, addSpace_);
     }
     std::ostream& os_;
+    bool addSpace_;
 };
 
 template <typename... Args>
 class LoggerFormatter<std::tuple<Args...> >
 {
 public:
-    static void print(std::ostream& os, const std::tuple<Args...>& t) {
+    static void print(std::ostream& os, const std::tuple<Args...>& t, const bool addSpace) {
+	(void)addSpace;
         os << '(';
-        call_foreach_tuple_with_index(LoggerTupleFormatter(os), t);
+        call_foreach_tuple_with_index(LoggerTupleFormatter(os, addSpace), t);
         os << ')';
     }
 };
@@ -45,7 +48,8 @@ template <>
 class LoggerFormatter<std::tuple<> >
 {
 public:
-    static void print(std::ostream& os, const std::tuple<>&) {
+    static void print(std::ostream& os, const std::tuple<>&, const bool addSpace) {
+	(void)addSpace;
         os << '(' << ')';
     }
 };

--- a/tlx/logger/unordered_map.hpp
+++ b/tlx/logger/unordered_map.hpp
@@ -22,15 +22,16 @@ class LoggerFormatter<std::unordered_map<K, V, H, E, A> >
 {
 public:
     static void print(std::ostream& os,
-                      const std::unordered_map<K, V, H, E, A>& data) {
+                      const std::unordered_map<K, V, H, E, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::unordered_map<K, V, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<K>::print(os, it->first);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<K>::print(os, it->first, addSpace);
             os << '=';
-            LoggerFormatter<V>::print(os, it->second);
+            LoggerFormatter<V>::print(os, it->second, addSpace);
         }
         os << '}';
     }
@@ -41,15 +42,16 @@ class LoggerFormatter<std::unordered_multimap<K, V, H, E, A> >
 {
 public:
     static void print(std::ostream& os,
-                      const std::unordered_multimap<K, V, H, E, A>& data) {
+                      const std::unordered_multimap<K, V, H, E, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::unordered_multimap<K, V, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<K>::print(os, it->first);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<K>::print(os, it->first, addSpace);
             os << '=';
-            LoggerFormatter<V>::print(os, it->second);
+            LoggerFormatter<V>::print(os, it->second, addSpace);
         }
         os << '}';
     }

--- a/tlx/logger/unordered_map.hpp
+++ b/tlx/logger/unordered_map.hpp
@@ -27,7 +27,7 @@ public:
         for (typename std::unordered_map<K, V, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<K>::print(os, it->first);
             os << '=';
             LoggerFormatter<V>::print(os, it->second);
@@ -46,7 +46,7 @@ public:
         for (typename std::unordered_multimap<K, V, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<K>::print(os, it->first);
             os << '=';
             LoggerFormatter<V>::print(os, it->second);

--- a/tlx/logger/unordered_set.hpp
+++ b/tlx/logger/unordered_set.hpp
@@ -27,7 +27,7 @@ public:
         for (typename std::unordered_set<T, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<T>::print(os, *it);
         }
         os << '}';
@@ -44,7 +44,7 @@ public:
         for (typename std::unordered_multiset<T, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ',';
+            if (it != data.begin()) os << ", ";
             LoggerFormatter<T>::print(os, *it);
         }
         os << '}';

--- a/tlx/logger/unordered_set.hpp
+++ b/tlx/logger/unordered_set.hpp
@@ -22,13 +22,14 @@ class LoggerFormatter<std::unordered_set<T, H, E, A> >
 {
 public:
     static void print(std::ostream& os,
-                      const std::unordered_set<T, H, E, A>& data) {
+                      const std::unordered_set<T, H, E, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::unordered_set<T, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<T>::print(os, *it);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<T>::print(os, *it, addSpace);
         }
         os << '}';
     }
@@ -39,13 +40,14 @@ class LoggerFormatter<std::unordered_multiset<T, H, E, A> >
 {
 public:
     static void print(std::ostream& os,
-                      const std::unordered_multiset<T, H, E, A>& data) {
+                      const std::unordered_multiset<T, H, E, A>& data, const bool addSpace) {
         os << '{';
         for (typename std::unordered_multiset<T, H, E, A>::const_iterator
              it = data.begin(); it != data.end(); ++it)
         {
-            if (it != data.begin()) os << ", ";
-            LoggerFormatter<T>::print(os, *it);
+            if (it != data.begin()) os << ',';
+            if (it != data.begin() && addSpace) os << ' ';
+            LoggerFormatter<T>::print(os, *it, addSpace);
         }
         os << '}';
     }


### PR DESCRIPTION
This makes the output easier to read for humans