### PR TITLE
Make tlx::RingBuffer compatible to C++20

### DIFF
--- a/tlx/container/ring_buffer.hpp
+++ b/tlx/container/ring_buffer.hpp
@@ -41,10 +41,10 @@ public:
 
     using alloc_traits = std::allocator_traits<allocator_type>;
 
-    using reference = typename allocator_type::reference;
-    using const_reference = typename allocator_type::const_reference;
-    using pointer = typename allocator_type::pointer;
-    using const_pointer = typename allocator_type::const_pointer;
+    typedef Type& reference;
+    typedef const Type& const_reference;
+    typedef Type* pointer;
+    typedef const Type* const_pointer;
 
     using size_type = typename allocator_type::size_type;
     using difference_type = typename allocator_type::difference_type;


### PR DESCRIPTION
`tlx::RingBuffer` was using member typedefs of `std::allocator` that have been deprecated in C++17 and ultimately removed in C++20. I have replaced the corresponding using directives by explicit typedefs to make it compilable in C++20.