### PR TITLE
Make math::integer_log2* constexpr

### DIFF
--- a/tlx/define.hpp
+++ b/tlx/define.hpp
@@ -22,6 +22,7 @@ print "#include <$_>\n" foreach sort glob("tlx/define/"."*.hpp");
 #include <tlx/define/attribute_format_printf.hpp>
 #include <tlx/define/attribute_packed.hpp>
 #include <tlx/define/attribute_warn_unused_result.hpp>
+#include <tlx/define/constexpr.hpp>
 #include <tlx/define/deprecated.hpp>
 #include <tlx/define/endian.hpp>
 #include <tlx/define/likely.hpp>

--- a/tlx/define/constexpr.hpp
+++ b/tlx/define/constexpr.hpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * tlx/define/constexpr.hpp
+ *
+ * Part of tlx - http://panthema.net/tlx
+ *
+ * Copyright (C) 2021 Lorenz Hübschle-Schneider <lorenz@4z2.de>
+ *
+ * All rights reserved. Published under the Boost Software License, Version 1.0
+ ******************************************************************************/
+
+#ifndef TLX_DEFINE_CONSTEXPR_HEADER
+#define TLX_DEFINE_CONSTEXPR_HEADER
+
+namespace tlx {
+
+//! \addtogroup tlx_define
+//! \{
+
+#if __cplusplus >= 201402L
+    #define TLX_ADVANCED_CONSTEXPR constexpr
+#else
+    #define TLX_ADVANCED_CONSTEXPR inline
+#endif
+
+//! \}
+
+} // namespace tlx
+
+#endif // !TLX_DEFINE_CONSTEXPR_HEADER
+
+/******************************************************************************/

