### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - name: "Ubuntu 18.04 gcc 7.5 Debug"
-          os: ubuntu-18.04
+        - name: "Ubuntu 20.04 gcc 7.5 Debug"
+          os: ubuntu-20.04
           build_type: "Debug"
 
         - name: "Ubuntu 20.04 gcc 9.3 Debug 32-bit"
@@ -38,9 +38,9 @@ jobs:
           gcc_install: "11"
           cxx_flags: "-D_GLIBCXX_DEBUG"
 
-        - name: "macOS 10.15 clang 12 Debug"
-          os: macos-10.15
-          build_type: "Debug"
+        # - name: "macOS 10.15 clang 12 Debug"
+        #   os: macos-10.15
+        #   build_type: "Debug"
 
         # - name: "Window Latest"
         #   os: windows-latest


### PR DESCRIPTION
GitHub no longer hosts runners for Ubuntu 18 and MacOS 10. Upgrading to MacOS 12 is not directly possible because TLX does not compile there. For now, just comment out MacOS builds.