### PR TITLE
d_ary_addressable_int_heap: Add push_without_update, make clear linear in size 

### DIFF
--- a/tests/container/d_ary_heap_test.cpp
+++ b/tests/container/d_ary_heap_test.cpp
@@ -187,6 +187,19 @@ void d_ary_addressable_int_heap_test(size_t size, uint32_t r_seed = 42) {
         check_handles(x, s);
     }
 
+
+    // Test inserting and building afterwards
+    fill_heap_and_set(x, s, keys);
+    x.clear();
+    for (auto key : keys) {
+        x.push_without_update(key);
+    }
+    x.update_all();
+    check_heap(x, s);
+    check_handles(x, s);
+    x.clear();
+    s.clear();
+
     // Test build_heap().
     fill_heap_and_set(x, s, keys);
     x.clear();

--- a/tlx/container/d_ary_addressable_int_heap.hpp
+++ b/tlx/container/d_ary_addressable_int_heap.hpp
@@ -89,7 +89,20 @@ public:
 
     //! Empties the heap.
     void clear() {
-        std::fill(handles_.begin(), handles_.end(), not_present());
+        if (heap_.size() * 64 / sizeof(key_type) < handles_.size()) {
+            // clear items individually if even assuming that every
+            // item is on a different cache line we still won't access
+            // all handles
+            for (const key_type &k : heap_) {
+                // Support clear after push_without_update()
+                if (k < handles_.size()) {
+                    handles_[k] = not_present();
+                }
+            }
+        } else {
+            std::fill(handles_.begin(), handles_.end(), not_present());
+        }
+
         heap_.clear();
     }
 

--- a/tlx/container/d_ary_addressable_int_heap.hpp
+++ b/tlx/container/d_ary_addressable_int_heap.hpp
@@ -104,18 +104,7 @@ public:
 
     //! Inserts a new item.
     void push(const key_type& new_key) {
-        // Avoid to add the key that we use to mark non present keys.
-        assert(new_key != not_present());
-        if (new_key >= handles_.size()) {
-            handles_.resize(new_key + 1, not_present());
-        }
-        else {
-            assert(handles_[new_key] == not_present());
-        }
-
-        // Insert the new item at the end of the heap.
-        handles_[new_key] = static_cast<key_type>(heap_.size());
-        heap_.push_back(new_key);
+        push_without_update(new_key);
         sift_up(heap_.size() - 1);
     }
 
@@ -134,6 +123,27 @@ public:
         handles_[new_key] = static_cast<key_type>(heap_.size());
         heap_.push_back(std::move(new_key));
         sift_up(heap_.size() - 1);
+    }
+
+    /*!
+     * Inserts a new item without updating the heap
+     *
+     * The heap is in an undefined state until \c update_all() or \c
+     * clear() is called.
+     */
+    void push_without_update(const key_type &new_key) {
+        // Avoid to add the key that we use to mark non present keys.
+        assert(new_key != not_present());
+        if (new_key >= handles_.size()) {
+            handles_.resize(new_key + 1, not_present());
+        }
+        else {
+            assert(handles_[new_key] == not_present());
+        }
+
+        // Insert the new item at the end of the heap.
+        handles_[new_key] = static_cast<key_type>(heap_.size());
+        heap_.push_back(std::move(new_key));
     }
 
     //! Removes the item with key \c key.


### PR DESCRIPTION
This makes the clear method linear in the size of the heap and adds a new method for adding elements without updating the heap. The use case is that I want to re-use a single heap several times as the keys are significantly larger than the size of the heap. Between the uses, I clear the heap and this should be linear in the number of remaining elements. I recognize that a simple linear fill is faster than random writes. Therefore, this only uses the random writes if we do not touch all cache lines with the random writes even if every write is on a separate cache line. I have not compared the performance and I'm also open to other suggestions. For adding new elements after the clear, I added the `push_without_update` method. It is very similar to the `build_heap` methods, just that it allows adding elements one-by-one and one has to call `update_all` (or `clear`) at the end. I have kept the update of the handles even though it is not strictly necessary as this ensures that `contains` can be used in between `push_without_update` calls. I have not added a `push_without_update` method that moves the key as the documentation states that `key_type` "has to be an unsigned integer type" and I cannot imagine that moving unsigned integers has any advantage over a pass by value or pass by reference.