### PR TITLE
Fix compatibility with gcc13 (Variant 1)

### DIFF
--- a/tlx/cmdline_parser.cpp
+++ b/tlx/cmdline_parser.cpp
@@ -302,13 +302,13 @@ class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentBytes32 final
     : public Argument
 {
 protected:
-    uint32_t& dest_;
+    std::uint32_t& dest_;
 
 public:
     //! contructor filling most attributes
     ArgumentBytes32(char key, const std::string& longkey,
                     const std::string& keytype, const std::string& desc,
-                    bool required, uint32_t& dest) // NOLINT
+                    bool required, std::uint32_t& dest) // NOLINT
         : Argument(key, longkey, keytype, desc, required), dest_(dest) { }
 
     const char * type_name() const final { return "bytes"; }
@@ -317,10 +317,10 @@ public:
     bool process(int& argc, const char* const*& argv) final { // NOLINT
         if (argc == 0)
             return false;
-        uint64_t dest;
+        std::uint64_t dest;
         if (parse_si_iec_units(argv[0], &dest) &&
-            static_cast<uint64_t>(
-                dest_ = static_cast<uint32_t>(dest)) == dest) {
+            static_cast<std::uint64_t>(
+                dest_ = static_cast<std::uint32_t>(dest)) == dest) {
             --argc, ++argv;
             return true;
         }
@@ -337,13 +337,13 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentBytes64 final : public Argument
 {
 protected:
-    uint64_t& dest_;
+    std::uint64_t& dest_;
 
 public:
     //! contructor filling most attributes
     ArgumentBytes64(char key, const std::string& longkey,
                     const std::string& keytype, const std::string& desc,
-                    bool required, uint64_t& dest) // NOLINT
+                    bool required, std::uint64_t& dest) // NOLINT
         : Argument(key, longkey, keytype, desc, required), dest_(dest) { }
 
     const char * type_name() const final { return "bytes"; }
@@ -574,7 +574,7 @@ void CmdlineParser::add_double(char key, const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              const std::string& keytype, uint32_t& dest,
+                              const std::string& keytype, std::uint32_t& dest,
                               const std::string& desc) {
     option_list_.emplace_back(
         new ArgumentBytes32(key, longkey, keytype, desc, false, dest));
@@ -582,7 +582,7 @@ void CmdlineParser::add_bytes(char key, const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              const std::string& keytype, uint64_t& dest,
+                              const std::string& keytype, std::uint64_t& dest,
                               const std::string& desc) {
     option_list_.emplace_back(
         new ArgumentBytes64(key, longkey, keytype, desc, false, dest));
@@ -650,12 +650,12 @@ void CmdlineParser::add_double(char key, const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              uint32_t& dest, const std::string& desc) {
+                              std::uint32_t& dest, const std::string& desc) {
     return add_bytes(key, longkey, "", dest, desc);
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              uint64_t& dest, const std::string& desc) {
+                              std::uint64_t& dest, const std::string& desc) {
     return add_bytes(key, longkey, "", dest, desc);
 }
 
@@ -713,12 +713,12 @@ void CmdlineParser::add_double(const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(const std::string& longkey,
-                              uint32_t& dest, const std::string& desc) {
+                              std::uint32_t& dest, const std::string& desc) {
     return add_bytes(0, longkey, "", dest, desc);
 }
 
 void CmdlineParser::add_bytes(const std::string& longkey,
-                              uint64_t& dest, const std::string& desc) {
+                              std::uint64_t& dest, const std::string& desc) {
     return add_bytes(0, longkey, "", dest, desc);
 }
 
@@ -772,14 +772,14 @@ void CmdlineParser::add_param_double(
 }
 
 void CmdlineParser::add_param_bytes(
-    const std::string& name, uint32_t& dest, const std::string& desc) {
+    const std::string& name, std::uint32_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes32(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
 void CmdlineParser::add_param_bytes(
-    const std::string& name, uint64_t& dest, const std::string& desc) {
+    const std::string& name, std::uint64_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes64(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
@@ -839,14 +839,14 @@ void CmdlineParser::add_opt_param_double(
 }
 
 void CmdlineParser::add_opt_param_bytes(
-    const std::string& name, uint32_t& dest, const std::string& desc) {
+    const std::string& name, std::uint32_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes32(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
 void CmdlineParser::add_opt_param_bytes(
-    const std::string& name, uint64_t& dest, const std::string& desc) {
+    const std::string& name, std::uint64_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes64(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());

--- a/tlx/cmdline_parser.hpp
+++ b/tlx/cmdline_parser.hpp
@@ -14,6 +14,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace tlx {
 
@@ -198,12 +199,12 @@ public:
     //! add SI/IEC suffixes byte size option -key, --longkey and store to 32-bit
     //! dest
     void add_bytes(char key, const std::string& longkey,
-                   uint32_t& dest, const std::string& desc); // NOLINT
+                   std::uint32_t& dest, const std::string& desc); // NOLINT
 
     //! add SI/IEC suffixes byte size option -key, --longkey and store to 64-bit
     //! dest
     void add_bytes(char key, const std::string& longkey,
-                   uint64_t& dest, const std::string& desc); // NOLINT
+                   std::uint64_t& dest, const std::string& desc); // NOLINT
 
     //! add string option -key, --longkey and store to dest
     void add_string(char key, const std::string& longkey,
@@ -257,11 +258,11 @@ public:
 
     //! add SI/IEC suffixes byte size option --longkey and store to 32-bit dest
     void add_bytes(const std::string& longkey,
-                   uint32_t& dest, const std::string& desc); // NOLINT
+                   std::uint32_t& dest, const std::string& desc); // NOLINT
 
     //! add SI/IEC suffixes byte size option --longkey and store to 64-bit dest
     void add_bytes(const std::string& longkey,
-                   uint64_t& dest, const std::string& desc); // NOLINT
+                   std::uint64_t& dest, const std::string& desc); // NOLINT
 
     //! add string option --longkey and store to dest
     void add_string(const std::string& longkey,
@@ -339,14 +340,14 @@ public:
     //! store to 64-bit dest
     void add_bytes(
         char key, const std::string& longkey,
-        const std::string& keytype, uint32_t& dest, // NOLINT
+        const std::string& keytype, std::uint32_t& dest, // NOLINT
         const std::string& desc);
 
     //! add SI/IEC suffixes byte size option -key, --longkey [keytype] and
     //! store to 64-bit dest
     void add_bytes(
         char key, const std::string& longkey,
-        const std::string& keytype, uint64_t& dest, // NOLINT
+        const std::string& keytype, std::uint64_t& dest, // NOLINT
         const std::string& desc);
 
     //! add string option -key, --longkey [keytype] and store to dest
@@ -401,13 +402,13 @@ public:
     //! add SI/IEC suffixes byte size parameter [name] with description and
     //! store to dest
     void add_param_bytes(
-        const std::string& name, uint32_t& dest, // NOLINT
+        const std::string& name, std::uint32_t& dest, // NOLINT
         const std::string& desc);
 
     //! add SI/IEC suffixes byte size parameter [name] with description and
     //! store to dest
     void add_param_bytes(
-        const std::string& name, uint64_t& dest, // NOLINT
+        const std::string& name, std::uint64_t& dest, // NOLINT
         const std::string& desc);
 
     //! add string parameter [name] with description and store to dest
@@ -464,13 +465,13 @@ public:
     //! add optional SI/IEC suffixes byte size parameter [name] with
     //! description and store to dest
     void add_opt_param_bytes(
-        const std::string& name, uint32_t& dest, // NOLINT
+        const std::string& name, std::uint32_t& dest, // NOLINT
         const std::string& desc);
 
     //! add optional SI/IEC suffixes byte size parameter [name] with
     //! description and store to dest
     void add_opt_param_bytes(
-        const std::string& name, uint64_t& dest, // NOLINT
+        const std::string& name, std::uint64_t& dest, // NOLINT
         const std::string& desc);
 
     //! add optional string parameter [name] with description and store to dest

--- a/tlx/container/loser_tree.hpp
+++ b/tlx/container/loser_tree.hpp
@@ -56,7 +56,7 @@ class LoserTreeCopyBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);
@@ -308,7 +308,7 @@ class LoserTreePointerBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);
@@ -530,7 +530,7 @@ class LoserTreeCopyUnguardedBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);
@@ -706,7 +706,7 @@ class LoserTreePointerUnguardedBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);

--- a/tlx/container/radix_heap.hpp
+++ b/tlx/container/radix_heap.hpp
@@ -24,6 +24,7 @@
 #include <tlx/math/div_ceil.hpp>
 #include <tlx/math/ffs.hpp>
 #include <tlx/meta/log2.hpp>
+#include <cstdint>
 
 namespace tlx {
 namespace radix_heap_detail {
@@ -169,7 +170,7 @@ class BitArrayRecursive<Size, true>
 {
     static_assert(Size <= 64, "Support at most 64 bits");
     using uint_type = typename std::conditional<
-        Size <= 32, uint32_t, uint64_t>::type;
+        Size <= 32, std::uint32_t, std::uint64_t>::type;
 
 public:
     static constexpr size_t size = Size;

--- a/tlx/container/ring_buffer.hpp
+++ b/tlx/container/ring_buffer.hpp
@@ -313,7 +313,7 @@ public:
 
     template <class Archive>
     void save(Archive& ar) const { // NOLINT
-        uint32_t ar_size = size();
+        std::uint32_t ar_size = size();
         ar(max_size_, ar_size);
         for (size_t i = 0; i < ar_size; ++i) ar(operator [] (i));
     }
@@ -334,7 +334,7 @@ public:
         begin_ = end_ = 0;
 
         // load items
-        uint32_t ar_size;
+        std::uint32_t ar_size;
         ar(ar_size);
 
         for (size_t i = 0; i < ar_size; ++i) {

--- a/tlx/digest/md5.cpp
+++ b/tlx/digest/md5.cpp
@@ -29,83 +29,83 @@ namespace tlx {
 
 namespace digest_detail {
 
-static inline uint32_t min(uint32_t x, uint32_t y) {
+static inline std::uint32_t min(std::uint32_t x, std::uint32_t y) {
     return x < y ? x : y;
 }
 
-static inline uint32_t load32l(const uint8_t* y) {
-    uint32_t res = 0;
+static inline std::uint32_t load32l(const std::uint8_t* y) {
+    std::uint32_t res = 0;
     for (size_t i = 0; i != 4; ++i)
-        res |= uint32_t(y[i]) << (i * 8);
+        res |= std::uint32_t(y[i]) << (i * 8);
     return res;
 }
 
-static inline void store32l(uint32_t x, uint8_t* y) {
+static inline void store32l(std::uint32_t x, std::uint8_t* y) {
     for (size_t i = 0; i != 4; ++i)
         y[i] = (x >> (i * 8)) & 255;
 }
 
-static inline void store64l(uint64_t x, uint8_t* y) {
+static inline void store64l(std::uint64_t x, std::uint8_t* y) {
     for (size_t i = 0; i != 8; ++i)
         y[i] = (x >> (i * 8)) & 255;
 }
 
 static inline
-uint32_t F(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (z ^ (x & (y ^ z)));
 }
 static inline
-uint32_t G(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t G(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (y ^ (z & (y ^ x)));
 }
 static inline
-uint32_t H(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t H(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (x ^ y ^ z);
 }
 static inline
-uint32_t I(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t I(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (y ^ (x | (~z)));
 }
 
-static inline void FF(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void FF(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + F(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static inline void GG(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void GG(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + G(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static inline void HH(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void HH(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + H(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static inline void II(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void II(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + I(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static const uint8_t Worder[64] = {
+static const std::uint8_t Worder[64] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     1, 6, 11, 0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12,
     5, 8, 11, 14, 1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15, 2,
     0, 7, 14, 5, 12, 3, 10, 1, 8, 15, 6, 13, 4, 11, 2, 9
 };
 
-static const uint8_t Rorder[64] = {
+static const std::uint8_t Rorder[64] = {
     7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
     5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
     4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
     6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21
 };
 
-static const uint32_t Korder[64] = {
+static const std::uint32_t Korder[64] = {
     0xd76aa478UL, 0xe8c7b756UL, 0x242070dbUL, 0xc1bdceeeUL, 0xf57c0fafUL,
     0x4787c62aUL, 0xa8304613UL, 0xfd469501UL, 0x698098d8UL, 0x8b44f7afUL,
     0xffff5bb1UL, 0x895cd7beUL, 0x6b901122UL, 0xfd987193UL, 0xa679438eUL,
@@ -121,8 +121,8 @@ static const uint32_t Korder[64] = {
     0xf7537e82UL, 0xbd3af235UL, 0x2ad7d2bbUL, 0xeb86d391UL
 };
 
-static void md5_compress(uint32_t state[4], const uint8_t* buf) {
-    uint32_t i, W[16], a, b, c, d, t;
+static void md5_compress(std::uint32_t state[4], const std::uint8_t* buf) {
+    std::uint32_t i, W[16], a, b, c, d, t;
 
     // copy the state into 512-bits into W[0..15]
     for (i = 0; i < 16; i++) {
@@ -172,7 +172,7 @@ MD5::MD5() {
     state_[3] = 0x10325476UL;
 }
 
-MD5::MD5(const void* data, uint32_t size) : MD5() {
+MD5::MD5(const void* data, std::uint32_t size) : MD5() {
     process(data, size);
 }
 
@@ -180,9 +180,9 @@ MD5::MD5(const std::string& str) : MD5() {
     process(str);
 }
 
-void MD5::process(const void* data, uint32_t size) {
-    const uint32_t block_size = sizeof(MD5::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+void MD5::process(const void* data, std::uint32_t size) {
+    const std::uint32_t block_size = sizeof(MD5::buf_);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -195,9 +195,9 @@ void MD5::process(const void* data, uint32_t size) {
         }
         else
         {
-            uint32_t n = digest_detail::min(size, (block_size - curlen_));
-            uint8_t* b = buf_ + curlen_;
-            for (const uint8_t* a = in; a != in + n; ++a, ++b) {
+            std::uint32_t n = digest_detail::min(size, (block_size - curlen_));
+            std::uint8_t* b = buf_ + curlen_;
+            for (const std::uint8_t* a = in; a != in + n; ++a, ++b) {
                 *b = *a;
             }
             curlen_ += n;
@@ -223,7 +223,7 @@ void MD5::finalize(void* digest) {
     length_ += curlen_ * 8;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length_ is currently above 56 bytes we append zeros then
     // md5_compress().  Then we can fall back to padding zeros and length
@@ -246,7 +246,7 @@ void MD5::finalize(void* digest) {
     // Copy output
     for (size_t i = 0; i < 4; i++) {
         digest_detail::store32l(
-            state_[i], static_cast<uint8_t*>(digest) + (4 * i));
+            state_[i], static_cast<std::uint8_t*>(digest) + (4 * i));
     }
 }
 
@@ -257,18 +257,18 @@ std::string MD5::digest() {
 }
 
 std::string MD5::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string MD5::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string md5_hex(const void* data, uint32_t size) {
+std::string md5_hex(const void* data, std::uint32_t size) {
     return MD5(data, size).digest_hex();
 }
 
@@ -276,7 +276,7 @@ std::string md5_hex(const std::string& str) {
     return MD5(str).digest_hex();
 }
 
-std::string md5_hex_uc(const void* data, uint32_t size) {
+std::string md5_hex_uc(const void* data, std::uint32_t size) {
     return MD5(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/md5.hpp
+++ b/tlx/digest/md5.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     MD5();
     //! construct context and process data range
-    MD5(const void* data, uint32_t size);
+    MD5(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit MD5(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint32_t state_[4];
-    uint32_t curlen_;
-    uint8_t buf_[64];
+    std::uint64_t length_;
+    std::uint32_t state_[4];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[64];
 };
 
 //! process data and return 16 byte (128 bit) digest hex encoded
-std::string md5_hex(const void* data, uint32_t size);
+std::string md5_hex(const void* data, std::uint32_t size);
 //! process data and return 16 byte (128 bit) digest hex encoded
 std::string md5_hex(const std::string& str);
 
 //! process data and return 16 byte (128 bit) digest upper-case hex encoded
-std::string md5_hex_uc(const void* data, uint32_t size);
+std::string md5_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 16 byte (128 bit) digest upper-case hex encoded
 std::string md5_hex_uc(const std::string& str);
 

--- a/tlx/digest/sha1.cpp
+++ b/tlx/digest/sha1.cpp
@@ -29,42 +29,42 @@ namespace tlx {
 
 namespace digest_detail {
 
-static inline uint32_t min(uint32_t x, uint32_t y) {
+static inline std::uint32_t min(std::uint32_t x, std::uint32_t y) {
     return x < y ? x : y;
 }
 
-static inline void store64h(uint64_t x, unsigned char* y) {
+static inline void store64h(std::uint64_t x, unsigned char* y) {
     for (int i = 0; i != 8; ++i)
         y[i] = (x >> ((7 - i) * 8)) & 255;
 }
-static inline uint32_t load32h(const uint8_t* y) {
-    return (uint32_t(y[0]) << 24) | (uint32_t(y[1]) << 16) |
-           (uint32_t(y[2]) << 8) | (uint32_t(y[3]) << 0);
+static inline std::uint32_t load32h(const std::uint8_t* y) {
+    return (std::uint32_t(y[0]) << 24) | (std::uint32_t(y[1]) << 16) |
+           (std::uint32_t(y[2]) << 8) | (std::uint32_t(y[3]) << 0);
 }
-static inline void store32h(uint32_t x, uint8_t* y) {
+static inline void store32h(std::uint32_t x, std::uint8_t* y) {
     for (int i = 0; i != 4; ++i)
         y[i] = (x >> ((3 - i) * 8)) & 255;
 }
 
 static inline
-uint32_t F0(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F0(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (z ^ (x & (y ^ z)));
 }
 static inline
-uint32_t F1(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F1(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (x ^ y ^ z);
 }
 static inline
-uint32_t F2(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F2(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return ((x & y) | (z & (x | y)));
 }
 static inline
-uint32_t F3(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F3(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (x ^ y ^ z);
 }
 
-static void sha1_compress(uint32_t state[4], const uint8_t* buf) {
-    uint32_t a, b, c, d, e, W[80], i, t;
+static void sha1_compress(std::uint32_t state[4], const std::uint8_t* buf) {
+    std::uint32_t a, b, c, d, e, W[80], i, t;
 
     /* copy the state into 512-bits into W[0..15] */
     for (i = 0; i < 16; i++) {
@@ -125,7 +125,7 @@ SHA1::SHA1() {
     state_[4] = 0xc3d2e1f0UL;
 }
 
-SHA1::SHA1(const void* data, uint32_t size) : SHA1() {
+SHA1::SHA1(const void* data, std::uint32_t size) : SHA1() {
     process(data, size);
 }
 
@@ -133,9 +133,9 @@ SHA1::SHA1(const std::string& str) : SHA1() {
     process(str);
 }
 
-void SHA1::process(const void* data, uint32_t size) {
-    const uint32_t block_size = sizeof(SHA1::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+void SHA1::process(const void* data, std::uint32_t size) {
+    const std::uint32_t block_size = sizeof(SHA1::buf_);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -148,9 +148,9 @@ void SHA1::process(const void* data, uint32_t size) {
         }
         else
         {
-            uint32_t n = digest_detail::min(size, (block_size - curlen_));
-            uint8_t* b = buf_ + curlen_;
-            for (const uint8_t* a = in; a != in + n; ++a, ++b) {
+            std::uint32_t n = digest_detail::min(size, (block_size - curlen_));
+            std::uint8_t* b = buf_ + curlen_;
+            for (const std::uint8_t* a = in; a != in + n; ++a, ++b) {
                 *b = *a;
             }
             curlen_ += n;
@@ -176,7 +176,7 @@ void SHA1::finalize(void* digest) {
     length_ += curlen_ * 8;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length_ is currently above 56 bytes we append zeros then
     // sha1_compress().  Then we can fall back to padding zeros and length
@@ -198,7 +198,7 @@ void SHA1::finalize(void* digest) {
 
     // Copy output
     for (size_t i = 0; i < 5; i++)
-        digest_detail::store32h(state_[i], static_cast<uint8_t*>(digest) + (4 * i));
+        digest_detail::store32h(state_[i], static_cast<std::uint8_t*>(digest) + (4 * i));
 }
 
 std::string SHA1::digest() {
@@ -208,18 +208,18 @@ std::string SHA1::digest() {
 }
 
 std::string SHA1::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string SHA1::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string sha1_hex(const void* data, uint32_t size) {
+std::string sha1_hex(const void* data, std::uint32_t size) {
     return SHA1(data, size).digest_hex();
 }
 
@@ -227,7 +227,7 @@ std::string sha1_hex(const std::string& str) {
     return SHA1(str).digest_hex();
 }
 
-std::string sha1_hex_uc(const void* data, uint32_t size) {
+std::string sha1_hex_uc(const void* data, std::uint32_t size) {
     return SHA1(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/sha1.hpp
+++ b/tlx/digest/sha1.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     SHA1();
     //! construct context and process data range
-    SHA1(const void* data, uint32_t size);
+    SHA1(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit SHA1(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint32_t state_[5];
-    uint32_t curlen_;
-    uint8_t buf_[64];
+    std::uint64_t length_;
+    std::uint32_t state_[5];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[64];
 };
 
 //! process data and return 20 byte (160 bit) digest hex encoded
-std::string sha1_hex(const void* data, uint32_t size);
+std::string sha1_hex(const void* data, std::uint32_t size);
 //! process data and return 20 byte (160 bit) digest hex encoded
 std::string sha1_hex(const std::string& str);
 
 //! process data and return 20 byte (160 bit) digest upper-case hex encoded
-std::string sha1_hex_uc(const void* data, uint32_t size);
+std::string sha1_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 20 byte (160 bit) digest upper-case hex encoded
 std::string sha1_hex_uc(const std::string& str);
 

--- a/tlx/digest/sha256.cpp
+++ b/tlx/digest/sha256.cpp
@@ -29,8 +29,8 @@ namespace tlx {
  * The library is free for all purposes without any express guarantee it works.
  */
 
-typedef uint32_t u32;
-typedef uint64_t u64;
+typedef std::uint32_t u32;
+typedef std::uint64_t u64;
 
 namespace {
 
@@ -54,15 +54,15 @@ static inline u32 min(u32 x, u32 y) {
     return x < y ? x : y;
 }
 
-static inline u32 load32(const uint8_t* y) {
+static inline u32 load32(const std::uint8_t* y) {
     return (u32(y[0]) << 24) | (u32(y[1]) << 16) |
            (u32(y[2]) << 8) | (u32(y[3]) << 0);
 }
-static inline void store64(u64 x, uint8_t* y) {
+static inline void store64(u64 x, std::uint8_t* y) {
     for (int i = 0; i != 8; ++i)
         y[i] = (x >> ((7 - i) * 8)) & 255;
 }
-static inline void store32(u32 x, uint8_t* y) {
+static inline void store32(u32 x, std::uint8_t* y) {
     for (int i = 0; i != 4; ++i)
         y[i] = (x >> ((3 - i) * 8)) & 255;
 }
@@ -89,7 +89,7 @@ static inline u32 Gamma1(u32 x) {
     return ror32(x, 17) ^ ror32(x, 19) ^ Sh(x, 10);
 }
 
-static void sha256_compress(uint32_t state[8], const uint8_t* buf) {
+static void sha256_compress(std::uint32_t state[8], const std::uint8_t* buf) {
     u32 S[8], W[64], t0, t1, t;
 
     // Copy state into S
@@ -141,7 +141,7 @@ SHA256::SHA256() {
     state_[7] = 0x5BE0CD19UL;
 }
 
-SHA256::SHA256(const void* data, uint32_t size)
+SHA256::SHA256(const void* data, std::uint32_t size)
     : SHA256() {
     process(data, size);
 }
@@ -153,7 +153,7 @@ SHA256::SHA256(const std::string& str)
 
 void SHA256::process(const void* data, u32 size) {
     const u32 block_size = sizeof(SHA256::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -191,7 +191,7 @@ void SHA256::finalize(void* digest) {
     length_ += curlen_ * 8;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length_ is currently above 56 bytes we append zeros then
     // sha256_compress().  Then we can fall back to padding zeros and length
@@ -214,7 +214,7 @@ void SHA256::finalize(void* digest) {
 
     // Copy output
     for (size_t i = 0; i < 8; i++)
-        store32(state_[i], static_cast<uint8_t*>(digest) + (4 * i));
+        store32(state_[i], static_cast<std::uint8_t*>(digest) + (4 * i));
 }
 
 std::string SHA256::digest() {
@@ -224,18 +224,18 @@ std::string SHA256::digest() {
 }
 
 std::string SHA256::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string SHA256::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string sha256_hex(const void* data, uint32_t size) {
+std::string sha256_hex(const void* data, std::uint32_t size) {
     return SHA256(data, size).digest_hex();
 }
 
@@ -243,7 +243,7 @@ std::string sha256_hex(const std::string& str) {
     return SHA256(str).digest_hex();
 }
 
-std::string sha256_hex_uc(const void* data, uint32_t size) {
+std::string sha256_hex_uc(const void* data, std::uint32_t size) {
     return SHA256(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/sha256.hpp
+++ b/tlx/digest/sha256.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     SHA256();
     //! construct context and process data range
-    SHA256(const void* data, uint32_t size);
+    SHA256(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit SHA256(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint32_t state_[8];
-    uint32_t curlen_;
-    uint8_t buf_[64];
+    std::uint64_t length_;
+    std::uint32_t state_[8];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[64];
 };
 
 //! process data and return 32 byte (256 bit) digest hex encoded
-std::string sha256_hex(const void* data, uint32_t size);
+std::string sha256_hex(const void* data, std::uint32_t size);
 //! process data and return 32 byte (256 bit) digest hex encoded
 std::string sha256_hex(const std::string& str);
 
 //! process data and return 32 byte (256 bit) digest upper-case hex encoded
-std::string sha256_hex_uc(const void* data, uint32_t size);
+std::string sha256_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 32 byte (256 bit) digest upper-case hex encoded
 std::string sha256_hex_uc(const std::string& str);
 

--- a/tlx/digest/sha512.cpp
+++ b/tlx/digest/sha512.cpp
@@ -29,7 +29,7 @@ namespace tlx {
 
 namespace digest_detail {
 
-static const uint64_t K[80] = {
+static const std::uint64_t K[80] = {
     0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL,
     0xe9b5dba58189dbbcULL, 0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL,
     0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL, 0xd807aa98a3030242ULL,
@@ -59,47 +59,47 @@ static const uint64_t K[80] = {
     0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
 };
 
-static inline uint32_t min(uint32_t x, uint32_t y) {
+static inline std::uint32_t min(std::uint32_t x, std::uint32_t y) {
     return x < y ? x : y;
 }
 
-static inline void store64(uint64_t x, unsigned char* y) {
+static inline void store64(std::uint64_t x, unsigned char* y) {
     for (int i = 0; i != 8; ++i)
         y[i] = (x >> ((7 - i) * 8)) & 255;
 }
-static inline uint64_t load64(const unsigned char* y) {
-    uint64_t res = 0;
+static inline std::uint64_t load64(const unsigned char* y) {
+    std::uint64_t res = 0;
     for (int i = 0; i != 8; ++i)
-        res |= uint64_t(y[i]) << ((7 - i) * 8);
+        res |= std::uint64_t(y[i]) << ((7 - i) * 8);
     return res;
 }
 
 static inline
-uint64_t Ch(const uint64_t& x, const uint64_t& y, const uint64_t& z) {
+std::uint64_t Ch(const std::uint64_t& x, const std::uint64_t& y, const std::uint64_t& z) {
     return z ^ (x & (y ^ z));
 }
 static inline
-uint64_t Maj(const uint64_t& x, const uint64_t& y, const uint64_t& z) {
+std::uint64_t Maj(const std::uint64_t& x, const std::uint64_t& y, const std::uint64_t& z) {
     return ((x | y) & z) | (x & y);
 }
-static inline uint64_t Sh(uint64_t x, uint64_t n) {
+static inline std::uint64_t Sh(std::uint64_t x, std::uint64_t n) {
     return x >> n;
 }
-static inline uint64_t Sigma0(uint64_t x) {
+static inline std::uint64_t Sigma0(std::uint64_t x) {
     return ror64(x, 28) ^ ror64(x, 34) ^ ror64(x, 39);
 }
-static inline uint64_t Sigma1(uint64_t x) {
+static inline std::uint64_t Sigma1(std::uint64_t x) {
     return ror64(x, 14) ^ ror64(x, 18) ^ ror64(x, 41);
 }
-static inline uint64_t Gamma0(uint64_t x) {
+static inline std::uint64_t Gamma0(std::uint64_t x) {
     return ror64(x, 1) ^ ror64(x, 8) ^ Sh(x, 7);
 }
-static inline uint64_t Gamma1(uint64_t x) {
+static inline std::uint64_t Gamma1(std::uint64_t x) {
     return ror64(x, 19) ^ ror64(x, 61) ^ Sh(x, 6);
 }
 
-static void sha512_compress(uint64_t state[8], const uint8_t* buf) {
-    uint64_t S[8], W[80], t0, t1;
+static void sha512_compress(std::uint64_t state[8], const std::uint8_t* buf) {
+    std::uint64_t S[8], W[80], t0, t1;
 
     // Copy state_ into S
     for (int i = 0; i < 8; i++)
@@ -115,8 +115,8 @@ static void sha512_compress(uint64_t state[8], const uint8_t* buf) {
 
     // Compress
     auto RND =
-        [&](uint64_t a, uint64_t b, uint64_t c, uint64_t& d, uint64_t e,
-            uint64_t f, uint64_t g, uint64_t& h, uint64_t i)
+        [&](std::uint64_t a, std::uint64_t b, std::uint64_t c, std::uint64_t& d, std::uint64_t e,
+            std::uint64_t f, std::uint64_t g, std::uint64_t& h, std::uint64_t i)
         {
             t0 = h + Sigma1(e) + Ch(e, f, g) + K[i] + W[i];
             t1 = Sigma0(a) + Maj(a, b, c);
@@ -156,7 +156,7 @@ SHA512::SHA512() {
     state_[7] = 0x5be0cd19137e2179ULL;
 }
 
-SHA512::SHA512(const void* data, uint32_t size) : SHA512() {
+SHA512::SHA512(const void* data, std::uint32_t size) : SHA512() {
     process(data, size);
 }
 
@@ -164,9 +164,9 @@ SHA512::SHA512(const std::string& str) : SHA512() {
     process(str);
 }
 
-void SHA512::process(const void* data, uint32_t size) {
-    const uint32_t block_size = sizeof(SHA512::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+void SHA512::process(const void* data, std::uint32_t size) {
+    const std::uint32_t block_size = sizeof(SHA512::buf_);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -179,9 +179,9 @@ void SHA512::process(const void* data, uint32_t size) {
         }
         else
         {
-            uint32_t n = digest_detail::min(size, (block_size - curlen_));
-            uint8_t* b = buf_ + curlen_;
-            for (const uint8_t* a = in; a != in + n; ++a, ++b) {
+            std::uint32_t n = digest_detail::min(size, (block_size - curlen_));
+            std::uint8_t* b = buf_ + curlen_;
+            for (const std::uint8_t* a = in; a != in + n; ++a, ++b) {
                 *b = *a;
             }
             curlen_ += n;
@@ -207,7 +207,7 @@ void SHA512::finalize(void* digest) {
     length_ += curlen_ * 8ULL;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length is currently above 112 bytes we append zeros then compress.
     // Then we can fall back to padding zeros and length encoding like normal.
@@ -232,7 +232,7 @@ void SHA512::finalize(void* digest) {
     // Copy output
     for (int i = 0; i < 8; i++) {
         digest_detail::store64(
-            state_[i], static_cast<uint8_t*>(digest) + (8 * i));
+            state_[i], static_cast<std::uint8_t*>(digest) + (8 * i));
     }
 }
 
@@ -243,18 +243,18 @@ std::string SHA512::digest() {
 }
 
 std::string SHA512::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string SHA512::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string sha512_hex(const void* data, uint32_t size) {
+std::string sha512_hex(const void* data, std::uint32_t size) {
     return SHA512(data, size).digest_hex();
 }
 
@@ -262,7 +262,7 @@ std::string sha512_hex(const std::string& str) {
     return SHA512(str).digest_hex();
 }
 
-std::string sha512_hex_uc(const void* data, uint32_t size) {
+std::string sha512_hex_uc(const void* data, std::uint32_t size) {
     return SHA512(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/sha512.hpp
+++ b/tlx/digest/sha512.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     SHA512();
     //! construct context and process data range
-    SHA512(const void* data, uint32_t size);
+    SHA512(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit SHA512(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint64_t state_[8];
-    uint32_t curlen_;
-    uint8_t buf_[128];
+    std::uint64_t length_;
+    std::uint64_t state_[8];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[128];
 };
 
 //! process data and return 64 byte (512 bit) digest hex encoded
-std::string sha512_hex(const void* data, uint32_t size);
+std::string sha512_hex(const void* data, std::uint32_t size);
 //! process data and return 64 byte (512 bit) digest hex encoded
 std::string sha512_hex(const std::string& str);
 
 //! process data and return 64 byte (512 bit) digest upper-case hex encoded
-std::string sha512_hex_uc(const void* data, uint32_t size);
+std::string sha512_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 64 byte (512 bit) digest upper-case hex encoded
 std::string sha512_hex_uc(const std::string& str);
 

--- a/tlx/math/bswap.hpp
+++ b/tlx/math/bswap.hpp
@@ -28,28 +28,28 @@ namespace tlx {
 // bswap16() - swap 16-bit integers
 
 //! bswap16 - generic implementation
-static inline uint16_t bswap16_generic(const uint16_t& x) {
+static inline std::uint16_t bswap16_generic(const std::uint16_t& x) {
     return ((x >> 8) & 0x00FFUL) | ((x << 8) & 0xFF00UL);
 }
 
 #if defined(__GNUC__) || defined(__clang__)
 
 //! bswap16 - gcc/clang intrinsic
-static inline uint16_t bswap16(const uint16_t& v) {
+static inline std::uint16_t bswap16(const std::uint16_t& v) {
     return __builtin_bswap16(v);
 }
 
 #elif defined(_MSC_VER)
 
 //! bswap16 - MSVC intrinsic
-static inline uint16_t bswap16(const uint16_t& v) {
+static inline std::uint16_t bswap16(const std::uint16_t& v) {
     return _byteswap_ushort(v);
 }
 
 #else
 
 //! bswap16 - generic
-static inline uint16_t bswap16(const uint16_t& v) {
+static inline std::uint16_t bswap16(const std::uint16_t& v) {
     return bswap16_generic(v);
 }
 
@@ -59,7 +59,7 @@ static inline uint16_t bswap16(const uint16_t& v) {
 // bswap32() - swap 32-bit integers
 
 //! bswap32 - generic implementation
-static inline uint32_t bswap32_generic(const uint32_t& x) {
+static inline std::uint32_t bswap32_generic(const std::uint32_t& x) {
     return ((x >> 24) & 0x000000FFUL) | ((x << 24) & 0xFF000000UL) |
            ((x >> 8) & 0x0000FF00UL) | ((x << 8) & 0x00FF0000UL);
 }
@@ -67,21 +67,21 @@ static inline uint32_t bswap32_generic(const uint32_t& x) {
 #if defined(__GNUC__) || defined(__clang__)
 
 //! bswap32 - gcc/clang intrinsic
-static inline uint32_t bswap32(const uint32_t& v) {
+static inline std::uint32_t bswap32(const std::uint32_t& v) {
     return __builtin_bswap32(v);
 }
 
 #elif defined(_MSC_VER)
 
 //! bswap32 - MSVC intrinsic
-static inline uint32_t bswap32(const uint32_t& v) {
+static inline std::uint32_t bswap32(const std::uint32_t& v) {
     return _byteswap_ulong(v);
 }
 
 #else
 
 //! bswap32 - generic
-static inline uint32_t bswap32(const uint32_t& v) {
+static inline std::uint32_t bswap32(const std::uint32_t& v) {
     return bswap32_generic(v);
 }
 
@@ -91,7 +91,7 @@ static inline uint32_t bswap32(const uint32_t& v) {
 // bswap64() - swap 64-bit integers
 
 //! bswap64 - generic implementation
-static inline uint64_t bswap64_generic(const uint64_t& x) {
+static inline std::uint64_t bswap64_generic(const std::uint64_t& x) {
     return ((x >> 56) & 0x00000000000000FFull) |
            ((x >> 40) & 0x000000000000FF00ull) |
            ((x >> 24) & 0x0000000000FF0000ull) |
@@ -105,21 +105,21 @@ static inline uint64_t bswap64_generic(const uint64_t& x) {
 #if defined(__GNUC__) || defined(__clang__)
 
 //! bswap64 - gcc/clang intrinsic
-static inline uint64_t bswap64(const uint64_t& v) {
+static inline std::uint64_t bswap64(const std::uint64_t& v) {
     return __builtin_bswap64(v);
 }
 
 #elif defined(_MSC_VER)
 
 //! bswap64 - MSVC intrinsic
-static inline uint64_t bswap64(const uint64_t& v) {
+static inline std::uint64_t bswap64(const std::uint64_t& v) {
     return _byteswap_uint64(v);
 }
 
 #else
 
 //! bswap64 - generic
-static inline uint64_t bswap64(const uint64_t& v) {
+static inline std::uint64_t bswap64(const std::uint64_t& v) {
     return bswap64_generic(v);
 }
 

--- a/tlx/math/bswap_be.hpp
+++ b/tlx/math/bswap_be.hpp
@@ -16,6 +16,7 @@
 
 #include <tlx/define/endian.hpp>
 #include <tlx/math/bswap.hpp>
+#include <cstdint>
 
 namespace tlx {
 
@@ -26,11 +27,11 @@ namespace tlx {
 // bswap16_be() - swap 16-bit integers to big-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint16_t bswap16_be(const uint16_t& v) {
+static inline std::uint16_t bswap16_be(const std::uint16_t& v) {
     return bswap16(v);
 }
 #elif TLX_BIG_ENDIAN
-static inline uint16_t bswap16_be(const uint16_t& v) {
+static inline std::uint16_t bswap16_be(const std::uint16_t& v) {
     return v;
 }
 #endif
@@ -39,11 +40,11 @@ static inline uint16_t bswap16_be(const uint16_t& v) {
 // bswap32_be() - swap 32-bit integers to big-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint32_t bswap32_be(const uint32_t& v) {
+static inline std::uint32_t bswap32_be(const std::uint32_t& v) {
     return bswap32(v);
 }
 #elif TLX_BIG_ENDIAN
-static inline uint32_t bswap32_be(const uint32_t& v) {
+static inline std::uint32_t bswap32_be(const std::uint32_t& v) {
     return v;
 }
 #endif
@@ -52,11 +53,11 @@ static inline uint32_t bswap32_be(const uint32_t& v) {
 // bswap64_be() - swap 64-bit integers to big-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint64_t bswap64_be(const uint64_t& v) {
+static inline std::uint64_t bswap64_be(const std::uint64_t& v) {
     return bswap64(v);
 }
 #elif TLX_BIG_ENDIAN
-static inline uint64_t bswap64_be(const uint64_t& v) {
+static inline std::uint64_t bswap64_be(const std::uint64_t& v) {
     return v;
 }
 #endif

--- a/tlx/math/bswap_le.hpp
+++ b/tlx/math/bswap_le.hpp
@@ -16,6 +16,7 @@
 
 #include <tlx/define/endian.hpp>
 #include <tlx/math/bswap.hpp>
+#include <cstdint>
 
 namespace tlx {
 
@@ -26,11 +27,11 @@ namespace tlx {
 // bswap16_le() - swap 16-bit integers to little-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint16_t bswap16_le(const uint16_t& v) {
+static inline std::uint16_t bswap16_le(const std::uint16_t& v) {
     return v;
 }
 #elif TLX_BIG_ENDIAN
-static inline uint16_t bswap16_le(const uint16_t& v) {
+static inline std::uint16_t bswap16_le(const std::uint16_t& v) {
     return bswap16(v);
 }
 #endif
@@ -39,11 +40,11 @@ static inline uint16_t bswap16_le(const uint16_t& v) {
 // bswap32_le() - swap 32-bit integers to little-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint32_t bswap32_le(const uint32_t& v) {
+static inline std::uint32_t bswap32_le(const std::uint32_t& v) {
     return v;
 }
 #elif TLX_BIG_ENDIAN
-static inline uint32_t bswap32_le(const uint32_t& v) {
+static inline std::uint32_t bswap32_le(const std::uint32_t& v) {
     return bswap32(v);
 }
 #endif
@@ -52,11 +53,11 @@ static inline uint32_t bswap32_le(const uint32_t& v) {
 // bswap64_le() - swap 64-bit integers to little-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint64_t bswap64_le(const uint64_t& v) {
+static inline std::uint64_t bswap64_le(const std::uint64_t& v) {
     return v;
 }
 #elif TLX_BIG_ENDIAN
-static inline uint64_t bswap64_le(const uint64_t& v) {
+static inline std::uint64_t bswap64_le(const std::uint64_t& v) {
     return bswap64(v);
 }
 #endif

--- a/tlx/math/popcount.hpp
+++ b/tlx/math/popcount.hpp
@@ -29,29 +29,29 @@ namespace tlx {
 // popcount() - count one bits
 
 //! popcount (count one bits) - generic SWAR implementation
-static inline unsigned popcount_generic8(uint8_t x) {
+static inline unsigned popcount_generic8(std::uint8_t x) {
     x = x - ((x >> 1) & 0x55);
     x = (x & 0x33) + ((x >> 2) & 0x33);
-    return static_cast<uint8_t>((x + (x >> 4)) & 0x0F);
+    return static_cast<std::uint8_t>((x + (x >> 4)) & 0x0F);
 }
 
 //! popcount (count one bits) - generic SWAR implementation
-static inline unsigned popcount_generic16(uint16_t x) {
+static inline unsigned popcount_generic16(std::uint16_t x) {
     x = x - ((x >> 1) & 0x5555);
     x = (x & 0x3333) + ((x >> 2) & 0x3333);
-    return static_cast<uint16_t>(((x + (x >> 4)) & 0x0F0F) * 0x0101) >> 8;
+    return static_cast<std::uint16_t>(((x + (x >> 4)) & 0x0F0F) * 0x0101) >> 8;
 }
 
 //! popcount (count one bits) -
 //! generic SWAR implementation from https://stackoverflow.com/questions/109023
-static inline unsigned popcount_generic32(uint32_t x) {
+static inline unsigned popcount_generic32(std::uint32_t x) {
     x = x - ((x >> 1) & 0x55555555);
     x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
     return (((x + (x >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
 }
 
 //! popcount (count one bits) - generic SWAR implementation
-static inline unsigned popcount_generic64(uint64_t x) {
+static inline unsigned popcount_generic64(std::uint64_t x) {
     x = x - ((x >> 1) & 0x5555555555555555);
     x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333);
     return (((x + (x >> 4)) & 0x0F0F0F0F0F0F0F0F) * 0x0101010101010101) >> 56;
@@ -112,13 +112,13 @@ inline unsigned popcount(Integral i) {
 //! popcount (count one bits)
 template <typename Integral>
 inline unsigned popcount(Integral i) {
-    if (sizeof(i) <= sizeof(uint8_t))
+    if (sizeof(i) <= sizeof(std::uint8_t))
         return popcount_generic8(i);
-    else if (sizeof(i) <= sizeof(uint16_t))
+    else if (sizeof(i) <= sizeof(std::uint16_t))
         return popcount_generic16(i);
-    else if (sizeof(i) <= sizeof(uint32_t))
+    else if (sizeof(i) <= sizeof(std::uint32_t))
         return popcount_generic32(i);
-    else if (sizeof(i) <= sizeof(uint64_t))
+    else if (sizeof(i) <= sizeof(std::uint64_t))
         return popcount_generic64(i);
     else
         abort();
@@ -131,15 +131,15 @@ inline unsigned popcount(Integral i) {
 
 static inline
 size_t popcount(const void* data, size_t size) {
-    const uint8_t* begin = reinterpret_cast<const uint8_t*>(data);
-    const uint8_t* end = begin + size;
+    const std::uint8_t* begin = reinterpret_cast<const std::uint8_t*>(data);
+    const std::uint8_t* end = begin + size;
     size_t total = 0;
     while (begin + 7 < end) {
-        total += popcount(*reinterpret_cast<const uint64_t*>(begin));
+        total += popcount(*reinterpret_cast<const std::uint64_t*>(begin));
         begin += 8;
     }
     if (begin + 3 < end) {
-        total += popcount(*reinterpret_cast<const uint32_t*>(begin));
+        total += popcount(*reinterpret_cast<const std::uint32_t*>(begin));
         begin += 4;
     }
     while (begin < end) {

--- a/tlx/math/rol.hpp
+++ b/tlx/math/rol.hpp
@@ -28,16 +28,16 @@ namespace tlx {
 // rol32() - rotate bits left in 32-bit integers
 
 //! rol32 - generic implementation
-static inline uint32_t rol32_generic(const uint32_t& x, int i) {
-    return (x << static_cast<uint32_t>(i & 31)) |
-           (x >> static_cast<uint32_t>((32 - (i & 31)) & 31));
+static inline std::uint32_t rol32_generic(const std::uint32_t& x, int i) {
+    return (x << static_cast<std::uint32_t>(i & 31)) |
+           (x >> static_cast<std::uint32_t>((32 - (i & 31)) & 31));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))
 
 //! rol32 - gcc/clang assembler
-static inline uint32_t rol32(const uint32_t& x, int i) {
-    uint32_t x1 = x;
+static inline std::uint32_t rol32(const std::uint32_t& x, int i) {
+    std::uint32_t x1 = x;
     asm ("roll %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -45,14 +45,14 @@ static inline uint32_t rol32(const uint32_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! rol32 - MSVC intrinsic
-static inline uint32_t rol32(const uint32_t& x, int i) {
+static inline std::uint32_t rol32(const std::uint32_t& x, int i) {
     return _rotl(x, i);
 }
 
 #else
 
 //! rol32 - generic
-static inline uint32_t rol32(const uint32_t& x, int i) {
+static inline std::uint32_t rol32(const std::uint32_t& x, int i) {
     return rol32_generic(x, i);
 }
 
@@ -62,16 +62,16 @@ static inline uint32_t rol32(const uint32_t& x, int i) {
 // rol64() - rotate bits left in 64-bit integers
 
 //! rol64 - generic implementation
-static inline uint64_t rol64_generic(const uint64_t& x, int i) {
-    return (x << static_cast<uint64_t>(i & 63)) |
-           (x >> static_cast<uint64_t>((64 - (i & 63)) & 63));
+static inline std::uint64_t rol64_generic(const std::uint64_t& x, int i) {
+    return (x << static_cast<std::uint64_t>(i & 63)) |
+           (x >> static_cast<std::uint64_t>((64 - (i & 63)) & 63));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
 
 //! rol64 - gcc/clang assembler
-static inline uint64_t rol64(const uint64_t& x, int i) {
-    uint64_t x1 = x;
+static inline std::uint64_t rol64(const std::uint64_t& x, int i) {
+    std::uint64_t x1 = x;
     asm ("rolq %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -79,14 +79,14 @@ static inline uint64_t rol64(const uint64_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! rol64 - MSVC intrinsic
-static inline uint64_t rol64(const uint64_t& x, int i) {
+static inline std::uint64_t rol64(const std::uint64_t& x, int i) {
     return _rotl64(x, i);
 }
 
 #else
 
 //! rol64 - generic
-static inline uint64_t rol64(const uint64_t& x, int i) {
+static inline std::uint64_t rol64(const std::uint64_t& x, int i) {
     return rol64_generic(x, i);
 }
 

--- a/tlx/math/ror.hpp
+++ b/tlx/math/ror.hpp
@@ -28,16 +28,16 @@ namespace tlx {
 // ror32() - rotate bits right in 32-bit integers
 
 //! ror32 - generic implementation
-static inline uint32_t ror32_generic(const uint32_t& x, int i) {
-    return (x >> static_cast<uint32_t>(i & 31)) |
-           (x << static_cast<uint32_t>((32 - (i & 31)) & 31));
+static inline std::uint32_t ror32_generic(const std::uint32_t& x, int i) {
+    return (x >> static_cast<std::uint32_t>(i & 31)) |
+           (x << static_cast<std::uint32_t>((32 - (i & 31)) & 31));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))
 
 //! ror32 - gcc/clang assembler
-static inline uint32_t ror32(const uint32_t& x, int i) {
-    uint32_t x1 = x;
+static inline std::uint32_t ror32(const std::uint32_t& x, int i) {
+    std::uint32_t x1 = x;
     asm ("rorl %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -45,14 +45,14 @@ static inline uint32_t ror32(const uint32_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! ror32 - MSVC intrinsic
-static inline uint32_t ror32(const uint32_t& x, int i) {
+static inline std::uint32_t ror32(const std::uint32_t& x, int i) {
     return _rotr(x, i);
 }
 
 #else
 
 //! ror32 - generic
-static inline uint32_t ror32(const uint32_t& x, int i) {
+static inline std::uint32_t ror32(const std::uint32_t& x, int i) {
     return ror32_generic(x, i);
 }
 
@@ -62,16 +62,16 @@ static inline uint32_t ror32(const uint32_t& x, int i) {
 // ror64() - rotate bits right in 64-bit integers
 
 //! ror64 - generic implementation
-static inline uint64_t ror64_generic(const uint64_t& x, int i) {
-    return (x >> static_cast<uint64_t>(i & 63)) |
-           (x << static_cast<uint64_t>((64 - (i & 63)) & 63));
+static inline std::uint64_t ror64_generic(const std::uint64_t& x, int i) {
+    return (x >> static_cast<std::uint64_t>(i & 63)) |
+           (x << static_cast<std::uint64_t>((64 - (i & 63)) & 63));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
 
 //! ror64 - gcc/clang assembler
-static inline uint64_t ror64(const uint64_t& x, int i) {
-    uint64_t x1 = x;
+static inline std::uint64_t ror64(const std::uint64_t& x, int i) {
+    std::uint64_t x1 = x;
     asm ("rorq %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -79,14 +79,14 @@ static inline uint64_t ror64(const uint64_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! ror64 - MSVC intrinsic
-static inline uint64_t ror64(const uint64_t& x, int i) {
+static inline std::uint64_t ror64(const std::uint64_t& x, int i) {
     return _rotr64(x, i);
 }
 
 #else
 
 //! ror64 - generic
-static inline uint64_t ror64(const uint64_t& x, int i) {
+static inline std::uint64_t ror64(const std::uint64_t& x, int i) {
     return ror64_generic(x, i);
 }
 

--- a/tlx/meta/log2.hpp
+++ b/tlx/meta/log2.hpp
@@ -26,7 +26,7 @@ namespace tlx {
 /******************************************************************************/
 // Log2Floor<Value>::value
 
-template <uint64_t Input>
+template <std::uint64_t Input>
 class Log2Floor
 {
 public:
@@ -52,7 +52,7 @@ public:
 /******************************************************************************/
 // Log2<Value>::floor and Log2<Value>::ceil
 
-template <uint64_t Input>
+template <std::uint64_t Input>
 class Log2
 {
 public:

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -26,7 +26,7 @@ static std::mutex s_timer_add_mutex;
 
 struct MultiTimer::Entry {
     //! hash of name for faster search
-    uint32_t hash;
+    std::uint32_t hash;
     //! reference to original string for comparison
     const char* name;
     //! duration of this timer
@@ -50,7 +50,7 @@ MultiTimer& MultiTimer::operator = (MultiTimer&&) = default;
 MultiTimer::~MultiTimer() = default;
 
 MultiTimer::Entry& MultiTimer::find_or_create(const char* name) {
-    uint32_t hash = hash_djb2(name);
+    std::uint32_t hash = hash_djb2(name);
     for (size_t i = 0; i < timers_.size(); ++i) {
         if (timers_[i].hash == hash && strcmp(timers_[i].name, name) == 0)
             return timers_[i];
@@ -65,7 +65,7 @@ MultiTimer::Entry& MultiTimer::find_or_create(const char* name) {
 
 void MultiTimer::start(const char* timer) {
     tlx_die_unless(timer);
-    uint32_t hash = hash_djb2(timer);
+    std::uint32_t hash = hash_djb2(timer);
     if (running_ && hash == running_hash_ && strcmp(running_, timer) == 0) {
         static bool warning_shown = false;
         if (!warning_shown) {

--- a/tlx/multi_timer.hpp
+++ b/tlx/multi_timer.hpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <ostream>
 #include <vector>
+#include <cstdint>
 
 namespace tlx {
 
@@ -94,7 +95,7 @@ private:
     //! currently running timer name
     const char* running_;
     //! hash of running_
-    uint32_t running_hash_;
+    std::uint32_t running_hash_;
     //! start of currently running timer name
     std::chrono::time_point<std::chrono::high_resolution_clock> time_point_;
 

--- a/tlx/siphash.hpp
+++ b/tlx/siphash.hpp
@@ -39,21 +39,21 @@
 namespace tlx {
 
 static inline
-uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
+std::uint64_t siphash_plain(const std::uint8_t key[16], const std::uint8_t* m, size_t len) {
 
-    uint64_t v0, v1, v2, v3;
-    uint64_t mi, k0, k1;
-    uint64_t last7;
+    std::uint64_t v0, v1, v2, v3;
+    std::uint64_t mi, k0, k1;
+    std::uint64_t last7;
     size_t i, blocks;
 
-    k0 = bswap64_le(*reinterpret_cast<const uint64_t*>(key + 0));
-    k1 = bswap64_le(*reinterpret_cast<const uint64_t*>(key + 8));
+    k0 = bswap64_le(*reinterpret_cast<const std::uint64_t*>(key + 0));
+    k1 = bswap64_le(*reinterpret_cast<const std::uint64_t*>(key + 8));
     v0 = k0 ^ 0x736f6d6570736575ull;
     v1 = k1 ^ 0x646f72616e646f6dull;
     v2 = k0 ^ 0x6c7967656e657261ull;
     v3 = k1 ^ 0x7465646279746573ull;
 
-    last7 = static_cast<uint64_t>(len & 0xff) << 56;
+    last7 = static_cast<std::uint64_t>(len & 0xff) << 56;
 
 #define TLX_SIPCOMPRESS() \
     v0 += v1; v2 += v3;   \
@@ -68,7 +68,7 @@ uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
     v2 = rol64(v2, 32);
 
     for (i = 0, blocks = (len & ~7); i < blocks; i += 8) {
-        mi = bswap64_le(*reinterpret_cast<const uint64_t*>(m + i));
+        mi = bswap64_le(*reinterpret_cast<const std::uint64_t*>(m + i));
         v3 ^= mi;
         TLX_SIPCOMPRESS();
         TLX_SIPCOMPRESS();
@@ -77,25 +77,25 @@ uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
 
     switch (len - blocks) {
     case 7:
-        last7 |= static_cast<uint64_t>(m[i + 6]) << 48;
+        last7 |= static_cast<std::uint64_t>(m[i + 6]) << 48;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 6:
-        last7 |= static_cast<uint64_t>(m[i + 5]) << 40;
+        last7 |= static_cast<std::uint64_t>(m[i + 5]) << 40;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 5:
-        last7 |= static_cast<uint64_t>(m[i + 4]) << 32;
+        last7 |= static_cast<std::uint64_t>(m[i + 4]) << 32;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 4:
-        last7 |= static_cast<uint64_t>(m[i + 3]) << 24;
+        last7 |= static_cast<std::uint64_t>(m[i + 3]) << 24;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 3:
-        last7 |= static_cast<uint64_t>(m[i + 2]) << 16;
+        last7 |= static_cast<std::uint64_t>(m[i + 2]) << 16;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 2:
-        last7 |= static_cast<uint64_t>(m[i + 1]) << 8;
+        last7 |= static_cast<std::uint64_t>(m[i + 1]) << 8;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 1:
-        last7 |= static_cast<uint64_t>(m[i + 0]);
+        last7 |= static_cast<std::uint64_t>(m[i + 0]);
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 0:
     default:;
@@ -122,7 +122,7 @@ uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
 #if defined(__SSE2__)
 
 union siphash_packedelem64 {
-    uint64_t u[2];
+    std::uint64_t u[2];
     __m128i v;
 };
 
@@ -141,11 +141,11 @@ static const siphash_packedelem64 siphash_final = {
 };
 
 static inline
-uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
+std::uint64_t siphash_sse2(const std::uint8_t key[16], const std::uint8_t* m, size_t len) {
 
     __m128i k, v02, v20, v13, v11, v33, mi;
-    uint64_t last7;
-    uint32_t lo, hi;
+    std::uint64_t last7;
+    std::uint32_t lo, hi;
     size_t i, blocks;
 
     k = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key + 0));
@@ -154,7 +154,7 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
     v02 = _mm_xor_si128(v02, _mm_unpacklo_epi64(k, k));
     v13 = _mm_xor_si128(v13, _mm_unpackhi_epi64(k, k));
 
-    last7 = static_cast<uint64_t>(len & 0xff) << 56;
+    last7 = static_cast<std::uint64_t>(len & 0xff) << 56;
 
 #define TLX_SIPCOMPRESS()                                                      \
     v11 = v13;                                                                 \
@@ -184,33 +184,33 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
 
     switch (len - blocks) {
     case 7:
-        last7 |= static_cast<uint64_t>(m[i + 6]) << 48;
+        last7 |= static_cast<std::uint64_t>(m[i + 6]) << 48;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 6:
-        last7 |= static_cast<uint64_t>(m[i + 5]) << 40;
+        last7 |= static_cast<std::uint64_t>(m[i + 5]) << 40;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 5:
-        last7 |= static_cast<uint64_t>(m[i + 4]) << 32;
+        last7 |= static_cast<std::uint64_t>(m[i + 4]) << 32;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 4:
-        last7 |= static_cast<uint64_t>(m[i + 3]) << 24;
+        last7 |= static_cast<std::uint64_t>(m[i + 3]) << 24;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 3:
-        last7 |= static_cast<uint64_t>(m[i + 2]) << 16;
+        last7 |= static_cast<std::uint64_t>(m[i + 2]) << 16;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 2:
-        last7 |= static_cast<uint64_t>(m[i + 1]) << 8;
+        last7 |= static_cast<std::uint64_t>(m[i + 1]) << 8;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 1:
-        last7 |= static_cast<uint64_t>(m[i + 0]);
+        last7 |= static_cast<std::uint64_t>(m[i + 0]);
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 0:
     default:;
     }
 
     mi = _mm_unpacklo_epi32(
-        _mm_cvtsi32_si128(static_cast<uint32_t>(last7)),
-        _mm_cvtsi32_si128(static_cast<uint32_t>(last7 >> 32)));
+        _mm_cvtsi32_si128(static_cast<std::uint32_t>(last7)),
+        _mm_cvtsi32_si128(static_cast<std::uint32_t>(last7 >> 32)));
     v13 = _mm_xor_si128(v13, _mm_slli_si128(mi, 8));
     TLX_SIPCOMPRESS();
     TLX_SIPCOMPRESS();
@@ -228,7 +228,7 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
 
 #undef TLX_SIPCOMPRESS
 
-    return (static_cast<uint64_t>(hi) << 32) | lo;
+    return (static_cast<std::uint64_t>(hi) << 32) | lo;
 }
 
 #endif  // defined(__SSE2__)
@@ -237,7 +237,7 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
 // Switch between available implementations
 
 static inline
-uint64_t siphash(const uint8_t key[16], const uint8_t* msg, size_t size) {
+std::uint64_t siphash(const std::uint8_t key[16], const std::uint8_t* msg, size_t size) {
 #if defined(__SSE2__)
     return siphash_sse2(key, msg, size);
 #else
@@ -246,7 +246,7 @@ uint64_t siphash(const uint8_t key[16], const uint8_t* msg, size_t size) {
 }
 
 static inline
-uint64_t siphash(const uint8_t* msg, size_t size) {
+std::uint64_t siphash(const std::uint8_t* msg, size_t size) {
     const unsigned char key[16] = {
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
     };
@@ -254,19 +254,19 @@ uint64_t siphash(const uint8_t* msg, size_t size) {
 }
 
 static inline
-uint64_t siphash(const char* msg, size_t size) {
-    return siphash(reinterpret_cast<const uint8_t*>(msg), size);
+std::uint64_t siphash(const char* msg, size_t size) {
+    return siphash(reinterpret_cast<const std::uint8_t*>(msg), size);
 }
 
 static inline
-uint64_t siphash(const std::string& str) {
+std::uint64_t siphash(const std::string& str) {
     return siphash(str.data(), str.size());
 }
 
 template <typename Type>
 static inline
-uint64_t siphash(const Type& value) {
-    return siphash(reinterpret_cast<const uint8_t*>(&value), sizeof(value));
+std::uint64_t siphash(const Type& value) {
+    return siphash(reinterpret_cast<const std::uint8_t*>(&value), sizeof(value));
 }
 
 #undef rol64

--- a/tlx/sort/strings.hpp
+++ b/tlx/sort/strings.hpp
@@ -31,7 +31,7 @@ namespace tlx {
 /******************************************************************************/
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
@@ -58,7 +58,7 @@ void sort_strings(char** strings, size_t size, size_t memory = 0) {
 }
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
@@ -100,7 +100,7 @@ void sort_strings(std::vector<char*>& strings, size_t memory = 0) {
 }
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
@@ -123,7 +123,7 @@ void sort_strings(std::vector<const char*>& strings, size_t memory = 0) {
 }
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
@@ -168,17 +168,17 @@ void sort_strings(std::vector<std::string>& strings, size_t memory = 0) {
 /******************************************************************************/
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(unsigned char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(unsigned char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     sort_strings_detail::radixsort_CE3(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::UCharStringSet, uint32_t>(
+            sort_strings_detail::UCharStringSet, std::uint32_t>(
             sort_strings_detail::UCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -191,24 +191,24 @@ void sort_strings_lcp(unsigned char** strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(
         reinterpret_cast<unsigned char**>(strings), size, lcp, memory);
 }
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(const unsigned char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(const unsigned char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     sort_strings_detail::radixsort_CE3(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::CUCharStringSet, uint32_t>(
+            sort_strings_detail::CUCharStringSet, std::uint32_t>(
             sort_strings_detail::CUCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -221,7 +221,7 @@ void sort_strings_lcp(const unsigned char** strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(const char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(const char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(
         reinterpret_cast<const unsigned char**>(strings), size, lcp, memory);
@@ -237,19 +237,19 @@ void sort_strings_lcp(const char** strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<unsigned char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<unsigned char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
@@ -262,19 +262,19 @@ void sort_strings_lcp(std::vector<unsigned char*>& strings, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<const char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<const char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
 
 /*!
- * Sort a set of strings represented by C-style uint8_t* in place.
+ * Sort a set of strings represented by C-style std::uint8_t* in place.
  *
  * If the memory limit is non zero, possibly slower algorithms will be selected
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<const unsigned char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<const unsigned char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
@@ -289,11 +289,11 @@ void sort_strings_lcp(std::vector<const unsigned char*>& strings, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::string* strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(std::string* strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     sort_strings_detail::radixsort_CE3(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::StdStringSet, uint32_t>(
+            sort_strings_detail::StdStringSet, std::uint32_t>(
             sort_strings_detail::StdStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -306,7 +306,7 @@ void sort_strings_lcp(std::string* strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<std::string>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<std::string>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -36,6 +36,7 @@
 #include <tlx/simple_vector.hpp>
 #include <tlx/thread_pool.hpp>
 #include <tlx/unused.hpp>
+#include <cstdint>
 
 namespace tlx {
 namespace sort_strings_detail {
@@ -317,7 +318,7 @@ public:
         ctx_.mtimer.add(mtimer_);
     }
 
-    simple_vector<uint8_t> bktcache_;
+    simple_vector<std::uint8_t> bktcache_;
     size_t bktcache_size_ = 0;
 
     void run() {
@@ -333,7 +334,7 @@ public:
 
         if (ctx_.enable_sequential_sample_sort && n >= ctx_.smallsort_threshold)
         {
-            bktcache_.resize(n * sizeof(uint16_t));
+            bktcache_.resize(n * sizeof(std::uint16_t));
             sort_sample_sort(strptr_, depth_);
         }
         else
@@ -368,7 +369,7 @@ public:
         bktsize_type bkt[bktnum + 1];
 
         SeqSampleSortStep(Context& ctx, const StringPtr& strptr, size_t depth,
-                          uint16_t* bktcache)
+                          std::uint16_t* bktcache)
             : strptr_(strptr), idx_(0), depth_(depth) {
             size_t n = strptr_.size();
 
@@ -447,7 +448,7 @@ public:
         assert(ss_front_ == 0);
         assert(ss_stack_.size() == 0);
 
-        uint16_t* bktcache = reinterpret_cast<uint16_t*>(bktcache_.data());
+        std::uint16_t* bktcache = reinterpret_cast<std::uint16_t*>(bktcache_.data());
 
         // sort first level
         ss_stack_.emplace_back(ctx_, strptr, depth, bktcache);
@@ -755,7 +756,7 @@ public:
         size_t idx_;
         unsigned char eq_recurse_;
         // typename StringPtr::StringSet::Char dchar_eq_, dchar_gt_;
-        uint8_t lcp_lt_, lcp_eq_, lcp_gt_;
+        std::uint8_t lcp_lt_, lcp_eq_, lcp_gt_;
 
         MKQSStep(Context& ctx, const StringPtr& strptr,
                  key_type* cache, size_t depth, bool CacheDirty)
@@ -1129,7 +1130,7 @@ public:
     //! individual bucket array of threads, keep bkt[0] for DistributeJob
     simple_vector<simple_vector<size_t> > bkt_;
     //! bucket ids cache, created by classifier and later counted
-    simple_vector<simple_vector<uint16_t> > bktcache_;
+    simple_vector<simple_vector<std::uint16_t> > bktcache_;
 
     /*------------------------------------------------------------------------*/
     // Constructor
@@ -1204,14 +1205,14 @@ public:
         if (strE < strB) strE = strB;
 
         bktcache_[p].resize(strE - strB);
-        uint16_t* bktcache = bktcache_[p].data();
+        std::uint16_t* bktcache = bktcache_[p].data();
         classifier_.classify(strset, strB, strE, bktcache, depth_);
 
         bkt_[p].resize(bktnum_ + (p == 0 ? 1 : 0));
         size_t* bkt = bkt_[p].data();
         memset(bkt, 0, bktnum_ * sizeof(size_t));
 
-        for (uint16_t* bc = bktcache; bc != bktcache + (strE - strB); ++bc)
+        for (std::uint16_t* bc = bktcache; bc != bktcache + (strE - strB); ++bc)
             ++bkt[*bc];
 
         if (--pwork_ == 0)
@@ -1259,7 +1260,7 @@ public:
         const StringSet& sorted = strptr_.shadow();
         typename StringSet::Iterator sbegin = sorted.begin();
 
-        uint16_t* bktcache = bktcache_[p].data();
+        std::uint16_t* bktcache = bktcache_[p].data();
         size_t* bkt = bkt_[p].data();
 
         for (StrIterator str = strB; str != strE; ++str, ++bktcache)
@@ -1400,12 +1401,12 @@ void PS5Context<Parameters>::enqueue(
     }
     else {
         if (strptr.size() < (1LLU << 32)) {
-            auto j = new PS5SmallsortJob<PS5Context, StringPtr, uint32_t>(
+            auto j = new PS5SmallsortJob<PS5Context, StringPtr, std::uint32_t>(
                 *this, pstep, strptr, depth);
             threads_.enqueue([j]() { j->run(); });
         }
         else {
-            auto j = new PS5SmallsortJob<PS5Context, StringPtr, uint64_t>(
+            auto j = new PS5SmallsortJob<PS5Context, StringPtr, std::uint64_t>(
                 *this, pstep, strptr, depth);
             threads_.enqueue([j]() { j->run(); });
         }

--- a/tlx/sort/strings/radix_sort.hpp
+++ b/tlx/sort/strings/radix_sort.hpp
@@ -29,6 +29,7 @@
 #include <stack>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 namespace tlx {
 
@@ -199,18 +200,18 @@ struct RadixStep_CE2 {
     typedef typename StringSet::Iterator Iterator;
 
     RadixStep_CE2(const StringShadowPtr& in_strptr, size_t depth,
-                  uint8_t* charcache) : strptr(in_strptr) {
+                  std::uint8_t* charcache) : strptr(in_strptr) {
 
         const StringSet& ss = strptr.active();
         const size_t n = ss.size();
 
         // read characters and count character occurrences
         std::fill(bkt_size, bkt_size + 256, 0);
-        uint8_t* cc = charcache;
+        std::uint8_t* cc = charcache;
         for (Iterator i = ss.begin(); i != ss.end(); ++i, ++cc)
             *cc = ss.get_uint8(ss[i], depth);
         for (cc = charcache; cc != charcache + n; ++cc)
-            ++bkt_size[static_cast<uint8_t>(*cc)];
+            ++bkt_size[static_cast<std::uint8_t>(*cc)];
 
         // prefix sum
         Iterator bkt_index[256];
@@ -221,7 +222,7 @@ struct RadixStep_CE2 {
         // distribute
         cc = charcache;
         for (Iterator i = ss.begin(); i != ss.end(); ++i, ++cc)
-            *(bkt_index[static_cast<uint8_t>(*cc)]++) = std::move(ss[i]);
+            *(bkt_index[static_cast<std::uint8_t>(*cc)]++) = std::move(ss[i]);
 
         idx = 0; // will increment to 1 on first process
         pos = bkt_size[0];
@@ -256,7 +257,7 @@ struct RadixStep_CE2 {
 
 template <typename StringPtr>
 static inline void
-radixsort_CI3(const StringPtr& strptr, uint16_t* charcache,
+radixsort_CI3(const StringPtr& strptr, std::uint16_t* charcache,
               size_t depth, size_t memory);
 
 /*
@@ -265,7 +266,7 @@ radixsort_CI3(const StringPtr& strptr, uint16_t* charcache,
 template <typename StringShadowPtr>
 static inline void
 radixsort_CE2_loop(const StringShadowPtr& strptr,
-                   uint8_t* charcache, size_t depth, size_t memory) {
+                   std::uint8_t* charcache, size_t depth, size_t memory) {
 
     typedef RadixStep_CE2<StringShadowPtr> RadixStep;
 
@@ -328,7 +329,7 @@ radixsort_CE2(const StringPtr& strptr, size_t depth, size_t memory) {
     // try to estimate the amount of memory used
     size_t memory_use =
         2 * sizeof(size_t) + sizeof(StringSet)
-        + ss.size() * sizeof(uint8_t)
+        + ss.size() * sizeof(std::uint8_t)
         + ss.size() * sizeof(typename StringSet::String);
     size_t memory_slack = 3 * sizeof(RadixStep);
 
@@ -336,7 +337,7 @@ radixsort_CE2(const StringPtr& strptr, size_t depth, size_t memory) {
         return radixsort_CI3(strptr, depth, memory);
 
     typename StringSet::Container shadow = ss.allocate(ss.size());
-    uint8_t* charcache = new uint8_t[ss.size()];
+    std::uint8_t* charcache = new std::uint8_t[ss.size()];
 
     radixsort_CE2_loop(strptr.add_shadow(StringSet(shadow)),
                        charcache, depth, memory - memory_use);
@@ -359,18 +360,18 @@ struct RadixStep_CE3 {
     typedef typename StringSet::Iterator Iterator;
 
     RadixStep_CE3(const StringShadowPtr& in_strptr, size_t depth,
-                  uint16_t* charcache) : strptr(in_strptr) {
+                  std::uint16_t* charcache) : strptr(in_strptr) {
 
         const StringSet& ss = strptr.active();
         const size_t n = ss.size();
 
         // read characters and count character occurrences
         std::fill(bkt_size, bkt_size + RADIX, 0);
-        uint16_t* cc = charcache;
+        std::uint16_t* cc = charcache;
         for (Iterator i = ss.begin(); i != ss.end(); ++i, ++cc)
             *cc = ss.get_uint16(ss[i], depth);
         for (cc = charcache; cc != charcache + n; ++cc)
-            ++bkt_size[static_cast<uint16_t>(*cc)];
+            ++bkt_size[static_cast<std::uint16_t>(*cc)];
 
         // prefix sum
         simple_vector<Iterator> bkt_index(RADIX);
@@ -402,7 +403,7 @@ struct RadixStep_CE3 {
         // distribute
         cc = charcache;
         for (Iterator i = ss.begin(); i != ss.end(); ++i, ++cc)
-            *(bkt_index[static_cast<uint16_t>(*cc)]++) = std::move(ss[i]);
+            *(bkt_index[static_cast<std::uint16_t>(*cc)]++) = std::move(ss[i]);
 
         // will increment to 1 on first process
         idx = 0;
@@ -428,7 +429,7 @@ struct RadixStep_CE3 {
 template <typename StringShadowPtr>
 static inline void
 radixsort_CE3_loop(const StringShadowPtr& strptr,
-                   uint16_t* charcache, size_t depth, size_t memory) {
+                   std::uint16_t* charcache, size_t depth, size_t memory) {
 
     enum { RADIX = 0x10000 };
 
@@ -468,7 +469,7 @@ radixsort_CE3_loop(const StringShadowPtr& strptr,
             {
                 radixsort_CE2_loop(
                     rs.strptr.flip(rs.pos, bkt_size),
-                    reinterpret_cast<uint8_t*>(charcache),
+                    reinterpret_cast<std::uint8_t*>(charcache),
                     depth + 2 * radixstack.size(),
                     memory - sizeof(RadixStep) * radixstack.size());
                 rs.pos += bkt_size;
@@ -515,7 +516,7 @@ radixsort_CE3(const StringPtr& strptr, size_t depth, size_t memory) {
     // try to estimate the amount of memory used
     size_t memory_use =
         2 * sizeof(size_t) + sizeof(StringSet)
-        + ss.size() * sizeof(uint16_t)
+        + ss.size() * sizeof(std::uint16_t)
         + ss.size() * sizeof(typename StringSet::String);
     size_t memory_slack = 3 * sizeof(RadixStep);
 
@@ -523,7 +524,7 @@ radixsort_CE3(const StringPtr& strptr, size_t depth, size_t memory) {
         return radixsort_CE2(strptr, depth, memory);
 
     typename StringSet::Container shadow = ss.allocate(ss.size());
-    uint16_t* charcache = new uint16_t[ss.size()];
+    std::uint16_t* charcache = new std::uint16_t[ss.size()];
 
     radixsort_CE3_loop(strptr.add_shadow(StringSet(shadow)),
                        charcache, depth, memory - memory_use);
@@ -545,18 +546,18 @@ struct RadixStep_CI2 {
     size_t bkt_size[256];
 
     RadixStep_CI2(const StringPtr& strptr,
-                  size_t base, size_t depth, uint8_t* charcache) {
+                  size_t base, size_t depth, std::uint8_t* charcache) {
 
         const StringSet& ss = strptr.active();
         size_t size = ss.size();
 
         // read characters and count character occurrences
         std::fill(bkt_size, bkt_size + 256, 0);
-        uint8_t* cc = charcache;
+        std::uint8_t* cc = charcache;
         for (Iterator i = ss.begin(); i != ss.end(); ++i, ++cc)
             *cc = ss.get_uint8(ss[i], depth);
         for (cc = charcache; cc != charcache + size; ++cc)
-            ++bkt_size[static_cast<uint8_t>(*cc)];
+            ++bkt_size[static_cast<std::uint8_t>(*cc)];
 
         // inclusive prefix sum
         size_t bkt[256];
@@ -571,7 +572,7 @@ struct RadixStep_CI2 {
         for (size_t i = 0, j; i < size - last_bkt_size; )
         {
             String perm = std::move(ss[ss.begin() + i]);
-            uint8_t permch = charcache[i];
+            std::uint8_t permch = charcache[i];
             while ((j = --bkt[permch]) > i)
             {
                 std::swap(perm, ss[ss.begin() + j]);
@@ -613,7 +614,7 @@ struct RadixStep_CI2 {
  */
 template <typename StringPtr>
 static inline void
-radixsort_CI2(const StringPtr& strptr, uint8_t* charcache,
+radixsort_CI2(const StringPtr& strptr, std::uint8_t* charcache,
               size_t depth, size_t memory) {
 
     typedef RadixStep_CI2<StringPtr> RadixStep;
@@ -681,13 +682,13 @@ radixsort_CI2(const StringPtr& strptr, size_t depth, size_t memory) {
     // try to estimate the amount of memory used
     size_t memory_use =
         2 * sizeof(size_t) + sizeof(StringSet)
-        + strptr.size() * sizeof(uint8_t);
+        + strptr.size() * sizeof(std::uint8_t);
     size_t memory_slack = 3 * sizeof(RadixStep);
 
     if (memory != 0 && memory < memory_use + memory_slack + 1)
         return multikey_quicksort(strptr, depth, memory);
 
-    uint8_t* charcache = new uint8_t[strptr.size()];
+    std::uint8_t* charcache = new std::uint8_t[strptr.size()];
 
     radixsort_CI2(strptr, charcache, depth, memory - memory_use);
 
@@ -709,17 +710,17 @@ struct RadixStep_CI3 {
     size_t bkt_size[RADIX];
 
     RadixStep_CI3(const StringPtr& strptr, size_t base, size_t depth,
-                  uint16_t* charcache) {
+                  std::uint16_t* charcache) {
 
         const StringSet& ss = strptr.active();
         const size_t n = ss.size();
         // read characters and count character occurrences
         std::fill(bkt_size, bkt_size + RADIX, 0);
-        uint16_t* cc = charcache;
+        std::uint16_t* cc = charcache;
         for (Iterator i = ss.begin(); i != ss.end(); ++i, ++cc)
             *cc = ss.get_uint16(ss[i], depth);
         for (cc = charcache; cc != charcache + n; ++cc)
-            ++bkt_size[static_cast<uint16_t>(*cc)];
+            ++bkt_size[static_cast<std::uint16_t>(*cc)];
 
         // inclusive prefix sum
         simple_vector<size_t> bkt_index(RADIX);
@@ -755,7 +756,7 @@ struct RadixStep_CI3 {
         for (size_t i = 0, j; i < n - last_bkt_size; )
         {
             String perm = std::move(ss[ss.begin() + i]);
-            uint16_t permch = charcache[i];
+            std::uint16_t permch = charcache[i];
             while ((j = --bkt_index[permch]) > i)
             {
                 std::swap(perm, ss[ss.begin() + j]);
@@ -785,7 +786,7 @@ struct RadixStep_CI3 {
  */
 template <typename StringPtr>
 static inline void
-radixsort_CI3(const StringPtr& strptr, uint16_t* charcache,
+radixsort_CI3(const StringPtr& strptr, std::uint16_t* charcache,
               size_t depth, size_t memory) {
     enum { RADIX = 0x10000 };
 
@@ -826,7 +827,7 @@ radixsort_CI3(const StringPtr& strptr, uint16_t* charcache,
             {
                 radixsort_CI2(
                     strptr.sub(rs.pos, bkt_size),
-                    reinterpret_cast<uint8_t*>(charcache),
+                    reinterpret_cast<std::uint8_t*>(charcache),
                     depth + 2 * radixstack.size(),
                     memory - sizeof(RadixStep) * radixstack.size());
                 rs.pos += bkt_size;
@@ -873,13 +874,13 @@ radixsort_CI3(const StringPtr& strptr, size_t depth, size_t memory) {
     // try to estimate the amount of memory used
     size_t memory_use =
         2 * sizeof(size_t) + sizeof(StringSet)
-        + strptr.size() * sizeof(uint16_t);
+        + strptr.size() * sizeof(std::uint16_t);
     size_t memory_slack = 3 * sizeof(RadixStep);
 
     if (memory != 0 && memory < memory_use + memory_slack + 1)
         return radixsort_CI2(strptr, depth, memory);
 
-    uint16_t* charcache = new uint16_t[strptr.size()];
+    std::uint16_t* charcache = new std::uint16_t[strptr.size()];
     radixsort_CI3(strptr, charcache, depth, memory - memory_use);
     delete[] charcache;
 }

--- a/tlx/sort/strings/sample_sort_tools.hpp
+++ b/tlx/sort/strings/sample_sort_tools.hpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 
 namespace tlx {
 namespace sort_strings_detail {
@@ -60,7 +61,7 @@ struct PerfectTreeCalculations {
 
         static const int bitmask = num_nodes;
 
-        int hi = treebits - 32 + clz<uint32_t>(id);
+        int hi = treebits - 32 + clz<std::uint32_t>(id);
         TLX_LOG << "high zero: " << hi;
 
         unsigned int bkt = ((id << (hi + 1)) & bitmask) | (1 << hi);
@@ -75,7 +76,7 @@ struct PerfectTreeCalculations {
 
         static const int bitmask = num_nodes;
 
-        int lo = ctz<uint32_t>(id) + 1;
+        int lo = ctz<std::uint32_t>(id) + 1;
         TLX_LOG << "low zero: " << lo;
 
         unsigned int bkt = ((id >> lo) & bitmask) | (1 << (treebits - lo));
@@ -374,7 +375,7 @@ public:
     //! search in splitter tree for bucket number, unrolled for Rollout keys at
     //! once.
     void find_bkt_unroll(
-        const key_type key[Rollout], uint16_t obkt[Rollout]) const {
+        const key_type key[Rollout], std::uint16_t obkt[Rollout]) const {
         // binary tree traversal without left branch
 
         unsigned int i[Rollout];
@@ -441,7 +442,7 @@ public:
     void classify(
         const StringSet& strset,
         typename StringSet::Iterator begin, typename StringSet::Iterator end,
-        uint16_t* bktout, size_t depth) const {
+        std::uint16_t* bktout, size_t depth) const {
         while (begin != end)
         {
             if (begin + Rollout <= end)
@@ -550,7 +551,7 @@ public:
     void classify(
         const StringSet& strset,
         typename StringSet::Iterator begin, typename StringSet::Iterator end,
-        uint16_t* bktout, size_t depth) const {
+        std::uint16_t* bktout, size_t depth) const {
         while (begin != end)
         {
             key_type key = get_key<key_type>(strset, *begin++, depth);
@@ -619,7 +620,7 @@ public:
     //! search in splitter tree for bucket number, unrolled for Rollout keys at
     //! once.
     void find_bkt_unroll(
-        const key_type key[Rollout], uint16_t obkt[Rollout]) const {
+        const key_type key[Rollout], std::uint16_t obkt[Rollout]) const {
         // binary tree traversal without left branch
 
         unsigned int i[Rollout];
@@ -687,7 +688,7 @@ public:
     void classify(
         const StringSet& strset,
         typename StringSet::Iterator begin, typename StringSet::Iterator end,
-        uint16_t* bktout, size_t depth) const {
+        std::uint16_t* bktout, size_t depth) const {
         while (begin != end)
         {
             if (begin + Rollout <= end)

--- a/tlx/sort/strings/string_set.hpp
+++ b/tlx/sort/strings/string_set.hpp
@@ -98,100 +98,100 @@ public:
     }
 
     //! Return up to 1 characters of string s at iterator i packed into a
-    //! uint8_t (only works correctly for 8-bit characters)
-    uint8_t get_uint8(
+    //! std::uint8_t (only works correctly for 8-bit characters)
+    std::uint8_t get_uint8(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
         if (ss.is_end(s, i)) return 0;
-        return uint8_t(*i);
+        return std::uint8_t(*i);
     }
 
     //! Return up to 2 characters of string s at iterator i packed into a
-    //! uint16_t (only works correctly for 8-bit characters)
-    uint16_t get_uint16(
+    //! std::uint16_t (only works correctly for 8-bit characters)
+    std::uint16_t get_uint16(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
-        uint16_t v = 0;
+        std::uint16_t v = 0;
         if (ss.is_end(s, i)) return v;
-        v = (uint16_t(*i) << 8);
+        v = (std::uint16_t(*i) << 8);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint16_t(*i) << 0);
+        v |= (std::uint16_t(*i) << 0);
         return v;
     }
 
     //! Return up to 4 characters of string s at iterator i packed into a
-    //! uint32_t (only works correctly for 8-bit characters)
-    uint32_t get_uint32(
+    //! std::uint32_t (only works correctly for 8-bit characters)
+    std::uint32_t get_uint32(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
-        uint32_t v = 0;
+        std::uint32_t v = 0;
         if (ss.is_end(s, i)) return v;
-        v = (uint32_t(*i) << 24);
+        v = (std::uint32_t(*i) << 24);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint32_t(*i) << 16);
+        v |= (std::uint32_t(*i) << 16);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint32_t(*i) << 8);
+        v |= (std::uint32_t(*i) << 8);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint32_t(*i) << 0);
+        v |= (std::uint32_t(*i) << 0);
         return v;
     }
 
     //! Return up to 8 characters of string s at iterator i packed into a
-    //! uint64_t (only works correctly for 8-bit characters)
-    uint64_t get_uint64(
+    //! std::uint64_t (only works correctly for 8-bit characters)
+    std::uint64_t get_uint64(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
-        uint64_t v = 0;
+        std::uint64_t v = 0;
         if (ss.is_end(s, i)) return v;
-        v = (uint64_t(*i) << 56);
+        v = (std::uint64_t(*i) << 56);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 48);
+        v |= (std::uint64_t(*i) << 48);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 40);
+        v |= (std::uint64_t(*i) << 40);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 32);
+        v |= (std::uint64_t(*i) << 32);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 24);
+        v |= (std::uint64_t(*i) << 24);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 16);
+        v |= (std::uint64_t(*i) << 16);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 8);
+        v |= (std::uint64_t(*i) << 8);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 0);
+        v |= (std::uint64_t(*i) << 0);
         return v;
     }
 
-    uint8_t get_uint8(const typename Traits::String& s, size_t depth) const {
+    std::uint8_t get_uint8(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint8(s, ss.get_chars(s, depth));
     }
 
-    uint16_t get_uint16(const typename Traits::String& s, size_t depth) const {
+    std::uint16_t get_uint16(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint16(s, ss.get_chars(s, depth));
     }
 
-    uint32_t get_uint32(const typename Traits::String& s, size_t depth) const {
+    std::uint32_t get_uint32(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint32(s, ss.get_chars(s, depth));
     }
 
-    uint64_t get_uint64(const typename Traits::String& s, size_t depth) const {
+    std::uint64_t get_uint64(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint64(s, ss.get_chars(s, depth));
     }
@@ -244,7 +244,7 @@ public:
 
 template <typename Type, typename StringSet>
 inline
-typename enable_if<sizeof(Type) == 4, uint32_t>::type
+typename enable_if<sizeof(Type) == 4, std::uint32_t>::type
 get_key(const StringSet& strset,
         const typename StringSet::String& s, size_t depth) {
     return strset.get_uint32(s, depth);
@@ -252,7 +252,7 @@ get_key(const StringSet& strset,
 
 template <typename Type, typename StringSet>
 inline
-typename enable_if<sizeof(Type) == 8, uint64_t>::type
+typename enable_if<sizeof(Type) == 8, std::uint64_t>::type
 get_key(const StringSet& strset,
         const typename StringSet::String& s, size_t depth) {
     return strset.get_uint64(s, depth);
@@ -373,7 +373,7 @@ class StdStringSetTraits
 {
 public:
     //! exported alias for character type
-    typedef uint8_t Char;
+    typedef std::uint8_t Char;
 
     //! String reference: std::string, which should be reference counted.
     typedef std::string String;
@@ -456,7 +456,7 @@ class UPtrStdStringSetTraits
 {
 public:
     //! exported alias for character type
-    typedef uint8_t Char;
+    typedef std::uint8_t Char;
 
     //! String reference: std::string, which should be reference counted.
     typedef std::unique_ptr<std::string> String;
@@ -552,7 +552,7 @@ public:
     typedef std::string Text;
 
     //! exported alias for character type
-    typedef uint8_t Char;
+    typedef std::uint8_t Char;
 
     //! String reference: suffix index of the text.
     typedef typename Text::size_type String;

--- a/tlx/sort/strings_parallel.hpp
+++ b/tlx/sort/strings_parallel.hpp
@@ -29,7 +29,7 @@ namespace tlx {
 /******************************************************************************/
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
@@ -55,7 +55,7 @@ void sort_strings_parallel(char** strings, size_t size, size_t memory = 0) {
 }
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
@@ -95,7 +95,7 @@ void sort_strings_parallel(std::vector<char*>& strings, size_t memory = 0) {
 }
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
@@ -118,7 +118,7 @@ void sort_strings_parallel(std::vector<const char*>& strings,
 }
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
@@ -162,16 +162,16 @@ void sort_strings_parallel(std::vector<std::string>& strings,
 /******************************************************************************/
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
 static inline
 void sort_strings_parallel_lcp(unsigned char** strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     sort_strings_detail::parallel_sample_sort(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::UCharStringSet, uint32_t>(
+            sort_strings_detail::UCharStringSet, std::uint32_t>(
             sort_strings_detail::UCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -183,23 +183,23 @@ void sort_strings_parallel_lcp(unsigned char** strings, size_t size,
  * The memory limit is currently not used.
  */
 static inline
-void sort_strings_parallel_lcp(char** strings, size_t size, uint32_t* lcp,
+void sort_strings_parallel_lcp(char** strings, size_t size, std::uint32_t* lcp,
                                size_t memory = 0) {
     return sort_strings_parallel_lcp(
         reinterpret_cast<unsigned char**>(strings), size, lcp, memory);
 }
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
 static inline
 void sort_strings_parallel_lcp(const unsigned char** strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     sort_strings_detail::parallel_sample_sort(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::CUCharStringSet, uint32_t>(
+            sort_strings_detail::CUCharStringSet, std::uint32_t>(
             sort_strings_detail::CUCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -212,7 +212,7 @@ void sort_strings_parallel_lcp(const unsigned char** strings, size_t size,
  */
 static inline
 void sort_strings_parallel_lcp(const char** strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         reinterpret_cast<const unsigned char**>(strings), size, lcp, memory);
 }
@@ -226,20 +226,20 @@ void sort_strings_parallel_lcp(const char** strings, size_t size,
  * The memory limit is currently not used.
  */
 static inline
-void sort_strings_parallel_lcp(std::vector<char*>& strings, uint32_t* lcp,
+void sort_strings_parallel_lcp(std::vector<char*>& strings, std::uint32_t* lcp,
                                size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
 static inline
 void sort_strings_parallel_lcp(std::vector<unsigned char*>& strings,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }
@@ -251,20 +251,20 @@ void sort_strings_parallel_lcp(std::vector<unsigned char*>& strings,
  * The memory limit is currently not used.
  */
 static inline
-void sort_strings_parallel_lcp(std::vector<const char*>& strings, uint32_t* lcp,
+void sort_strings_parallel_lcp(std::vector<const char*>& strings, std::uint32_t* lcp,
                                size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }
 
 /*!
- * Sort a set of strings in parallel represented by C-style uint8_t* in place.
+ * Sort a set of strings in parallel represented by C-style std::uint8_t* in place.
  *
  * The memory limit is currently not used.
  */
 static inline
 void sort_strings_parallel_lcp(std::vector<const unsigned char*>& strings,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }
@@ -279,10 +279,10 @@ void sort_strings_parallel_lcp(std::vector<const unsigned char*>& strings,
  */
 static inline
 void sort_strings_parallel_lcp(std::string* strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     sort_strings_detail::parallel_sample_sort(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::StdStringSet, uint32_t>(
+            sort_strings_detail::StdStringSet, std::uint32_t>(
             sort_strings_detail::StdStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -295,7 +295,7 @@ void sort_strings_parallel_lcp(std::string* strings, size_t size,
  */
 static inline
 void sort_strings_parallel_lcp(std::vector<std::string>& strings,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }

--- a/tlx/string/base64.cpp
+++ b/tlx/string/base64.cpp
@@ -23,8 +23,8 @@ namespace tlx {
 // Base64 Encoding and Decoding
 
 std::string base64_encode(const void* data, size_t size, size_t line_break) {
-    const uint8_t* in = reinterpret_cast<const uint8_t*>(data);
-    const uint8_t* in_end = in + size;
+    const std::uint8_t* in = reinterpret_cast<const std::uint8_t*>(data);
+    const std::uint8_t* in_end = in + size;
     std::string out;
 
     if (size == 0) return out;
@@ -42,7 +42,7 @@ std::string base64_encode(const void* data, size_t size, size_t line_break) {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
     };
 
-    uint8_t result = 0;
+    std::uint8_t result = 0;
     size_t line_begin = 0;
 
     while (true)
@@ -53,10 +53,10 @@ std::string base64_encode(const void* data, size_t size, size_t line_break) {
         }
 
         // step 0: process first byte, write first letter
-        uint8_t fragment = *in++;
+        std::uint8_t fragment = *in++;
         result = (fragment & 0xFC) >> 2;
         out += encoding64[result];
-        result = static_cast<uint8_t>((fragment & 0x03) << 4);
+        result = static_cast<std::uint8_t>((fragment & 0x03) << 4);
 
         // step 1: if string finished here, add two padding '='s
         if (in == in_end) {
@@ -71,7 +71,7 @@ std::string base64_encode(const void* data, size_t size, size_t line_break) {
         fragment = *in++;
         result |= (fragment & 0xF0) >> 4;
         out += encoding64[result];
-        result = static_cast<uint8_t>((fragment & 0x0F) << 2);
+        result = static_cast<std::uint8_t>((fragment & 0x0F) << 2);
 
         // step 2: if string finished here, add one padding '='
         if (in == in_end) {
@@ -106,18 +106,18 @@ std::string base64_encode(const std::string& str, size_t line_break) {
 /******************************************************************************/
 
 std::string base64_decode(const void* data, size_t size, bool strict) {
-    const uint8_t* in = reinterpret_cast<const uint8_t*>(data);
-    const uint8_t* in_end = in + size;
+    const std::uint8_t* in = reinterpret_cast<const std::uint8_t*>(data);
+    const std::uint8_t* in_end = in + size;
     std::string out;
 
     // estimate the output size, assume that the whole input string is
     // base64 encoded.
     out.reserve(size * 3 / 4);
 
-    static constexpr uint8_t ex = 255;
-    static constexpr uint8_t ws = 254;
+    static constexpr std::uint8_t ex = 255;
+    static constexpr std::uint8_t ws = 254;
     // value lookup table: -1 -> exception, -2 -> skip whitespace
-    static const uint8_t decoding64[256] = {
+    static const std::uint8_t decoding64[256] = {
         ex, ex, ex, ex, ex, ex, ex, ex, ex, ws, ws, ex, ex, ws, ex, ex,
         ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex,
         ws, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, 62, ex, ex, ex, 63,
@@ -136,7 +136,7 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
         ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex
     };
 
-    uint8_t outchar, fragment;
+    std::uint8_t outchar, fragment;
 
     static const char* ex_message =
         "Invalid character encountered during base64 decoding.";
@@ -153,7 +153,7 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>((fragment & 0x3F) << 2);
+        outchar = static_cast<std::uint8_t>((fragment & 0x3F) << 2);
 
         // step 1: get second valid letter. output the first byte.
         do {
@@ -165,10 +165,10 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>(outchar | ((fragment & 0x30) >> 4));
+        outchar = static_cast<std::uint8_t>(outchar | ((fragment & 0x30) >> 4));
         out += static_cast<char>(outchar);
 
-        outchar = static_cast<uint8_t>((fragment & 0x0F) << 4);
+        outchar = static_cast<std::uint8_t>((fragment & 0x0F) << 4);
 
         // step 2: get third valid letter. output the second byte.
         do {
@@ -180,10 +180,10 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>(outchar | ((fragment & 0x3C) >> 2));
+        outchar = static_cast<std::uint8_t>(outchar | ((fragment & 0x3C) >> 2));
         out += static_cast<char>(outchar);
 
-        outchar = static_cast<uint8_t>((fragment & 0x03) << 6);
+        outchar = static_cast<std::uint8_t>((fragment & 0x03) << 6);
 
         // step 3: get fourth valid letter. output the third byte.
         do {
@@ -195,7 +195,7 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>(outchar | ((fragment & 0x3F) >> 0));
+        outchar = static_cast<std::uint8_t>(outchar | ((fragment & 0x3F) >> 0));
         out += static_cast<char>(outchar);
     }
 }

--- a/tlx/string/base64.hpp
+++ b/tlx/string/base64.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_BASE64_HEADER
 
 #include <string>
+#include <cstdint>
 
 namespace tlx {
 

--- a/tlx/string/format_iec_units.hpp
+++ b/tlx/string/format_iec_units.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_FORMAT_IEC_UNITS_HEADER
 
 #include <string>
+#include <cstdint>
 
 namespace tlx {
 
@@ -20,7 +21,7 @@ namespace tlx {
 
 //! Format a byte size using IEC (Ki, Mi, Gi, Ti) suffixes (powers of
 //! two). Returns "123 Ki" or similar.
-std::string format_iec_units(uint64_t number, int precision = 3);
+std::string format_iec_units(std::uint64_t number, int precision = 3);
 
 //! \}
 

--- a/tlx/string/format_si_iec_units.cpp
+++ b/tlx/string/format_si_iec_units.cpp
@@ -16,8 +16,8 @@
 namespace tlx {
 
 //! Format number as something like 1 TB
-std::string format_si_units(uint64_t number, int precision) {
-    // may not overflow, std::numeric_limits<uint64_t>::max() == 16 EiB
+std::string format_si_units(std::uint64_t number, int precision) {
+    // may not overflow, std::numeric_limits<std::uint64_t>::max() == 16 EiB
     double multiplier = 1000.0;
     static const char* SI_endings[] = {
         "", "k", "M", "G", "T", "P", "E"
@@ -35,8 +35,8 @@ std::string format_si_units(uint64_t number, int precision) {
 }
 
 //! Format number as something like 1 TiB
-std::string format_iec_units(uint64_t number, int precision) {
-    // may not overflow, std::numeric_limits<uint64_t>::max() == 16 EiB
+std::string format_iec_units(std::uint64_t number, int precision) {
+    // may not overflow, std::numeric_limits<std::uint64_t>::max() == 16 EiB
     double multiplier = 1024.0;
     static const char* IEC_endings[] = {
         "", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"

--- a/tlx/string/format_si_units.hpp
+++ b/tlx/string/format_si_units.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_FORMAT_SI_UNITS_HEADER
 
 #include <string>
+#include <cstdint>
 
 namespace tlx {
 
@@ -20,7 +21,7 @@ namespace tlx {
 
 //! Format a byte size using SI (K, M, G, T) suffixes (powers of ten). Returns
 //! "123 M" or similar.
-std::string format_si_units(uint64_t number, int precision = 3);
+std::string format_si_units(std::uint64_t number, int precision = 3);
 
 //! \}
 

--- a/tlx/string/hash_djb2.hpp
+++ b/tlx/string/hash_djb2.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_HASH_DJB2_HEADER
 
 #include <string>
+#include <cstdint>
 
 namespace tlx {
 
@@ -23,8 +24,8 @@ namespace tlx {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const unsigned char* str) {
-    uint32_t hash = 5381;
+std::uint32_t hash_djb2(const unsigned char* str) {
+    std::uint32_t hash = 5381;
     unsigned char c;
     while ((c = *str++) != 0) {
         // hash * 33 + c
@@ -38,7 +39,7 @@ uint32_t hash_djb2(const unsigned char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const char* str) {
+std::uint32_t hash_djb2(const char* str) {
     return hash_djb2(reinterpret_cast<const unsigned char*>(str));
 }
 
@@ -47,8 +48,8 @@ uint32_t hash_djb2(const char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const unsigned char* str, size_t size) {
-    uint32_t hash = 5381;
+std::uint32_t hash_djb2(const unsigned char* str, size_t size) {
+    std::uint32_t hash = 5381;
     while (size-- > 0) {
         // hash * 33 + c
         hash = ((hash << 5) + hash) + static_cast<unsigned char>(*str++);
@@ -61,7 +62,7 @@ uint32_t hash_djb2(const unsigned char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const char* str, size_t size) {
+std::uint32_t hash_djb2(const char* str, size_t size) {
     return hash_djb2(reinterpret_cast<const unsigned char*>(str), size);
 }
 
@@ -70,7 +71,7 @@ uint32_t hash_djb2(const char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const std::string& str) {
+std::uint32_t hash_djb2(const std::string& str) {
     return hash_djb2(str.data(), str.size());
 }
 

--- a/tlx/string/hash_sdbm.hpp
+++ b/tlx/string/hash_sdbm.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_HASH_SDBM_HEADER
 
 #include <string>
+#include <cstdint>
 
 namespace tlx {
 
@@ -23,8 +24,8 @@ namespace tlx {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const unsigned char* str) {
-    uint32_t hash = 0;
+std::uint32_t hash_sdbm(const unsigned char* str) {
+    std::uint32_t hash = 0;
     unsigned char c;
     while ((c = *str++) != 0) {
         hash = c + (hash << 6) + (hash << 16) - hash;
@@ -37,7 +38,7 @@ uint32_t hash_sdbm(const unsigned char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const char* str) {
+std::uint32_t hash_sdbm(const char* str) {
     return hash_sdbm(reinterpret_cast<const unsigned char*>(str));
 }
 
@@ -46,8 +47,8 @@ uint32_t hash_sdbm(const char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const unsigned char* str, size_t size) {
-    uint32_t hash = 0;
+std::uint32_t hash_sdbm(const unsigned char* str, size_t size) {
+    std::uint32_t hash = 0;
     while (size-- > 0) {
         hash = static_cast<unsigned char>(*str++)
                + (hash << 6) + (hash << 16) - hash;
@@ -60,7 +61,7 @@ uint32_t hash_sdbm(const unsigned char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const char* str, size_t size) {
+std::uint32_t hash_sdbm(const char* str, size_t size) {
     return hash_sdbm(reinterpret_cast<const unsigned char*>(str), size);
 }
 
@@ -69,7 +70,7 @@ uint32_t hash_sdbm(const char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const std::string& str) {
+std::uint32_t hash_sdbm(const std::string& str) {
     return hash_sdbm(str.data(), str.size());
 }
 

--- a/tlx/string/hexdump.cpp
+++ b/tlx/string/hexdump.cpp
@@ -47,7 +47,7 @@ std::string hexdump(const std::vector<char>& data) {
     return hexdump(data.data(), data.size());
 }
 
-std::string hexdump(const std::vector<uint8_t>& data) {
+std::string hexdump(const std::vector<std::uint8_t>& data) {
     return hexdump(data.data(), data.size());
 }
 
@@ -55,7 +55,7 @@ std::string hexdump_sourcecode(
     const std::string& str, const std::string& var_name) {
 
     std::ostringstream header;
-    header << "const uint8_t " << var_name << "[" << str.size() << "] = {\n";
+    header << "const std::uint8_t " << var_name << "[" << str.size() << "] = {\n";
 
     static const int perline = 16;
 
@@ -121,7 +121,7 @@ std::string hexdump_lc(const std::vector<char>& data) {
     return hexdump_lc(data.data(), data.size());
 }
 
-std::string hexdump_lc(const std::vector<uint8_t>& data) {
+std::string hexdump_lc(const std::vector<std::uint8_t>& data) {
     return hexdump_lc(data.data(), data.size());
 }
 

--- a/tlx/string/hexdump.hpp
+++ b/tlx/string/hexdump.hpp
@@ -62,16 +62,16 @@ std::string hexdump_type(const Type& t) {
 std::string hexdump(const std::vector<char>& data);
 
 /*!
- * Dump a uint8_t vector as a sequence of uppercase hexadecimal pairs.
+ * Dump a std::uint8_t vector as a sequence of uppercase hexadecimal pairs.
  *
  * \param data  binary data to output in hex
  * \return      string of hexadecimal pairs
  */
-std::string hexdump(const std::vector<uint8_t>& data);
+std::string hexdump(const std::vector<std::uint8_t>& data);
 
 /*!
  * Dump a (binary) string into a C source code snippet. The snippet defines an
- * array of const uint8_t* holding the data of the string.
+ * array of const std::uint8_t* holding the data of the string.
  *
  * \param str       string to output as C source array
  * \param var_name  name of the array variable in the outputted code snippet
@@ -120,12 +120,12 @@ std::string hexdump_lc_type(const Type& t) {
 std::string hexdump_lc(const std::vector<char>& data);
 
 /*!
- * Dump a uint8_t vector as a sequence of lowercase hexadecimal pairs.
+ * Dump a std::uint8_t vector as a sequence of lowercase hexadecimal pairs.
  *
  * \param data  binary data to output in hex
  * \return      string of hexadecimal pairs
  */
-std::string hexdump_lc(const std::vector<uint8_t>& data);
+std::string hexdump_lc(const std::vector<std::uint8_t>& data);
 
 /******************************************************************************/
 // Parser for Hex Digit Sequence

--- a/tlx/string/parse_si_iec_units.cpp
+++ b/tlx/string/parse_si_iec_units.cpp
@@ -15,7 +15,7 @@
 namespace tlx {
 
 bool parse_si_iec_units(
-    const char* str, uint64_t* out_size, char default_unit) {
+    const char* str, std::uint64_t* out_size, char default_unit) {
 
     char* endptr;
     *out_size = strtoul(str, &endptr, 10);
@@ -86,7 +86,7 @@ bool parse_si_iec_units(
 }
 
 bool parse_si_iec_units(
-    const std::string& str, uint64_t* out_size, char default_unit) {
+    const std::string& str, std::uint64_t* out_size, char default_unit) {
     return parse_si_iec_units(str.c_str(), out_size, default_unit);
 }
 

--- a/tlx/string/parse_si_iec_units.hpp
+++ b/tlx/string/parse_si_iec_units.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_PARSE_SI_IEC_UNITS_HEADER
 
 #include <string>
+#include <cstdint>
 
 namespace tlx {
 
@@ -25,7 +26,7 @@ namespace tlx {
  * (powers of ten) or in K/M/G/T/P (power of two).
  */
 bool parse_si_iec_units(
-    const char* str, uint64_t* out_size, char default_unit = 0);
+    const char* str, std::uint64_t* out_size, char default_unit = 0);
 
 /*!
  * Parse a string like "343KB" or "44 GiB" into the corresponding size in
@@ -34,7 +35,7 @@ bool parse_si_iec_units(
  * (powers of ten) or in K/M/G/T/P (power of two).
  */
 bool parse_si_iec_units(
-    const std::string& str, uint64_t* out_size, char default_unit = 0);
+    const std::string& str, std::uint64_t* out_size, char default_unit = 0);
 
 //! \}
 


### PR DESCRIPTION
gcc13 no longer supports uintX_t types automatically. See https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=6f038efd93593da6e661b829d1bd3877e75550f1