--- a/tlx/math/integer_log2.hpp
+++ b/tlx/math/integer_log2.hpp
@@ -13,6 +13,12 @@
 
 namespace tlx {
 
+#if __cplusplus >= 201402L
+    #define TLX_ADVANCED_CONSTEXPR constexpr
+#else
+    #define TLX_ADVANCED_CONSTEXPR inline
+#endif
+
 //! \addtogroup tlx_math
 //! \{
 
@@ -21,7 +27,7 @@ namespace tlx {
 
 //! calculate the log2 floor of an integer type
 template <typename IntegerType>
-static constexpr unsigned integer_log2_floor_template(IntegerType i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor_template(IntegerType i) {
     unsigned p = 0;
     while (i >= 65536) i >>= 16, p += 16;
     while (i >= 256) i >>= 8, p += 8;
@@ -35,37 +41,37 @@ static constexpr unsigned integer_log2_floor_template(IntegerType i) {
 #if defined(__GNUC__) || defined(__clang__)
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(int i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(int i) {
     if (i == 0) return 0;
     return 8 * sizeof(int) - 1 - __builtin_clz(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(unsigned int i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(unsigned int i) {
     if (i == 0) return 0;
     return 8 * sizeof(unsigned) - 1 - __builtin_clz(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(long i) {
     if (i == 0) return 0;
     return 8 * sizeof(long) - 1 - __builtin_clzl(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(unsigned long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(unsigned long i) {
     if (i == 0) return 0;
     return 8 * sizeof(unsigned long) - 1 - __builtin_clzl(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(long long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(long long i) {
     if (i == 0) return 0;
     return 8 * sizeof(long long) - 1 - __builtin_clzll(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(unsigned long long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(unsigned long long i) {
     if (i == 0) return 0;
     return 8 * sizeof(unsigned long long) - 1 - __builtin_clzll(i);
 }
@@ -73,32 +79,32 @@ static constexpr unsigned integer_log2_floor(unsigned long long i) {
 #else
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(int i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(int i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(unsigned int i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(unsigned int i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(long i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(unsigned long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(unsigned long i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(long long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(long long i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_floor(unsigned long long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_floor(unsigned long long i) {
     return integer_log2_floor_template(i);
 }
 
@@ -108,37 +114,37 @@ static constexpr unsigned integer_log2_floor(unsigned long long i) {
 // integer_log2_ceil()
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_ceil(int i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_ceil(int i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_ceil(unsigned int i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_ceil(unsigned int i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_ceil(long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_ceil(long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_ceil(unsigned long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_ceil(unsigned long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_ceil(long long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_ceil(long long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static constexpr unsigned integer_log2_ceil(unsigned long long i) {
+static TLX_ADVANCED_CONSTEXPR unsigned integer_log2_ceil(unsigned long long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }

--- a/tlx/math/integer_log2.hpp
+++ b/tlx/math/integer_log2.hpp
@@ -11,13 +11,9 @@
 #ifndef TLX_MATH_INTEGER_LOG2_HEADER
 #define TLX_MATH_INTEGER_LOG2_HEADER
 
-namespace tlx {
+#include <tlx/define/constexpr.hpp>
 
-#if __cplusplus >= 201402L
-    #define TLX_ADVANCED_CONSTEXPR constexpr
-#else
-    #define TLX_ADVANCED_CONSTEXPR inline
-#endif
+namespace tlx {
 
 //! \addtogroup tlx_math
 //! \{

--- a/tlx/math/integer_log2.hpp
+++ b/tlx/math/integer_log2.hpp
@@ -21,7 +21,7 @@ namespace tlx {
 
 //! calculate the log2 floor of an integer type
 template <typename IntegerType>
-static inline unsigned integer_log2_floor_template(IntegerType i) {
+static constexpr unsigned integer_log2_floor_template(IntegerType i) {
     unsigned p = 0;
     while (i >= 65536) i >>= 16, p += 16;
     while (i >= 256) i >>= 8, p += 8;
@@ -35,37 +35,37 @@ static inline unsigned integer_log2_floor_template(IntegerType i) {
 #if defined(__GNUC__) || defined(__clang__)
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(int i) {
+static constexpr unsigned integer_log2_floor(int i) {
     if (i == 0) return 0;
     return 8 * sizeof(int) - 1 - __builtin_clz(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(unsigned int i) {
+static constexpr unsigned integer_log2_floor(unsigned int i) {
     if (i == 0) return 0;
     return 8 * sizeof(unsigned) - 1 - __builtin_clz(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(long i) {
+static constexpr unsigned integer_log2_floor(long i) {
     if (i == 0) return 0;
     return 8 * sizeof(long) - 1 - __builtin_clzl(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(unsigned long i) {
+static constexpr unsigned integer_log2_floor(unsigned long i) {
     if (i == 0) return 0;
     return 8 * sizeof(unsigned long) - 1 - __builtin_clzl(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(long long i) {
+static constexpr unsigned integer_log2_floor(long long i) {
     if (i == 0) return 0;
     return 8 * sizeof(long long) - 1 - __builtin_clzll(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(unsigned long long i) {
+static constexpr unsigned integer_log2_floor(unsigned long long i) {
     if (i == 0) return 0;
     return 8 * sizeof(unsigned long long) - 1 - __builtin_clzll(i);
 }
@@ -73,32 +73,32 @@ static inline unsigned integer_log2_floor(unsigned long long i) {
 #else
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(int i) {
+static constexpr unsigned integer_log2_floor(int i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(unsigned int i) {
+static constexpr unsigned integer_log2_floor(unsigned int i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(long i) {
+static constexpr unsigned integer_log2_floor(long i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(unsigned long i) {
+static constexpr unsigned integer_log2_floor(unsigned long i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(long long i) {
+static constexpr unsigned integer_log2_floor(long long i) {
     return integer_log2_floor_template(i);
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_floor(unsigned long long i) {
+static constexpr unsigned integer_log2_floor(unsigned long long i) {
     return integer_log2_floor_template(i);
 }
 
@@ -108,37 +108,37 @@ static inline unsigned integer_log2_floor(unsigned long long i) {
 // integer_log2_ceil()
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_ceil(int i) {
+static constexpr unsigned integer_log2_ceil(int i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_ceil(unsigned int i) {
+static constexpr unsigned integer_log2_ceil(unsigned int i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_ceil(long i) {
+static constexpr unsigned integer_log2_ceil(long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_ceil(unsigned long i) {
+static constexpr unsigned integer_log2_ceil(unsigned long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_ceil(long long i) {
+static constexpr unsigned integer_log2_ceil(long long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }
 
 //! calculate the log2 floor of an integer type
-static inline unsigned integer_log2_ceil(unsigned long long i) {
+static constexpr unsigned integer_log2_ceil(unsigned long long i) {
     if (i <= 1) return 0;
     return integer_log2_floor(i - 1) + 1;
 }


### PR DESCRIPTION
I don't see a reason why not and I'd like to use them in a `constexpr` context.

Since `constexpr` implies `inline` ([dcl.constexpr], §7.1.5/2 in the C++11 standard: *"constexpr functions and constexpr constructors are implicitly inline (7.1.2)."*), this is strictly stronger.