### PR TITLE
Fix CI: use Ubuntu 20.04 and 22.04, omit MacOS and gcc 13 for now, update uncrustify to 0.76.0f

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,9 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - name: "Ubuntu 18.04 gcc 7.5 Debug"
-          os: ubuntu-18.04
+        - name: "Ubuntu 20.04 gcc 7.5 Debug"
+          os: ubuntu-20.04
           build_type: "Debug"
+          gcc_install: "7"
 
         - name: "Ubuntu 20.04 gcc 9.3 Debug 32-bit"
           os: ubuntu-20.04
@@ -38,9 +39,19 @@ jobs:
           gcc_install: "11"
           cxx_flags: "-D_GLIBCXX_DEBUG"
 
-        - name: "macOS 10.15 clang 12 Debug"
-          os: macos-10.15
+        - name: "Ubuntu 22.04 gcc 11 Debug"
+          os: ubuntu-22.04
           build_type: "Debug"
+
+        # - name: "Ubuntu 22.04 gcc 13 Release GLIBCXX_DEBUG"
+        #   os: ubuntu-22.04
+        #   build_type: "Release"
+        #   gcc_install: "13"
+        #   cxx_flags: "-D_GLIBCXX_DEBUG"
+
+        # - name: "macOS 12 clang X Debug"
+        #   os: macos-12
+        #   build_type: "Debug"
 
         # - name: "Window Latest"
         #   os: windows-latest

--- a/misc/format/analyze-source.pl
+++ b/misc/format/analyze-source.pl
@@ -10,8 +10,8 @@
 ################################################################################
 
 # uncrustify executable
-my $uncrustify = "uncrustify-0.68.1";
-my $uncrustify_sign = "Uncrustify-0.68-2-8c80bd84";
+my $uncrustify = "uncrustify";
+my $uncrustify_sign = "Uncrustify-0.76.0_f";
 
 # print multiple email addresses
 my $email_multimap = 0;

--- a/misc/format/uncrustify.cfg
+++ b/misc/format/uncrustify.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.68-2-8c80bd84
+# Uncrustify-0.76.0_f
 
 #
 # General options
@@ -37,6 +37,9 @@ string_replace_tab_chars        = true     # true/false
 # Improvements to template detection may make this option obsolete.
 tok_split_gte                   = true     # true/false
 
+# Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).
+disable_processing_nl_cont      = false    # true/false
+
 # Specify the marker used in comments to disable processing of part of the
 # file.
 #
@@ -51,8 +54,14 @@ enable_processing_cmt           = ""         # string
 # Enable parsing of digraphs.
 enable_digraphs                 = false    # true/false
 
+# Option to allow both disable_processing_cmt and enable_processing_cmt
+# strings, if specified, to be interpreted as ECMAScript regular expressions.
+# If true, a regex search will be performed within comments according to the
+# specified patterns in order to disable/enable processing.
+processing_cmt_as_regex         = false    # true/false
+
 # Add or remove the UTF-8 BOM (recommend 'remove').
-utf8_bom                        = ignore   # ignore/add/remove/force
+utf8_bom                        = ignore   # ignore/add/remove/force/not_defined
 
 # If the file contains bytes with values between 128 and 255, but is not
 # UTF-8, then output as UTF-8.
@@ -67,184 +76,249 @@ utf8_force                      = false    # true/false
 
 # Add or remove space around non-assignment symbolic operators ('+', '/', '%',
 # '<<', and so forth).
-sp_arith                        = force    # ignore/add/remove/force
+sp_arith                        = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around arithmetic operators '+' and '-'.
 #
 # Overrides sp_arith.
-sp_arith_additive               = ignore   # ignore/add/remove/force
+sp_arith_additive               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment operator '=', '+=', etc.
-sp_assign                       = force    # ignore/add/remove/force
+sp_assign                       = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around '=' in C++11 lambda capture specifications.
 #
 # Overrides sp_assign.
-sp_cpp_lambda_assign            = remove   # ignore/add/remove/force
+sp_cpp_lambda_assign            = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space after the capture specification in C++11 lambda.
-sp_cpp_lambda_paren             = remove   # ignore/add/remove/force
+# Add or remove space after the capture specification of a C++11 lambda when
+# an argument list is present, as in '[] <here> (int x){ ... }'.
+sp_cpp_lambda_square_paren      = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the capture specification of a C++11 lambda with
+# no argument list is present, as in '[] <here> { ... }'.
+sp_cpp_lambda_square_brace      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the opening parenthesis and before the closing
+# parenthesis of a argument list of a C++11 lambda, as in
+# '[]( <here> int x <here> ){ ... }'.
+sp_cpp_lambda_argument_list     = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the argument list of a C++11 lambda, as in
+# '[](int x) <here> { ... }'.
+sp_cpp_lambda_paren_brace       = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a lambda body and its call operator of an
+# immediately invoked lambda, as in '[]( ... ){ ... } <here> ( ... )'.
+sp_cpp_lambda_fparen            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment operator '=' in a prototype.
-sp_assign_default               = force    # ignore/add/remove/force
+#
+# If set to ignore, use sp_assign.
+sp_assign_default               = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before assignment operator '=', '+=', etc.
 #
 # Overrides sp_assign.
-sp_before_assign                = force    # ignore/add/remove/force
+sp_before_assign                = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after assignment operator '=', '+=', etc.
 #
 # Overrides sp_assign.
-sp_after_assign                 = force    # ignore/add/remove/force
+sp_after_assign                 = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space in 'enum {'.
+#
+# Default: add
+sp_enum_brace                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space in 'NS_ENUM ('.
-sp_enum_paren                   = ignore   # ignore/add/remove/force
+sp_enum_paren                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment '=' in enum.
-sp_enum_assign                  = force    # ignore/add/remove/force
+sp_enum_assign                  = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before assignment '=' in enum.
 #
 # Overrides sp_enum_assign.
-sp_enum_before_assign           = force    # ignore/add/remove/force
+sp_enum_before_assign           = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after assignment '=' in enum.
 #
 # Overrides sp_enum_assign.
-sp_enum_after_assign            = force    # ignore/add/remove/force
+sp_enum_after_assign            = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment ':' in enum.
-sp_enum_colon                   = ignore   # ignore/add/remove/force
+sp_enum_colon                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around preprocessor '##' concatenation operator.
 #
 # Default: add
-sp_pp_concat                    = force    # ignore/add/remove/force
+sp_pp_concat                    = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after preprocessor '#' stringify operator.
 # Also affects the '#@' charizing operator.
-sp_pp_stringify                 = remove   # ignore/add/remove/force
+sp_pp_stringify                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before preprocessor '#' stringify operator
 # as in '#define x(y) L#y'.
-sp_before_pp_stringify          = force    # ignore/add/remove/force
+sp_before_pp_stringify          = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around boolean operators '&&' and '||'.
-sp_bool                         = force    # ignore/add/remove/force
+sp_bool                         = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around compare operator '<', '>', '==', etc.
-sp_compare                      = force    # ignore/add/remove/force
+sp_compare                      = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '(' and ')'.
-sp_inside_paren                 = remove   # ignore/add/remove/force
+sp_inside_paren                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between nested parentheses, i.e. '((' vs. ') )'.
-sp_paren_paren                  = remove   # ignore/add/remove/force
+sp_paren_paren                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.
-sp_cparen_oparen                = remove   # ignore/add/remove/force
+sp_cparen_oparen                = remove   # ignore/add/remove/force/not_defined
 
 # Whether to balance spaces inside nested parentheses.
 sp_balance_nested_parens        = false    # true/false
 
 # Add or remove space between ')' and '{'.
-sp_paren_brace                  = force    # ignore/add/remove/force
+sp_paren_brace                  = force    # ignore/add/remove/force/not_defined
 
-# Add or remove space between nested braces, i.e. '{{' vs '{ {'.
-sp_brace_brace                  = ignore   # ignore/add/remove/force
+# Add or remove space between nested braces, i.e. '{{' vs. '{ {'.
+sp_brace_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before pointer star '*'.
-sp_before_ptr_star              = remove   # ignore/add/remove/force
+sp_before_ptr_star              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before pointer star '*' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_ptr_star is used instead.
-sp_before_unnamed_ptr_star      = remove   # ignore/add/remove/force
+# variable name. If set to ignore, sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star      = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space between pointer stars '*'.
-sp_between_ptr_star             = remove   # ignore/add/remove/force
+# Add or remove space between pointer stars '*', as in 'int ***a;'.
+sp_between_ptr_star             = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer star '*', if followed by a word.
-sp_after_ptr_star               = force    # ignore/add/remove/force
+#
+# Overrides sp_type_func.
+sp_after_ptr_star               = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer caret '^', if followed by a word.
-sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force
+sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer star '*', if followed by a qualifier.
-sp_after_ptr_star_qualifier     = force    # ignore/add/remove/force
+sp_after_ptr_star_qualifier     = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after a pointer star '*', if followed by a function
 # prototype or function definition.
-sp_after_ptr_star_func          = force    # ignore/add/remove/force
+#
+# Overrides sp_after_ptr_star and sp_type_func.
+sp_after_ptr_star_func          = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space after a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_after_ptr_star_trailing      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the pointer star '*' and the name of the variable
+# in a function pointer definition.
+sp_ptr_star_func_var            = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the pointer star '*' and the name of the type
+# in a function pointer type definition.
+sp_ptr_star_func_type           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after a pointer star '*', if followed by an open
-# parenthesis, as in 'void* (*)().
-sp_ptr_star_paren               = ignore   # ignore/add/remove/force
+# parenthesis, as in 'void* (*)()'.
+sp_ptr_star_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a pointer star '*', if followed by a function
 # prototype or function definition.
-sp_before_ptr_star_func         = force    # ignore/add/remove/force
+sp_before_ptr_star_func         = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space before a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_before_ptr_star_trailing     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&'.
-sp_before_byref                 = remove   # ignore/add/remove/force
+sp_before_byref                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_byref is used instead.
-sp_before_unnamed_byref         = remove   # ignore/add/remove/force
+# variable name. If set to ignore, sp_before_byref is used instead.
+sp_before_unnamed_byref         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after reference sign '&', if followed by a word.
-sp_after_byref                  = force    # ignore/add/remove/force
+#
+# Overrides sp_type_func.
+sp_after_byref                  = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after a reference sign '&', if followed by a function
 # prototype or function definition.
-sp_after_byref_func             = force    # ignore/add/remove/force
+#
+# Overrides sp_after_byref and sp_type_func.
+sp_after_byref_func             = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&', if followed by a function
 # prototype or function definition.
-sp_before_byref_func            = remove   # ignore/add/remove/force
+sp_before_byref_func            = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space between type and word.
+# Add or remove space after a reference sign '&', if followed by an open
+# parenthesis, as in 'char& (*)()'.
+sp_byref_paren                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between type and word. In cases where total removal of
+# whitespace would be a syntax error, a value of 'remove' is treated the same
+# as 'force'.
+#
+# This also affects some other instances of space following a type that are
+# not covered by other options; for example, between the return type and
+# parenthesis of a function type template argument, between the type and
+# parenthesis of an array parameter, or between 'decltype(...)' and the
+# following word.
 #
 # Default: force
-sp_after_type                   = force    # ignore/add/remove/force
+sp_after_type                   = force    # ignore/add/remove/force/not_defined
 
-# Add or remove space between 'decltype(...)' and word.
-sp_after_decltype               = ignore   # ignore/add/remove/force
+# Add or remove space between 'decltype(...)' and word,
+# brace or function call.
+sp_after_decltype               = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space before the parenthesis in the D constructs
 # 'template Foo(' and 'class Foo('.
-sp_before_template_paren        = ignore   # ignore/add/remove/force
+sp_before_template_paren        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'template' and '<'.
 # If set to ignore, sp_before_angle is used.
-sp_template_angle               = force    # ignore/add/remove/force
+sp_template_angle               = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before '<'.
-sp_before_angle                 = remove   # ignore/add/remove/force
+sp_before_angle                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '<' and '>'.
-sp_inside_angle                 = remove   # ignore/add/remove/force
+sp_inside_angle                 = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside '<>'.
+sp_inside_angle_empty           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and ':'.
-sp_angle_colon                  = ignore   # ignore/add/remove/force
+sp_angle_colon                  = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space after '<>'.
-sp_after_angle                  = remove   # ignore/add/remove/force
+# Add or remove space after '>'.
+sp_after_angle                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and '(' as found in 'new List<byte>(foo);'.
-sp_angle_paren                  = remove   # ignore/add/remove/force
+sp_angle_paren                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and '()' as found in 'new List<byte>();'.
-sp_angle_paren_empty            = ignore   # ignore/add/remove/force
+sp_angle_paren_empty            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and a word as in 'List<byte> m;' or
 # 'template <typename T> static ...'.
-sp_angle_word                   = force    # ignore/add/remove/force
+sp_angle_word                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and '>' in '>>' (template stuff).
 #
 # Default: add
-sp_angle_shift                  = force    # ignore/add/remove/force
+sp_angle_shift                  = force    # ignore/add/remove/force/not_defined
 
 # (C++11) Permit removal of the space between '>>' in 'foo<bar<int> >'. Note
 # that sp_angle_shift cannot remove the space without this option.
@@ -252,596 +326,728 @@ sp_permit_cpp11_shift           = false    # true/false
 
 # Add or remove space before '(' of control statements ('if', 'for', 'switch',
 # 'while', etc.).
-sp_before_sparen                = force    # ignore/add/remove/force
+sp_before_sparen                = force    # ignore/add/remove/force/not_defined
 
-# Add or remove space inside '(' and ')' of control statements.
-sp_inside_sparen                = remove   # ignore/add/remove/force
+# Add or remove space inside '(' and ')' of control statements other than
+# 'for'.
+sp_inside_sparen                = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space after '(' of control statements.
+# Add or remove space after '(' of control statements other than 'for'.
 #
 # Overrides sp_inside_sparen.
-sp_inside_sparen_open           = ignore   # ignore/add/remove/force
+sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before ')' of control statements.
+# Add or remove space before ')' of control statements other than 'for'.
 #
 # Overrides sp_inside_sparen.
-sp_inside_sparen_close          = ignore   # ignore/add/remove/force
+sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside '(' and ')' of 'for' statements.
+sp_inside_for                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after '(' of 'for' statements.
+#
+# Overrides sp_inside_for.
+sp_inside_for_open              = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before ')' of 'for' statements.
+#
+# Overrides sp_inside_for.
+sp_inside_for_close             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ')' of control statements.
-sp_after_sparen                 = force    # ignore/add/remove/force
+sp_after_sparen                 = force    # ignore/add/remove/force/not_defined
 
-# Add or remove space between ')' and '{' of of control statements.
-sp_sparen_brace                 = force    # ignore/add/remove/force
+# Add or remove space between ')' and '{' of control statements.
+sp_sparen_brace                 = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space between 'do' and '{'.
+sp_do_brace_open                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '}' and 'while'.
+sp_brace_close_while            = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between 'while' and '('. Overrides sp_before_sparen.
+sp_while_paren_open             = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space between 'invariant' and '('.
-sp_invariant_paren              = ignore   # ignore/add/remove/force
+sp_invariant_paren              = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space after the ')' in 'invariant (C) c'.
-sp_after_invariant_paren        = ignore   # ignore/add/remove/force
+sp_after_invariant_paren        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
-sp_special_semi                 = force    # ignore/add/remove/force
+sp_special_semi                 = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before ';'.
 #
 # Default: remove
-sp_before_semi                  = remove   # ignore/add/remove/force
+sp_before_semi                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before ';' in non-empty 'for' statements.
-sp_before_semi_for              = remove   # ignore/add/remove/force
+sp_before_semi_for              = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space before a semicolon of an empty part of a for statement.
-sp_before_semi_for_empty        = force    # ignore/add/remove/force
+# Add or remove space before a semicolon of an empty left part of a for
+# statement, as in 'for ( <here> ; ; )'.
+sp_before_semi_for_empty        = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space between the semicolons of an empty middle part of a for
+# statement, as in 'for ( ; <here> ; )'.
+sp_between_semi_for_empty       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ';', except when followed by a comment.
 #
 # Default: add
-sp_after_semi                   = add      # ignore/add/remove/force
+sp_after_semi                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space after ';' in non-empty 'for' statements.
 #
 # Default: force
-sp_after_semi_for               = force    # ignore/add/remove/force
+sp_after_semi_for               = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after the final semicolon of an empty part of a for
 # statement, as in 'for ( ; ; <here> )'.
-sp_after_semi_for_empty         = force    # ignore/add/remove/force
+sp_after_semi_for_empty         = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before '[' (except '[]').
-sp_before_square                = remove   # ignore/add/remove/force
+sp_before_square                = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space before '[' for a variable definition.
+#
+# Default: remove
+sp_before_vardef_square         = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space before '[' for asm block.
+sp_before_square_asm_block      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before '[]'.
-sp_before_squares               = remove   # ignore/add/remove/force
+sp_before_squares               = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before C++17 structured bindings.
-sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
+sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside a non-empty '[' and ']'.
-sp_inside_square                = remove   # ignore/add/remove/force
+sp_inside_square                = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside '[]'.
+sp_inside_square_empty          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
 # ']'. If set to ignore, sp_inside_square is used.
-sp_inside_square_oc_array       = ignore   # ignore/add/remove/force
+sp_inside_square_oc_array       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.
-sp_after_comma                  = force    # ignore/add/remove/force
+sp_after_comma                  = force    # ignore/add/remove/force/not_defined
 
-# Add or remove space before ','.
+# Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.
 #
 # Default: remove
-sp_before_comma                 = remove   # ignore/add/remove/force
+sp_before_comma                 = remove   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between ',' and ']' in multidimensional array type
+# (C#, Vala) Add or remove space between ',' and ']' in multidimensional array type
 # like 'int[,,]'.
-sp_after_mdatype_commas         = ignore   # ignore/add/remove/force
+sp_after_mdatype_commas         = ignore   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between '[' and ',' in multidimensional array type
+# (C#, Vala) Add or remove space between '[' and ',' in multidimensional array type
 # like 'int[,,]'.
-sp_before_mdatype_commas        = ignore   # ignore/add/remove/force
+sp_before_mdatype_commas        = ignore   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between ',' in multidimensional array type
+# (C#, Vala) Add or remove space between ',' in multidimensional array type
 # like 'int[,,]'.
-sp_between_mdatype_commas       = ignore   # ignore/add/remove/force
+sp_between_mdatype_commas       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between an open parenthesis and comma,
 # i.e. '(,' vs. '( ,'.
 #
 # Default: force
-sp_paren_comma                  = force    # ignore/add/remove/force
+sp_paren_comma                  = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space between a type and ':'.
+sp_type_colon                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the variadic '...' when preceded by a
+# non-punctuator.
+# The value REMOVE will be overridden with FORCE
+sp_after_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the variadic '...' when preceded by a
 # non-punctuator.
-sp_before_ellipsis              = remove   # ignore/add/remove/force
+# The value REMOVE will be overridden with FORCE
+sp_before_ellipsis              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a type and '...'.
-sp_type_ellipsis                = ignore   # ignore/add/remove/force
+sp_type_ellipsis                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a '*' and '...'.
+sp_ptr_type_ellipsis            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and '...'.
-sp_paren_ellipsis               = ignore   # ignore/add/remove/force
+sp_paren_ellipsis               = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '&&' and '...'.
+sp_byref_ellipsis               = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between ')' and a qualifier such as 'const'.
+sp_paren_qualifier              = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between ')' and 'noexcept'.
+sp_paren_noexcept               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after class ':'.
-sp_after_class_colon            = force    # ignore/add/remove/force
+sp_after_class_colon            = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before class ':'.
-sp_before_class_colon           = force    # ignore/add/remove/force
+sp_before_class_colon           = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after class constructor ':'.
-sp_after_constr_colon           = force    # ignore/add/remove/force
+#
+# Default: add
+sp_after_constr_colon           = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before class constructor ':'.
-sp_before_constr_colon          = force    # ignore/add/remove/force
+#
+# Default: add
+sp_before_constr_colon          = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before case ':'.
 #
 # Default: remove
-sp_before_case_colon            = remove   # ignore/add/remove/force
+sp_before_case_colon            = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'operator' and operator sign.
-sp_after_operator               = force    # ignore/add/remove/force
+sp_after_operator               = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between the operator symbol and the open parenthesis, as
 # in 'operator ++('.
-sp_after_operator_sym           = force    # ignore/add/remove/force
+sp_after_operator_sym           = force    # ignore/add/remove/force/not_defined
 
 # Overrides sp_after_operator_sym when the operator has no arguments, as in
 # 'operator *()'.
-sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force
+sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or
 # '(int)a' vs. '(int) a'.
-sp_after_cast                   = remove   # ignore/add/remove/force
+sp_after_cast                   = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove spaces inside cast parentheses.
-sp_inside_paren_cast            = remove   # ignore/add/remove/force
+sp_inside_paren_cast            = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between the type and open parenthesis in a C++ cast,
 # i.e. 'int(exp)' vs. 'int (exp)'.
-sp_cpp_cast_paren               = remove   # ignore/add/remove/force
+sp_cpp_cast_paren               = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'sizeof' and '('.
-sp_sizeof_paren                 = remove   # ignore/add/remove/force
+sp_sizeof_paren                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'sizeof' and '...'.
-sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force
+sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'sizeof...' and '('.
-sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force
+sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '...' and a parameter pack.
+sp_ellipsis_parameter_pack      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a parameter pack and '...'.
+sp_parameter_pack_ellipsis      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'decltype' and '('.
-sp_decltype_paren               = ignore   # ignore/add/remove/force
+sp_decltype_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # (Pawn) Add or remove space after the tag keyword.
-sp_after_tag                    = ignore   # ignore/add/remove/force
+sp_after_tag                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside enum '{' and '}'.
-sp_inside_braces_enum           = force    # ignore/add/remove/force
+sp_inside_braces_enum           = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space inside struct/union '{' and '}'.
-sp_inside_braces_struct         = force    # ignore/add/remove/force
+sp_inside_braces_struct         = force    # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'
-sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force
+sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after open brace in an unnamed temporary
-# direct-list-initialization.
-sp_after_type_brace_init_lst_open = ignore   # ignore/add/remove/force
+# direct-list-initialization
+# if statement is a brace_init_lst
+# works only if sp_brace_brace is set to ignore.
+sp_after_type_brace_init_lst_open = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before close brace in an unnamed temporary
-# direct-list-initialization.
-sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force
+# direct-list-initialization
+# if statement is a brace_init_lst
+# works only if sp_brace_brace is set to ignore.
+sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space inside an unnamed temporary direct-list-initialization.
-sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force
+# Add or remove space inside an unnamed temporary direct-list-initialization
+# if statement is a brace_init_lst
+# works only if sp_brace_brace is set to ignore
+# works only if sp_before_type_brace_init_lst_close is set to ignore.
+sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{' and '}'.
-sp_inside_braces                = force    # ignore/add/remove/force
+sp_inside_braces                = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{}'.
-sp_inside_braces_empty          = force    # ignore/add/remove/force
+sp_inside_braces_empty          = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space around trailing return operator '->'.
+sp_trailing_return              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between return type and function name. A minimum of 1
 # is forced except for pointer return types.
-sp_type_func                    = force    # ignore/add/remove/force
+sp_type_func                    = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between type and open brace of an unnamed temporary
 # direct-list-initialization.
-sp_type_brace_init_lst          = ignore   # ignore/add/remove/force
+sp_type_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' on function declaration.
-sp_func_proto_paren             = remove   # ignore/add/remove/force
+sp_func_proto_paren             = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function declaration
 # without parameters.
-sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
+sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space between function name and '(' on function definition.
-sp_func_def_paren               = remove   # ignore/add/remove/force
+# Add or remove space between function name and '(' with a typedef specifier.
+sp_func_type_paren              = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between alias name and '(' of a non-pointer function type typedef.
+sp_func_def_paren               = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function definition
 # without parameters.
-sp_func_def_paren_empty         = ignore   # ignore/add/remove/force
+sp_func_def_paren_empty         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside empty function '()'.
-sp_inside_fparens               = remove   # ignore/add/remove/force
+# Overrides sp_after_angle unless use_sp_after_angle_always is set to true.
+sp_inside_fparens               = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside function '(' and ')'.
-sp_inside_fparen                = remove   # ignore/add/remove/force
+sp_inside_fparen                = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.
-sp_inside_tparen                = remove   # ignore/add/remove/force
+sp_inside_tparen                = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between the ')' and '(' in a function type, as in
 # 'void (*x)(...)'.
-sp_after_tparen_close           = remove   # ignore/add/remove/force
+sp_after_tparen_close           = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ']' and '(' when part of a function call.
-sp_square_fparen                = remove   # ignore/add/remove/force
+sp_square_fparen                = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and '{' of function.
-sp_fparen_brace                 = force    # ignore/add/remove/force
+sp_fparen_brace                 = force    # ignore/add/remove/force/not_defined
 
-# Add or remove space between ')' and '{' of s function call in object
+# Add or remove space between ')' and '{' of a function call in object
 # initialization.
 #
 # Overrides sp_fparen_brace.
-sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force
+sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force/not_defined
 
 # (Java) Add or remove space between ')' and '{{' of double brace initializer.
-sp_fparen_dbrace                = ignore   # ignore/add/remove/force
+sp_fparen_dbrace                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' on function calls.
-sp_func_call_paren              = remove   # ignore/add/remove/force
+sp_func_call_paren              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function calls without
-# parameters. If set to 'ignore' (the default), sp_func_call_paren is used.
-sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
+# parameters. If set to ignore (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between the user function name and '(' on function
 # calls. You need to set a keyword to be a user function in the config file,
 # like:
 #   set func_call_user tr _ i18n
-sp_func_call_user_paren         = remove   # ignore/add/remove/force
+sp_func_call_user_paren         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside user function '(' and ')'.
-sp_func_call_user_inside_fparen = ignore   # ignore/add/remove/force
+sp_func_call_user_inside_fparen = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between nested parentheses with user functions,
 # i.e. '((' vs. '( ('.
-sp_func_call_user_paren_paren   = ignore   # ignore/add/remove/force
+sp_func_call_user_paren_paren   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a constructor/destructor and the open
 # parenthesis.
-sp_func_class_paren             = remove   # ignore/add/remove/force
+sp_func_class_paren             = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a constructor without parameters or destructor
 # and '()'.
-sp_func_class_paren_empty       = ignore   # ignore/add/remove/force
+sp_func_class_paren_empty       = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after 'return'.
+#
+# Default: force
+sp_return                       = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'return' and '('.
-sp_return_paren                 = force    # ignore/add/remove/force
+sp_return_paren                 = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'return' and '{'.
-sp_return_brace                 = ignore   # ignore/add/remove/force
+sp_return_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '__attribute__' and '('.
-sp_attribute_paren              = force    # ignore/add/remove/force
+sp_attribute_paren              = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'defined' and '(' in '#if defined (FOO)'.
-sp_defined_paren                = remove   # ignore/add/remove/force
+sp_defined_paren                = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'throw' and '(' in 'throw (something)'.
-sp_throw_paren                  = force    # ignore/add/remove/force
+sp_throw_paren                  = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'throw' and anything other than '(' as in
 # '@throw [...];'.
-sp_after_throw                  = add      # ignore/add/remove/force
+sp_after_throw                  = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'catch' and '(' in 'catch (something) { }'.
 # If set to ignore, sp_before_sparen is used.
-sp_catch_paren                  = force    # ignore/add/remove/force
+sp_catch_paren                  = force    # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@catch' and '('
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
-sp_oc_catch_paren               = ignore   # ignore/add/remove/force
+sp_oc_catch_paren               = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space between class name and '('
+# in '@interface className(categoryName)<ProtocolName>:BaseClass'
+sp_oc_classname_paren           = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space between 'version' and '('
 # in 'version (something) { }'. If set to ignore, sp_before_sparen is used.
-sp_version_paren                = ignore   # ignore/add/remove/force
+sp_version_paren                = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space between 'scope' and '('
 # in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.
-sp_scope_paren                  = ignore   # ignore/add/remove/force
+sp_scope_paren                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'super' and '(' in 'super (something)'.
 #
 # Default: remove
-sp_super_paren                  = remove   # ignore/add/remove/force
+sp_super_paren                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'this' and '(' in 'this (something)'.
 #
 # Default: remove
-sp_this_paren                   = remove   # ignore/add/remove/force
+sp_this_paren                   = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a macro name and its definition.
-sp_macro                        = ignore   # ignore/add/remove/force
+sp_macro                        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a macro function ')' and its definition.
-sp_macro_func                   = ignore   # ignore/add/remove/force
+sp_macro_func                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'else' and '{' if on the same line.
-sp_else_brace                   = force    # ignore/add/remove/force
+sp_else_brace                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'else' if on the same line.
-sp_brace_else                   = force    # ignore/add/remove/force
+sp_brace_else                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and the name of a typedef on the same line.
-sp_brace_typedef                = force    # ignore/add/remove/force
+sp_brace_typedef                = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '{' of a 'catch' statement, if the '{' and
 # 'catch' are on the same line, as in 'catch (decl) <here> {'.
-sp_catch_brace                  = force    # ignore/add/remove/force
+sp_catch_brace                  = force    # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the '{' of a '@catch' statement, if the '{'
 # and '@catch' are on the same line, as in '@catch (decl) <here> {'.
 # If set to ignore, sp_catch_brace is used.
-sp_oc_catch_brace               = ignore   # ignore/add/remove/force
+sp_oc_catch_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'catch' if on the same line.
-sp_brace_catch                  = force    # ignore/add/remove/force
+sp_brace_catch                  = force    # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '}' and '@catch' if on the same line.
 # If set to ignore, sp_brace_catch is used.
-sp_oc_brace_catch               = ignore   # ignore/add/remove/force
+sp_oc_brace_catch               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'finally' and '{' if on the same line.
-sp_finally_brace                = force    # ignore/add/remove/force
+sp_finally_brace                = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'finally' if on the same line.
-sp_brace_finally                = force    # ignore/add/remove/force
+sp_brace_finally                = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'try' and '{' if on the same line.
-sp_try_brace                    = force    # ignore/add/remove/force
+sp_try_brace                    = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between get/set and '{' if on the same line.
-sp_getset_brace                 = add      # ignore/add/remove/force
+sp_getset_brace                 = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space between a variable and '{' for C++ uniform
 # initialization.
-#
-# Default: add
-sp_word_brace                   = add      # ignore/add/remove/force
+sp_word_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a variable and '{' for a namespace.
 #
 # Default: add
-sp_word_brace_ns                = add      # ignore/add/remove/force
+sp_word_brace_ns                = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '::' operator.
-sp_before_dc                    = remove   # ignore/add/remove/force
+sp_before_dc                    = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '::' operator.
-sp_after_dc                     = remove   # ignore/add/remove/force
+sp_after_dc                     = remove   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove around the D named array initializer ':' operator.
-sp_d_array_colon                = ignore   # ignore/add/remove/force
+sp_d_array_colon                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '!' (not) unary operator.
 #
 # Default: remove
-sp_not                          = remove   # ignore/add/remove/force
+sp_not                          = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space between two '!' (not) unary operators.
+# If set to ignore, sp_not will be used.
+sp_not_not                      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '~' (invert) unary operator.
 #
 # Default: remove
-sp_inv                          = remove   # ignore/add/remove/force
+sp_inv                          = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '&' (address-of) unary operator. This does not
 # affect the spacing after a '&' that is part of a type.
 #
 # Default: remove
-sp_addr                         = remove   # ignore/add/remove/force
+sp_addr                         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space around the '.' or '->' operators.
 #
 # Default: remove
-sp_member                       = remove   # ignore/add/remove/force
+sp_member                       = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '*' (dereference) unary operator. This does
 # not affect the spacing after a '*' that is part of a type.
 #
 # Default: remove
-sp_deref                        = remove   # ignore/add/remove/force
+sp_deref                        = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.
 #
 # Default: remove
-sp_sign                         = remove   # ignore/add/remove/force
+sp_sign                         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '++' and '--' the word to which it is being
 # applied, as in '(--x)' or 'y++;'.
 #
 # Default: remove
-sp_incdec                       = remove   # ignore/add/remove/force
+sp_incdec                       = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a backslash-newline at the end of a line.
 #
 # Default: add
-sp_before_nl_cont               = force    # ignore/add/remove/force
+sp_before_nl_cont               = force    # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'
 # or '+(int) bar;'.
-sp_after_oc_scope               = add      # ignore/add/remove/force
+sp_after_oc_scope               = add      # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the colon in message specs,
 # i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.
-sp_after_oc_colon               = add      # ignore/add/remove/force
+sp_after_oc_colon               = add      # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the colon in message specs,
 # i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.
-sp_before_oc_colon              = ignore   # ignore/add/remove/force
+sp_before_oc_colon              = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'.
-sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force
+sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'.
-sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force
+sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the colon in message specs,
 # i.e. '[object setValue:1];' vs. '[object setValue: 1];'.
-sp_after_send_oc_colon          = ignore   # ignore/add/remove/force
+sp_after_send_oc_colon          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the colon in message specs,
 # i.e. '[object setValue:1];' vs. '[object setValue :1];'.
-sp_before_send_oc_colon         = ignore   # ignore/add/remove/force
+sp_before_send_oc_colon         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the (type) in message specs,
 # i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.
-sp_after_oc_type                = ignore   # ignore/add/remove/force
+sp_after_oc_type                = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the first (type) in message specs,
 # i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.
-sp_after_oc_return_type         = remove   # ignore/add/remove/force
+sp_after_oc_return_type         = remove   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@selector' and '(',
 # i.e. '@selector(msgName)' vs. '@selector (msgName)'.
 # Also applies to '@protocol()' constructs.
-sp_after_oc_at_sel              = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel              = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@selector(x)' and the following word,
 # i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.
-sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space inside '@selector' parentheses,
 # i.e. '@selector(foo)' vs. '@selector( foo )'.
 # Also applies to '@protocol()' constructs.
-sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force
+sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before a block pointer caret,
 # i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.
-sp_before_oc_block_caret        = ignore   # ignore/add/remove/force
+sp_before_oc_block_caret        = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after a block pointer caret,
 # i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.
-sp_after_oc_block_caret         = ignore   # ignore/add/remove/force
+sp_after_oc_block_caret         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between the receiver and selector in a message,
 # as in '[receiver selector ...]'.
-sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force
+sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after '@property'.
-sp_after_oc_property            = ignore   # ignore/add/remove/force
+sp_after_oc_property            = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@synchronized' and the open parenthesis,
 # i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.
-sp_after_oc_synchronized        = ignore   # ignore/add/remove/force
+sp_after_oc_synchronized        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around the ':' in 'b ? t : f'.
-sp_cond_colon                   = force    # ignore/add/remove/force
+sp_cond_colon                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before the ':' in 'b ? t : f'.
 #
 # Overrides sp_cond_colon.
-sp_cond_colon_before            = force    # ignore/add/remove/force
+sp_cond_colon_before            = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after the ':' in 'b ? t : f'.
 #
 # Overrides sp_cond_colon.
-sp_cond_colon_after             = force    # ignore/add/remove/force
+sp_cond_colon_after             = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around the '?' in 'b ? t : f'.
-sp_cond_question                = force    # ignore/add/remove/force
+sp_cond_question                = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '?' in 'b ? t : f'.
 #
 # Overrides sp_cond_question.
-sp_cond_question_before         = ignore   # ignore/add/remove/force
+sp_cond_question_before         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '?' in 'b ? t : f'.
 #
 # Overrides sp_cond_question.
-sp_cond_question_after          = ignore   # ignore/add/remove/force
+sp_cond_question_after          = ignore   # ignore/add/remove/force/not_defined
 
 # In the abbreviated ternary form '(a ?: b)', add or remove space between '?'
 # and ':'.
 #
 # Overrides all other sp_cond_* options.
-sp_cond_ternary_short           = ignore   # ignore/add/remove/force
+sp_cond_ternary_short           = ignore   # ignore/add/remove/force/not_defined
 
 # Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make
 # sense here.
-sp_case_label                   = force    # ignore/add/remove/force
+sp_case_label                   = force    # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space around the D '..' operator.
-sp_range                        = ignore   # ignore/add/remove/force
+sp_range                        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
-sp_after_for_colon              = add      # ignore/add/remove/force
+# as in 'for (Type var : <here> expr)'.
+sp_after_for_colon              = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space before ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
-sp_before_for_colon             = add      # ignore/add/remove/force
+# as in 'for (Type var <here> : expr)'.
+sp_before_for_colon             = add      # ignore/add/remove/force/not_defined
 
-# (D) Add or remove space between 'extern' and '(' as in 'extern (C)'.
-sp_extern_paren                 = ignore   # ignore/add/remove/force
+# (D) Add or remove space between 'extern' and '(' as in 'extern <here> (C)'.
+sp_extern_paren                 = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space after the opening of a C++ comment,
-# i.e. '// A' vs. '//A'.
-sp_cmt_cpp_start                = add      # ignore/add/remove/force
+# Add or remove space after the opening of a C++ comment, as in '// <here> A'.
+sp_cmt_cpp_start                = add      # ignore/add/remove/force/not_defined
 
-# If true, space is added with sp_cmt_cpp_start will be added after doxygen
+# Add or remove space in a C++ region marker comment, as in '// <here> BEGIN'.
+# A region marker is defined as a comment which is not preceded by other text
+# (i.e. the comment is the first non-whitespace on the line), and which starts
+# with either 'BEGIN' or 'END'.
+#
+# Overrides sp_cmt_cpp_start.
+sp_cmt_cpp_region               = ignore   # ignore/add/remove/force/not_defined
+
+# If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = true     # true/false
 
-# If true, space is added with sp_cmt_cpp_start will be added after Qt
-# translator or meta-data comments like '//:', '//=', and '//~'.
+# If true, space added with sp_cmt_cpp_start will be added after Qt translator
+# or meta-data comments like '//:', '//=', and '//~'.
 sp_cmt_cpp_qttr                 = false    # true/false
 
 # Add or remove space between #else or #endif and a trailing comment.
-sp_endif_cmt                    = ignore   # ignore/add/remove/force
+sp_endif_cmt                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after 'new', 'delete' and 'delete[]'.
-sp_after_new                    = add      # ignore/add/remove/force
+sp_after_new                    = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'new' and '(' in 'new()'.
-sp_between_new_paren            = force    # ignore/add/remove/force
+sp_between_new_paren            = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and type in 'new(foo) BAR'.
-sp_after_newop_paren            = ignore   # ignore/add/remove/force
+sp_after_newop_paren            = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space inside parenthesis of the new operator
+# Add or remove space inside parentheses of the new operator
 # as in 'new(foo) BAR'.
-sp_inside_newop_paren           = ignore   # ignore/add/remove/force
+sp_inside_newop_paren           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the open parenthesis of the new operator,
 # as in 'new(foo) BAR'.
 #
 # Overrides sp_inside_newop_paren.
-sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
+sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the close parenthesis of the new operator,
 # as in 'new(foo) BAR'.
 #
 # Overrides sp_inside_newop_paren.
-sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
+sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before a trailing or embedded comment.
-sp_before_tr_emb_cmt            = ignore   # ignore/add/remove/force
+# Add or remove space before a trailing comment.
+sp_before_tr_cmt                = ignore   # ignore/add/remove/force/not_defined
 
-# Number of spaces before a trailing or embedded comment.
-sp_num_before_tr_emb_cmt        = 0        # unsigned number
+# Number of spaces before a trailing comment.
+sp_num_before_tr_cmt            = 0        # unsigned number
+
+# Add or remove space before an embedded comment.
+#
+# Default: force
+sp_before_emb_cmt               = force    # ignore/add/remove/force/not_defined
+
+# Number of spaces before an embedded comment.
+#
+# Default: 1
+sp_num_before_emb_cmt           = 1        # unsigned number
+
+# Add or remove space after an embedded comment.
+#
+# Default: force
+sp_after_emb_cmt                = force    # ignore/add/remove/force/not_defined
+
+# Number of spaces after an embedded comment.
+#
+# Default: 1
+sp_num_after_emb_cmt            = 1        # unsigned number
 
 # (Java) Add or remove space between an annotation and the open parenthesis.
-sp_annotation_paren             = ignore   # ignore/add/remove/force
+sp_annotation_paren             = ignore   # ignore/add/remove/force/not_defined
 
 # If true, vbrace tokens are dropped to the previous token and skipped.
 sp_skip_vbrace_tokens           = false    # true/false
 
 # Add or remove space after 'noexcept'.
-sp_after_noexcept               = ignore   # ignore/add/remove/force
+sp_after_noexcept               = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after '_'.
+sp_vala_after_translation       = ignore   # ignore/add/remove/force/not_defined
 
 # If true, a <TAB> is inserted after #define.
 force_tab_after_define          = false    # true/false
@@ -855,15 +1061,21 @@ force_tab_after_define          = false    # true/false
 # Default: 8
 indent_columns                  = 4        # unsigned number
 
-# The continuation indent. If non-zero, this overrides the indent of '(' and
-# '=' continuation indents. Negative values are OK; negative value is absolute
-# and not increased for each '(' level.
+# Whether to ignore indent for the first continuation line. Subsequent
+# continuation lines will still be indented to match the first.
+indent_ignore_first_continue    = false    # true/false
+
+# The continuation indent. If non-zero, this overrides the indent of '(', '['
+# and '=' continuation indents. Negative values are OK; negative value is
+# absolute and not increased for each '(' or '[' level.
 #
 # For FreeBSD, this is set to 4.
+# Requires indent_ignore_first_continue=false.
 indent_continue                 = 0        # number
 
 # The continuation indent, only for class header line(s). If non-zero, this
 # overrides the indent of 'class' continuation indents.
+# Requires indent_ignore_first_continue=false.
 indent_continue_class_head      = 0        # unsigned number
 
 # Whether to indent empty lines (i.e. lines which contain only spaces before
@@ -910,7 +1122,7 @@ indent_braces_no_class          = false    # true/false
 indent_braces_no_struct         = false    # true/false
 
 # Whether to indent based on the size of the brace parent,
-# i.e. 'if' → 3 spaces, 'for' → 4 spaces, etc.
+# i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
 indent_brace_parent             = false    # true/false
 
 # Whether to indent based on the open parenthesis instead of the open brace
@@ -932,17 +1144,31 @@ indent_namespace                = false    # true/false
 indent_namespace_single_indent  = false    # true/false
 
 # The number of spaces to indent a namespace block.
+# If set to zero, use the value indent_columns
 indent_namespace_level          = 0        # unsigned number
 
 # If the body of the namespace is longer than this number, it won't be
 # indented. Requires indent_namespace=true. 0 means no limit.
 indent_namespace_limit          = 0        # unsigned number
 
+# Whether to indent only in inner namespaces (nested in other namespaces).
+# Requires indent_namespace=true.
+indent_namespace_inner_only     = false    # true/false
+
 # Whether the 'extern "C"' body is indented.
 indent_extern                   = false    # true/false
 
 # Whether the 'class' body is indented.
 indent_class                    = true     # true/false
+
+# Whether to ignore indent for the leading base class colon.
+indent_ignore_before_class_colon = false    # true/false
+
+# Additional indent before the leading base class colon.
+# Negative values decrease indent down to the first column.
+# Requires indent_ignore_before_class_colon=false and a newline break before
+# the colon (see pos_class_colon and nl_class_colon)
+indent_before_class_colon       = 0        # number
 
 # Whether to indent the stuff after a leading base class colon.
 indent_class_colon              = true     # true/false
@@ -951,13 +1177,21 @@ indent_class_colon              = true     # true/false
 # colon. Requires indent_class_colon=true.
 indent_class_on_colon           = false    # true/false
 
+# Whether to ignore indent for a leading class initializer colon.
+indent_ignore_before_constr_colon = false    # true/false
+
 # Whether to indent the stuff after a leading class initializer colon.
 indent_constr_colon             = true     # true/false
 
-# Virtual indent from the ':' for member initializers.
+# Virtual indent from the ':' for leading member initializers.
 #
 # Default: 2
 indent_ctor_init_leading        = 2        # unsigned number
+
+# Virtual indent from the ':' for following member initializers.
+#
+# Default: 2
+indent_ctor_init_following      = 2        # unsigned number
 
 # Additional indent for constructor initializer list.
 # Negative values decrease indent down to the first column.
@@ -969,16 +1203,19 @@ indent_else_if                  = false    # true/false
 
 # Amount to indent variable declarations after a open brace.
 #
-# <0: Relative
-# ≥0: Absolute
+#  <0: Relative
+# >=0: Absolute
 indent_var_def_blk              = 0        # number
 
 # Whether to indent continued variable declarations instead of aligning.
 indent_var_def_cont             = true     # true/false
 
-# Whether to indent continued shift expressions ('<<' and '>>') instead of
-# aligning. Set align_left_shift=false when enabling this.
-indent_shift                    = false    # true/false
+# How to indent continued shift expressions ('<<' and '>>').
+# Set align_left_shift=false when using this.
+#  0: Align shift operators instead of indenting them (default)
+#  1: Indent by one level
+# -1: Preserve original indentation
+indent_shift                    = 0        # number
 
 # Whether to force indentation of function definitions to start in column 1.
 indent_func_def_force_col1      = false    # true/false
@@ -987,19 +1224,30 @@ indent_func_def_force_col1      = false    # true/false
 # rather than aligning parameters under the open parenthesis.
 indent_func_call_param          = false    # true/false
 
-# Same as indent_func_call_param, but for function definitions.
+# Whether to indent continued function definition parameters one indent level,
+# rather than aligning parameters under the open parenthesis.
 indent_func_def_param           = false    # true/false
 
-# Same as indent_func_call_param, but for function prototypes.
+# for function definitions, only if indent_func_def_param is false
+# Allows to align params when appropriate and indent them when not
+# behave as if it was true if paren position is more than this value
+# if paren position is more than the option value
+indent_func_def_param_paren_pos_threshold = 0        # unsigned number
+
+# Whether to indent continued function call prototype one indent level,
+# rather than aligning parameters under the open parenthesis.
 indent_func_proto_param         = false    # true/false
 
-# Same as indent_func_call_param, but for class declarations.
+# Whether to indent continued function call declaration one indent level,
+# rather than aligning parameters under the open parenthesis.
 indent_func_class_param         = false    # true/false
 
-# Same as indent_func_call_param, but for class variable constructors.
+# Whether to indent continued class variable constructors one indent level,
+# rather than aligning parameters under the open parenthesis.
 indent_func_ctor_var_param      = false    # true/false
 
-# Same as indent_func_call_param, but for template parameter lists.
+# Whether to indent continued template parameter list one indent level,
+# rather than aligning parameters under the open parenthesis.
 indent_template_param           = false    # true/false
 
 # Double the indent for indent_func_xxx_param options.
@@ -1014,6 +1262,16 @@ indent_func_const               = 0        # unsigned number
 # prototype.
 indent_func_throw               = 0        # unsigned number
 
+# How to indent within a macro followed by a brace on the same line
+# This allows reducing the indent in macros that have (for example)
+# `do { ... } while (0)` blocks bracketing them.
+#
+# true:  add an indent for the brace on the same line as the macro
+# false: do not add an indent for the brace on the same line as the macro
+#
+# Default: true
+indent_macro_brace              = true     # true/false
+
 # The number of spaces to indent a continued '->' or '.'.
 # Usually set to 0, 1, or indent_columns.
 indent_member                   = 0        # unsigned number
@@ -1023,14 +1281,37 @@ indent_member                   = 0        # unsigned number
 indent_member_single            = false    # true/false
 
 # Spaces to indent single line ('//') comments on lines before code.
-indent_sing_line_comments       = 0        # unsigned number
+indent_single_line_comments_before = 0        # unsigned number
+
+# Spaces to indent single line ('//') comments on lines after code.
+indent_single_line_comments_after = 0        # unsigned number
+
+# When opening a paren for a control statement (if, for, while, etc), increase
+# the indent level by this value. Negative values decrease the indent level.
+indent_sparen_extra             = 0        # number
 
 # Whether to indent trailing single line ('//') comments relative to the code
 # instead of trying to keep the same absolute column.
 indent_relative_single_line_comments = false    # true/false
 
 # Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
+# It might be wise to choose the same value for the option indent_case_brace.
 indent_switch_case              = 0        # unsigned number
+
+# Spaces to indent the body of a 'switch' before any 'case'.
+# Usually the same as indent_columns or indent_switch_case.
+indent_switch_body              = 0        # unsigned number
+
+# Whether to ignore indent for '{' following 'case'.
+indent_ignore_case_brace        = false    # true/false
+
+# Spaces to indent '{' from 'case'. By default, the brace will appear under
+# the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
+# It might be wise to choose the same value for the option indent_switch_case.
+indent_case_brace               = 0        # number
+
+# indent 'break' with 'case' from 'switch'.
+indent_switch_break_with_case   = false    # true/false
 
 # Whether to indent preprocessor statements inside of switch statements.
 #
@@ -1041,23 +1322,43 @@ indent_switch_pp                = true     # true/false
 # Usually 0.
 indent_case_shift               = 0        # unsigned number
 
-# Spaces to indent '{' from 'case'. By default, the brace will appear under
-# the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
-indent_case_brace               = 0        # number
+# Whether to align comments before 'case' with the 'case'.
+#
+# Default: true
+indent_case_comment             = true     # true/false
+
+# Whether to indent comments not found in first column.
+#
+# Default: true
+indent_comment                  = true     # true/false
 
 # Whether to indent comments found in first column.
 indent_col1_comment             = false    # true/false
 
-# How to indent goto labels.
+# Whether to indent multi string literal in first column.
+indent_col1_multi_string_literal = false    # true/false
+
+# Align comments on adjacent lines that are this many columns apart or less.
 #
-# >0: Absolute column where 1 is the leftmost column
-# ≤0: Subtract from brace indent
+# Default: 3
+indent_comment_align_thresh     = 3        # unsigned number
+
+# Whether to ignore indent for goto labels.
+indent_ignore_label             = false    # true/false
+
+# How to indent goto labels. Requires indent_ignore_label=false.
+#
+#  >0: Absolute column where 1 is the leftmost column
+# <=0: Subtract from brace indent
 #
 # Default: 1
 indent_label                    = 1        # number
 
-# Same as indent_label, but for access specifiers that are followed by a
+# How to indent access specifiers that are followed by a
 # colon.
+#
+#  >0: Absolute column where 1 is the leftmost column
+# <=0: Subtract from brace indent
 #
 # Default: 1
 indent_access_spec              = -4       # number
@@ -1072,10 +1373,11 @@ indent_paren_nl                 = false    # true/false
 
 # How to indent a close parenthesis after a newline.
 #
-# 0: Indent to body level (default)
-# 1: Align under the open parenthesis
-# 2: Indent to the brace level
-indent_paren_close              = 0        # unsigned number
+#  0: Indent to body level (default)
+#  1: Align under the open parenthesis
+#  2: Indent to the brace level
+# -1: Preserve original indentation
+indent_paren_close              = 0        # number
 
 # Whether to indent the open parenthesis of a function definition,
 # if the parenthesis is on its own line.
@@ -1089,20 +1391,41 @@ indent_paren_after_func_decl    = false    # true/false
 # if the parenthesis is on its own line.
 indent_paren_after_func_call    = false    # true/false
 
-# Whether to indent a comma when inside a parenthesis.
-# If true, aligns under the open parenthesis.
-indent_comma_paren              = false    # true/false
+# How to indent a comma when inside braces.
+#  0: Indent by one level (default)
+#  1: Align under the open brace
+# -1: Preserve original indentation
+indent_comma_brace              = 0        # number
 
-# Whether to indent a Boolean operator when inside a parenthesis.
-# If true, aligns under the open parenthesis.
-indent_bool_paren               = false    # true/false
+# How to indent a comma when inside parentheses.
+#  0: Indent by one level (default)
+#  1: Align under the open parenthesis
+# -1: Preserve original indentation
+indent_comma_paren              = 0        # number
+
+# How to indent a Boolean operator when inside parentheses.
+#  0: Indent by one level (default)
+#  1: Align under the open parenthesis
+# -1: Preserve original indentation
+indent_bool_paren               = 0        # number
+
+# Whether to ignore the indentation of a Boolean operator when outside
+# parentheses.
+indent_ignore_bool              = false    # true/false
+
+# Whether to ignore the indentation of an arithmetic operator.
+indent_ignore_arith             = false    # true/false
 
 # Whether to indent a semicolon when inside a for parenthesis.
 # If true, aligns under the open for parenthesis.
 indent_semicolon_for_paren      = false    # true/false
 
+# Whether to ignore the indentation of a semicolon outside of a 'for'
+# statement.
+indent_ignore_semicolon         = false    # true/false
+
 # Whether to align the first expression to following ones
-# if indent_bool_paren=true.
+# if indent_bool_paren=1.
 indent_first_bool_expr          = false    # true/false
 
 # Whether to align the first expression to following ones
@@ -1116,17 +1439,27 @@ indent_square_nl                = false    # true/false
 # (ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.
 indent_preserve_sql             = false    # true/false
 
+# Whether to ignore the indentation of an assignment operator.
+indent_ignore_assign            = false    # true/false
+
 # Whether to align continued statements at the '='. If false or if the '=' is
 # followed by a newline, the next line is indent one tab.
 #
 # Default: true
 indent_align_assign             = true     # true/false
 
-# Whether to align continued statements at the '('. If false or the '(' is not
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
+# Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #
 # Default: true
 indent_align_paren              = true     # true/false
+
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
 
 # (OC) Whether to indent Objective-C blocks at brace level instead of usual
 # rules.
@@ -1174,7 +1507,7 @@ indent_oc_block_msg_from_brace  = false    # true/false
 indent_min_vbrace_open          = 0        # unsigned number
 
 # Whether to add further spaces after regular indent to reach next tabstop
-# when identing after virtual brace open and newline.
+# when indenting after virtual brace open and newline.
 indent_vbrace_open_on_tabstop   = false    # true/false
 
 # How to indent after a brace followed by another token (not a newline).
@@ -1187,6 +1520,15 @@ indent_token_after_brace        = true     # true/false
 # Whether to indent the body of a C++11 lambda.
 indent_cpp_lambda_body          = false    # true/false
 
+# How to indent compound literals that are being returned.
+# true: add both the indent from return & the compound literal open brace
+#       (i.e. 2 indent levels)
+# false: only indent 1 level, don't add the indent for the open brace, only
+#        add the indent for the return.
+#
+# Default: true
+indent_compound_literal_return  = true     # true/false
+
 # (C#) Whether to indent a 'using' block if no braces are used.
 #
 # Default: true
@@ -1195,9 +1537,15 @@ indent_using_block              = true     # true/false
 # How to indent the continuation of ternary operator.
 #
 # 0: Off (default)
-# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
+
+# Whether to indent the statements inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
 
 # If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 indent_off_after_return_new     = false    # true/false
@@ -1209,12 +1557,22 @@ indent_single_after_return      = false    # true/false
 # have their own indentation).
 indent_ignore_asm_block         = false    # true/false
 
+# Don't indent the close parenthesis of a function definition,
+# if the parenthesis is on its own line.
+donot_indent_func_def_close_paren = false    # true/false
+
 #
 # Newline adding and removing options
 #
 
-# Whether to collapse empty blocks between '{' and '}'.
+# Whether to collapse empty blocks between '{' and '}' except for functions.
+# Use nl_collapse_empty_body_functions to specify how empty function braces
+# should be formatted.
 nl_collapse_empty_body          = true     # true/false
+
+# Whether to collapse empty blocks between '{' and '}' for functions only.
+# If true, overrides nl_inside_empty_func.
+nl_collapse_empty_body_functions = false    # true/false
 
 # Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.
 nl_assign_leave_one_liners      = true     # true/false
@@ -1232,6 +1590,7 @@ nl_getset_leave_one_liners      = true     # true/false
 nl_cs_property_leave_one_liners = false    # true/false
 
 # Don't split one-line function definitions, as in 'int foo() { return 0; }'.
+# might modify nl_func_type_name
 nl_func_leave_one_liners        = false    # true/false
 
 # Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.
@@ -1243,6 +1602,9 @@ nl_if_leave_one_liners          = false    # true/false
 # Don't split one-line while statements, as in 'while(...) b++;'.
 nl_while_leave_one_liners       = false    # true/false
 
+# Don't split one-line do statements, as in 'do { b++; } while(...);'.
+nl_do_leave_one_liners          = false    # true/false
+
 # Don't split one-line for statements, as in 'for(...) b++;'.
 nl_for_leave_one_liners         = false    # true/false
 
@@ -1250,195 +1612,166 @@ nl_for_leave_one_liners         = false    # true/false
 nl_oc_msg_leave_one_liner       = false    # true/false
 
 # (OC) Add or remove newline between method declaration and '{'.
-nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between Objective-C block signature and '{'.
-nl_oc_block_brace               = ignore   # ignore/add/remove/force
+nl_oc_block_brace               = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove blank line before '@interface' statement.
+nl_oc_before_interface          = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove blank line before '@implementation' statement.
+nl_oc_before_implementation     = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove blank line before '@end' statement.
+nl_oc_before_end                = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between '@interface' and '{'.
-nl_oc_interface_brace           = ignore   # ignore/add/remove/force
+nl_oc_interface_brace           = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between '@implementation' and '{'.
-nl_oc_implementation_brace      = ignore   # ignore/add/remove/force
+nl_oc_implementation_brace      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newlines at the start of the file.
-nl_start_of_file                = remove   # ignore/add/remove/force
+nl_start_of_file                = remove   # ignore/add/remove/force/not_defined
 
 # The minimum number of newlines at the start of the file (only used if
 # nl_start_of_file is 'add' or 'force').
 nl_start_of_file_min            = 0        # unsigned number
 
 # Add or remove newline at the end of the file.
-nl_end_of_file                  = force    # ignore/add/remove/force
+nl_end_of_file                  = force    # ignore/add/remove/force/not_defined
 
 # The minimum number of newlines at the end of the file (only used if
 # nl_end_of_file is 'add' or 'force').
 nl_end_of_file_min              = 1        # unsigned number
 
 # Add or remove newline between '=' and '{'.
-nl_assign_brace                 = ignore   # ignore/add/remove/force
+nl_assign_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between '=' and '['.
-nl_assign_square                = ignore   # ignore/add/remove/force
+nl_assign_square                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '[]' and '{'.
-nl_tsquare_brace                = ignore   # ignore/add/remove/force
+nl_tsquare_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline after '= ['. Will also affect the newline before
 # the ']'.
-nl_after_square_assign          = ignore   # ignore/add/remove/force
-
-# The number of blank lines after a block of variable definitions at the top
-# of a function body.
-#
-# 0 = No change (default).
-nl_func_var_def_blk             = 0        # unsigned number
-
-# The number of newlines before a block of typedefs. If nl_after_access_spec
-# is non-zero, that option takes precedence.
-#
-# 0 = No change (default).
-nl_typedef_blk_start            = 0        # unsigned number
-
-# The number of newlines after a block of typedefs.
-#
-# 0 = No change (default).
-nl_typedef_blk_end              = 0        # unsigned number
-
-# The maximum number of consecutive newlines within a block of typedefs.
-#
-# 0 = No change (default).
-nl_typedef_blk_in               = 0        # unsigned number
-
-# The number of newlines before a block of variable definitions not at the top
-# of a function body. If nl_after_access_spec is non-zero, that option takes
-# precedence.
-#
-# 0 = No change (default).
-nl_var_def_blk_start            = 0        # unsigned number
-
-# The number of newlines after a block of variable definitions not at the top
-# of a function body.
-#
-# 0 = No change (default).
-nl_var_def_blk_end              = 0        # unsigned number
-
-# The maximum number of consecutive newlines within a block of variable
-# definitions.
-#
-# 0 = No change (default).
-nl_var_def_blk_in               = 0        # unsigned number
+nl_after_square_assign          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function call's ')' and '{', as in
 # 'list_for_each(item, &list) { }'.
-nl_fcall_brace                  = ignore   # ignore/add/remove/force
+nl_fcall_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum' and '{'.
-nl_enum_brace                   = remove   # ignore/add/remove/force
+nl_enum_brace                   = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum' and 'class'.
-nl_enum_class                   = ignore   # ignore/add/remove/force
+nl_enum_class                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum class' and the identifier.
-nl_enum_class_identifier        = ignore   # ignore/add/remove/force
+nl_enum_class_identifier        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum class' type and ':'.
-nl_enum_identifier_colon        = ignore   # ignore/add/remove/force
+nl_enum_identifier_colon        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum class identifier :' and type.
-nl_enum_colon_type              = ignore   # ignore/add/remove/force
+nl_enum_colon_type              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'struct and '{'.
-nl_struct_brace                 = remove   # ignore/add/remove/force
+nl_struct_brace                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'union' and '{'.
-nl_union_brace                  = remove   # ignore/add/remove/force
+nl_union_brace                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'if' and '{'.
-nl_if_brace                     = ignore   # ignore/add/remove/force
+nl_if_brace                     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'else'.
-nl_brace_else                   = force    # ignore/add/remove/force
+nl_brace_else                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'else if' and '{'. If set to ignore,
 # nl_if_brace is used instead.
-nl_elseif_brace                 = ignore   # ignore/add/remove/force
+nl_elseif_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'else' and '{'.
-nl_else_brace                   = ignore   # ignore/add/remove/force
+nl_else_brace                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'else' and 'if'.
-nl_else_if                      = remove   # ignore/add/remove/force
+nl_else_if                      = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove newline before '{' opening brace
+nl_before_opening_brace_func_class_def = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before 'if'/'else if' closing parenthesis.
-nl_before_if_closing_paren      = ignore   # ignore/add/remove/force
+nl_before_if_closing_paren      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'finally'.
-nl_brace_finally                = ignore   # ignore/add/remove/force
+nl_brace_finally                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'finally' and '{'.
-nl_finally_brace                = ignore   # ignore/add/remove/force
+nl_finally_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'try' and '{'.
-nl_try_brace                    = ignore   # ignore/add/remove/force
+nl_try_brace                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between get/set and '{'.
-nl_getset_brace                 = ignore   # ignore/add/remove/force
+nl_getset_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'for' and '{'.
-nl_for_brace                    = ignore   # ignore/add/remove/force
+nl_for_brace                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before the '{' of a 'catch' statement, as in
 # 'catch (decl) <here> {'.
-nl_catch_brace                  = ignore   # ignore/add/remove/force
+nl_catch_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline before the '{' of a '@catch' statement, as in
 # '@catch (decl) <here> {'. If set to ignore, nl_catch_brace is used.
-nl_oc_catch_brace               = ignore   # ignore/add/remove/force
+nl_oc_catch_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'catch'.
-nl_brace_catch                  = ignore   # ignore/add/remove/force
+nl_brace_catch                  = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between '}' and '@catch'. If set to ignore,
 # nl_brace_catch is used.
-nl_oc_brace_catch               = ignore   # ignore/add/remove/force
+nl_oc_brace_catch               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and ']'.
-nl_brace_square                 = ignore   # ignore/add/remove/force
+nl_brace_square                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and ')' in a function invocation.
-nl_brace_fparen                 = ignore   # ignore/add/remove/force
+nl_brace_fparen                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'while' and '{'.
-nl_while_brace                  = ignore   # ignore/add/remove/force
+nl_while_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between 'scope (x)' and '{'.
-nl_scope_brace                  = ignore   # ignore/add/remove/force
+nl_scope_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between 'unittest' and '{'.
-nl_unittest_brace               = ignore   # ignore/add/remove/force
+nl_unittest_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between 'version (x)' and '{'.
-nl_version_brace                = ignore   # ignore/add/remove/force
+nl_version_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # (C#) Add or remove newline between 'using' and '{'.
-nl_using_brace                  = ignore   # ignore/add/remove/force
+nl_using_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between two open or close braces. Due to general
 # newline/brace handling, REMOVE may not work.
-nl_brace_brace                  = force    # ignore/add/remove/force
+nl_brace_brace                  = force    # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'do' and '{'.
-nl_do_brace                     = ignore   # ignore/add/remove/force
+nl_do_brace                     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'while' of 'do' statement.
-nl_brace_while                  = ignore   # ignore/add/remove/force
+nl_brace_while                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'switch' and '{'.
-nl_switch_brace                 = ignore   # ignore/add/remove/force
+nl_switch_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'synchronized' and '{'.
-nl_synchronized_brace           = ignore   # ignore/add/remove/force
+nl_synchronized_brace           = ignore   # ignore/add/remove/force/not_defined
 
 # Add a newline between ')' and '{' if the ')' is on a different line than the
 # if/for/etc.
@@ -1446,6 +1779,14 @@ nl_synchronized_brace           = ignore   # ignore/add/remove/force
 # Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and
 # nl_catch_brace.
 nl_multi_line_cond              = false    # true/false
+
+# Add a newline after '(' if an if/for/while/switch condition spans multiple
+# lines
+nl_multi_line_sparen_open       = ignore   # ignore/add/remove/force/not_defined
+
+# Add a newline before ')' if an if/for/while/switch condition spans multiple
+# lines. Overrides nl_before_if_closing_paren if both are specified.
+nl_multi_line_sparen_close      = ignore   # ignore/add/remove/force/not_defined
 
 # Force a newline in a define after the macro name for multi-line defines.
 nl_multi_line_define            = false    # true/false
@@ -1460,86 +1801,141 @@ nl_after_case                   = false    # true/false
 # Add or remove newline between a case ':' and '{'.
 #
 # Overrides nl_after_case.
-nl_case_colon_brace             = ignore   # ignore/add/remove/force
+nl_case_colon_brace             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between ')' and 'throw'.
-nl_before_throw                 = ignore   # ignore/add/remove/force
+nl_before_throw                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'namespace' and '{'.
-nl_namespace_brace              = remove   # ignore/add/remove/force
+nl_namespace_brace              = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove newline between 'template<>' and whatever follows.
-nl_template_class               = add      # ignore/add/remove/force
+# Add or remove newline after 'template<...>' of a template class.
+nl_template_class               = add      # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<...>' of a template class declaration.
+#
+# Overrides nl_template_class.
+nl_template_class_decl          = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<>' of a specialized class declaration.
+#
+# Overrides nl_template_class_decl.
+nl_template_class_decl_special  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<...>' of a template class definition.
+#
+# Overrides nl_template_class.
+nl_template_class_def           = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<>' of a specialized class definition.
+#
+# Overrides nl_template_class_def.
+nl_template_class_def_special   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<...>' of a template function.
+nl_template_func                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<...>' of a template function
+# declaration.
+#
+# Overrides nl_template_func.
+nl_template_func_decl           = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<>' of a specialized function
+# declaration.
+#
+# Overrides nl_template_func_decl.
+nl_template_func_decl_special   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<...>' of a template function
+# definition.
+#
+# Overrides nl_template_func.
+nl_template_func_def            = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<>' of a specialized function
+# definition.
+#
+# Overrides nl_template_func_def.
+nl_template_func_def_special    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after 'template<...>' of a template variable.
+nl_template_var                 = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline between 'template<...>' and 'using' of a templated
+# type alias.
+nl_template_using               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'class' and '{'.
-nl_class_brace                  = force    # ignore/add/remove/force
+nl_class_brace                  = force    # ignore/add/remove/force/not_defined
 
-# Add or remove newline before or after (depending on pos_class_comma) each
-# ',' in the base class list.
-nl_class_init_args              = ignore   # ignore/add/remove/force
+# Add or remove newline before or after (depending on pos_class_comma,
+# may not be IGNORE) each',' in the base class list.
+nl_class_init_args              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after each ',' in the constructor member
 # initialization. Related to nl_constr_colon, pos_constr_colon and
 # pos_constr_comma.
-nl_constr_init_args             = ignore   # ignore/add/remove/force
+nl_constr_init_args             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before first element, after comma, and after last
 # element, in 'enum'.
-nl_enum_own_lines               = ignore   # ignore/add/remove/force
+nl_enum_own_lines               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between return type and function name in a function
 # definition.
-nl_func_type_name               = ignore   # ignore/add/remove/force
+# might be modified by nl_func_leave_one_liners
+nl_func_type_name               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between return type and function name inside a class
 # definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name
 # is used instead.
-nl_func_type_name_class         = ignore   # ignore/add/remove/force
+nl_func_type_name_class         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between class specification and '::'
 # in 'void A::f() { }'. Only appears in separate member implementation (does
 # not appear with in-line implementation).
-nl_func_class_scope             = ignore   # ignore/add/remove/force
+nl_func_class_scope             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between function scope and name, as in
 # 'void A :: <here> f() { }'.
-nl_func_scope_name              = ignore   # ignore/add/remove/force
+nl_func_scope_name              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between return type and function name in a prototype.
-nl_func_proto_type_name         = ignore   # ignore/add/remove/force
+nl_func_proto_type_name         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function name and the opening '(' in the
 # declaration.
-nl_func_paren                   = ignore   # ignore/add/remove/force
+nl_func_paren                   = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_paren for functions with no parameters.
-nl_func_paren_empty             = ignore   # ignore/add/remove/force
+nl_func_paren_empty             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function name and the opening '(' in the
 # definition.
-nl_func_def_paren               = ignore   # ignore/add/remove/force
+nl_func_def_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_paren for functions with no parameters.
-nl_func_def_paren_empty         = ignore   # ignore/add/remove/force
+nl_func_def_paren_empty         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function name and the opening '(' in the
 # call.
-nl_func_call_paren              = ignore   # ignore/add/remove/force
+nl_func_call_paren              = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_call_paren for functions with no parameters.
-nl_func_call_paren_empty        = ignore   # ignore/add/remove/force
+nl_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function declaration.
-nl_func_decl_start              = ignore   # ignore/add/remove/force
+nl_func_decl_start              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function definition.
-nl_func_def_start               = ignore   # ignore/add/remove/force
+nl_func_def_start               = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_decl_start when there is only one parameter.
-nl_func_decl_start_single       = ignore   # ignore/add/remove/force
+nl_func_decl_start_single       = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single        = ignore   # ignore/add/remove/force
+nl_func_def_start_single        = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function declaration if '(' and ')'
 # are in different lines. If false, nl_func_decl_start is used instead.
@@ -1550,10 +1946,13 @@ nl_func_decl_start_multi_line   = false    # true/false
 nl_func_def_start_multi_line    = false    # true/false
 
 # Add or remove newline after each ',' in a function declaration.
-nl_func_decl_args               = ignore   # ignore/add/remove/force
+nl_func_decl_args               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after each ',' in a function definition.
-nl_func_def_args                = ignore   # ignore/add/remove/force
+nl_func_def_args                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline after each ',' in a function call.
+nl_func_call_args               = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after each ',' in a function declaration if '('
 # and ')' are in different lines. If false, nl_func_decl_args is used instead.
@@ -1564,16 +1963,16 @@ nl_func_decl_args_multi_line    = false    # true/false
 nl_func_def_args_multi_line     = false    # true/false
 
 # Add or remove newline before the ')' in a function declaration.
-nl_func_decl_end                = ignore   # ignore/add/remove/force
+nl_func_decl_end                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before the ')' in a function definition.
-nl_func_def_end                 = ignore   # ignore/add/remove/force
+nl_func_def_end                 = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_decl_end when there is only one parameter.
-nl_func_decl_end_single         = ignore   # ignore/add/remove/force
+nl_func_decl_end_single         = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_end when there is only one parameter.
-nl_func_def_end_single          = ignore   # ignore/add/remove/force
+nl_func_def_end_single          = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline before ')' in a function declaration if '(' and ')'
 # are in different lines. If false, nl_func_decl_end is used instead.
@@ -1584,13 +1983,20 @@ nl_func_decl_end_multi_line     = false    # true/false
 nl_func_def_end_multi_line      = false    # true/false
 
 # Add or remove newline between '()' in a function declaration.
-nl_func_decl_empty              = remove   # ignore/add/remove/force
+nl_func_decl_empty              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '()' in a function definition.
-nl_func_def_empty               = remove   # ignore/add/remove/force
+nl_func_def_empty               = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '()' in a function call.
-nl_func_call_empty              = ignore   # ignore/add/remove/force
+nl_func_call_empty              = ignore   # ignore/add/remove/force/not_defined
+
+# Whether to add a newline after '(' in a function call,
+# has preference over nl_func_call_start_multi_line.
+nl_func_call_start              = ignore   # ignore/add/remove/force/not_defined
+
+# Whether to add a newline before ')' in a function call.
+nl_func_call_end                = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function call if '(' and ')' are in
 # different lines.
@@ -1604,40 +2010,68 @@ nl_func_call_args_multi_line    = false    # true/false
 # different lines.
 nl_func_call_end_multi_line     = false    # true/false
 
+# Whether to respect nl_func_call_XXX option in case of closure args.
+nl_func_call_args_multi_line_ignore_closures = false    # true/false
+
+# Whether to add a newline after '<' of a template parameter list.
+nl_template_start               = false    # true/false
+
+# Whether to add a newline after each ',' in a template parameter list.
+nl_template_args                = false    # true/false
+
+# Whether to add a newline before '>' of a template parameter list.
+nl_template_end                 = false    # true/false
+
 # (OC) Whether to put each Objective-C message parameter on a separate line.
 # See nl_oc_msg_leave_one_liner.
 nl_oc_msg_args                  = false    # true/false
 
+# (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
+nl_oc_msg_args_min_params       = 0        # unsigned number
+
+# (OC) Max code width of Objective-C message before applying nl_oc_msg_args.
+nl_oc_msg_args_max_code_width   = 0        # unsigned number
+
 # Add or remove newline between function signature and '{'.
-nl_fdef_brace                   = remove   # ignore/add/remove/force
+nl_fdef_brace                   = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove newline between function signature and '{',
+# if signature ends with ')'. Overrides nl_fdef_brace.
+nl_fdef_brace_cond              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between C++11 lambda signature and '{'.
-nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force
+nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'return' and the return expression.
-nl_return_expr                  = remove   # ignore/add/remove/force
+nl_return_expr                  = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove newline between 'throw' and the throw expression.
+nl_throw_expr                   = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after semicolons, except in 'for' statements.
 nl_after_semicolon              = true     # true/false
 
 # (Java) Add or remove newline between the ')' and '{{' of the double brace
 # initializer.
-nl_paren_dbrace_open            = ignore   # ignore/add/remove/force
+nl_paren_dbrace_open            = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after the type in an unnamed temporary
-# direct-list-initialization.
-nl_type_brace_init_lst          = ignore   # ignore/add/remove/force
+# direct-list-initialization, better:
+# before a direct-list-initialization.
+nl_type_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after the open brace in an unnamed temporary
 # direct-list-initialization.
-nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force
+nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline before the close brace in an unnamed temporary
 # direct-list-initialization.
-nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force
+nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline before '{'.
+nl_before_brace_open            = false    # true/false
+
+# Whether to add a newline after '{'.
 nl_after_brace_open             = true     # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line
@@ -1663,7 +2097,7 @@ nl_after_vbrace_close           = false    # true/false
 # Add or remove newline between the close brace and identifier,
 # as in 'struct { int a; } <here> b;'. Affects enumerations, unions and
 # structures. If set to ignore, uses nl_after_brace_close.
-nl_brace_struct_var             = ignore   # ignore/add/remove/force
+nl_brace_struct_var             = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to alter newlines in '#define' macros.
 nl_define_macro                 = true     # true/false
@@ -1681,41 +2115,61 @@ nl_squeeze_ifdef                = false    # true/false
 nl_squeeze_ifdef_top_level      = false    # true/false
 
 # Add or remove blank line before 'if'.
-nl_before_if                    = ignore   # ignore/add/remove/force
+nl_before_if                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'if' statement. Add/Force work only if the
 # next token is not a closing brace.
-nl_after_if                     = ignore   # ignore/add/remove/force
+nl_after_if                     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'for'.
-nl_before_for                   = ignore   # ignore/add/remove/force
+nl_before_for                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'for' statement.
-nl_after_for                    = ignore   # ignore/add/remove/force
+nl_after_for                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'while'.
-nl_before_while                 = ignore   # ignore/add/remove/force
+nl_before_while                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'while' statement.
-nl_after_while                  = ignore   # ignore/add/remove/force
+nl_after_while                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'switch'.
-nl_before_switch                = ignore   # ignore/add/remove/force
+nl_before_switch                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'switch' statement.
-nl_after_switch                 = ignore   # ignore/add/remove/force
+nl_after_switch                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'synchronized'.
-nl_before_synchronized          = ignore   # ignore/add/remove/force
+nl_before_synchronized          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'synchronized' statement.
-nl_after_synchronized           = ignore   # ignore/add/remove/force
+nl_after_synchronized           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'do'.
-nl_before_do                    = ignore   # ignore/add/remove/force
+nl_before_do                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'do/while' statement.
-nl_after_do                     = ignore   # ignore/add/remove/force
+nl_after_do                     = ignore   # ignore/add/remove/force/not_defined
+
+# Ignore nl_before_{if,for,switch,do,synchronized} if the control
+# statement is immediately after a case statement.
+# if nl_before_{if,for,switch,do} is set to remove, this option
+# does nothing.
+nl_before_ignore_after_case     = false    # true/false
+
+# Whether to put a blank line before 'return' statements, unless after an open
+# brace.
+nl_before_return                = false    # true/false
+
+# Whether to put a blank line after 'return' statements, unless followed by a
+# close brace.
+nl_after_return                 = false    # true/false
+
+# Whether to put a blank line before a member '.' or '->' operators.
+nl_before_member                = ignore   # ignore/add/remove/force/not_defined
+
+# (Java) Whether to put a blank line after a member '.' or '->' operators.
+nl_after_member                 = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to double-space commented-entries in 'struct'/'union'/'enum'.
 nl_ds_struct_enum_cmt           = false    # true/false
@@ -1726,33 +2180,37 @@ nl_ds_struct_enum_close_brace   = false    # true/false
 
 # Add or remove newline before or after (depending on pos_class_colon) a class
 # colon, as in 'class Foo <here> : <or here> public Bar'.
-nl_class_colon                  = ignore   # ignore/add/remove/force
+nl_class_colon                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline around a class constructor colon. The exact position
 # depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.
-nl_constr_colon                 = ignore   # ignore/add/remove/force
+nl_constr_colon                 = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'
 # into a single line. If true, prevents other brace newline rules from turning
-# such code into four lines.
+# such code into four lines. If true, it also preserves one-liner namespaces.
 nl_namespace_two_to_one_liner   = false    # true/false
 
 # Whether to remove a newline in simple unbraced if statements, turning them
-# into one-liners, as in 'if(b)\n i++;' → 'if(b) i++;'.
+# into one-liners, as in 'if(b)\n i++;' => 'if(b) i++;'.
 nl_create_if_one_liner          = false    # true/false
 
 # Whether to remove a newline in simple unbraced for statements, turning them
-# into one-liners, as in 'for (...)\n stmt;' → 'for (...) stmt;'.
+# into one-liners, as in 'for (...)\n stmt;' => 'for (...) stmt;'.
 nl_create_for_one_liner         = false    # true/false
 
 # Whether to remove a newline in simple unbraced while statements, turning
-# them into one-liners, as in 'while (expr)\n stmt;' → 'while (expr) stmt;'.
+# them into one-liners, as in 'while (expr)\n stmt;' => 'while (expr) stmt;'.
 nl_create_while_one_liner       = false    # true/false
 
 # Whether to collapse a function definition whose body (not counting braces)
 # is only one line so that the entire definition (prototype, braces, body) is
 # a single line.
 nl_create_func_def_one_liner    = false    # true/false
+
+# Whether to split one-line simple list definitions into three lines by
+# adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
+nl_create_list_one_liner        = false    # true/false
 
 # Whether to split one-line simple unbraced if statements into two lines by
 # adding a newline, as in 'if(b) <here> i++;'.
@@ -1766,6 +2224,10 @@ nl_split_for_one_liner          = false    # true/false
 # adding a newline, as in 'while (expr) <here> stmt;'.
 nl_split_while_one_liner        = false    # true/false
 
+# Don't add a newline before a cpp-comment in a parameter list of a function
+# call.
+donot_add_nl_before_cpp_comment = false    # true/false
+
 #
 # Blank line options
 #
@@ -1776,10 +2238,17 @@ nl_max                          = 2        # unsigned number
 # The maximum number of consecutive newlines in a function.
 nl_max_blank_in_func            = 0        # unsigned number
 
+# The number of newlines inside an empty function body.
+# This option overrides eat_blanks_after_open_brace and
+# eat_blanks_before_close_brace, but is ignored when
+# nl_collapse_empty_body_functions=true
+nl_inside_empty_func            = 0        # unsigned number
+
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number
 
-# The number of newlines before a multi-line function definition.
+# The number of newlines before a multi-line function definition. Where
+# applicable, this option is overridden with eat_blanks_after_open_brace=true
 nl_before_func_body_def         = 0        # unsigned number
 
 # The number of newlines before a class constructor/destructor prototype.
@@ -1824,6 +2293,53 @@ nl_after_func_body_class        = 0        # unsigned number
 # Overrides nl_after_func_body and nl_after_func_body_class.
 nl_after_func_body_one_liner    = 0        # unsigned number
 
+# The number of newlines before a block of typedefs. If nl_after_access_spec
+# is non-zero, that option takes precedence.
+#
+# 0: No change (default).
+nl_typedef_blk_start            = 0        # unsigned number
+
+# The number of newlines after a block of typedefs.
+#
+# 0: No change (default).
+nl_typedef_blk_end              = 0        # unsigned number
+
+# The maximum number of consecutive newlines within a block of typedefs.
+#
+# 0: No change (default).
+nl_typedef_blk_in               = 0        # unsigned number
+
+# The minimum number of blank lines after a block of variable definitions
+# at the top of a function body. If any preprocessor directives appear
+# between the opening brace of the function and the variable block, then
+# it is considered as not at the top of the function.Newlines are added
+# before trailing preprocessor directives, if any exist.
+#
+# 0: No change (default).
+nl_var_def_blk_end_func_top     = 0        # unsigned number
+
+# The minimum number of empty newlines before a block of variable definitions
+# not at the top of a function body. If nl_after_access_spec is non-zero,
+# that option takes precedence. Newlines are not added at the top of the
+# file or just after an opening brace. Newlines are added above any
+# preprocessor directives before the block.
+#
+# 0: No change (default).
+nl_var_def_blk_start            = 0        # unsigned number
+
+# The minimum number of empty newlines after a block of variable definitions
+# not at the top of a function body. Newlines are not added if the block
+# is at the bottom of the file or just before a preprocessor directive.
+#
+# 0: No change (default).
+nl_var_def_blk_end              = 0        # unsigned number
+
+# The maximum number of consecutive newlines within a block of variable
+# definitions.
+#
+# 0: No change (default).
+nl_var_def_blk_in               = 0        # unsigned number
+
 # The minimum number of newlines before a multi-line comment.
 # Doesn't apply if after a brace open or another multi-line comment.
 nl_before_block_comment         = 0        # unsigned number
@@ -1842,6 +2358,9 @@ nl_after_multiline_comment      = false    # true/false
 # Whether to force a newline after a label's colon.
 nl_after_label_colon            = false    # true/false
 
+# The number of newlines before a struct definition.
+nl_before_struct                = 0        # unsigned number
+
 # The number of newlines after '}' or ';' of a struct/enum/union definition.
 nl_after_struct                 = 0        # unsigned number
 
@@ -1851,18 +2370,33 @@ nl_before_class                 = 0        # unsigned number
 # The number of newlines after '}' or ';' of a class definition.
 nl_after_class                  = 0        # unsigned number
 
+# The number of newlines before a namespace.
+nl_before_namespace             = 0        # unsigned number
+
+# The number of newlines after '{' of a namespace. This also adds newlines
+# before the matching '}'.
+#
+# 0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
+#     applicable, otherwise no change.
+#
+# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
+nl_inside_namespace             = 0        # unsigned number
+
+# The number of newlines after '}' of a namespace.
+nl_after_namespace              = 0        # unsigned number
+
 # The number of newlines before an access specifier label. This also includes
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change (default).
+# 0: No change (default).
 nl_before_access_spec           = 2        # unsigned number
 
 # The number of newlines after an access specifier label. This also includes
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change (default).
+# 0: No change (default).
 #
 # Overrides nl_typedef_blk_start and nl_var_def_blk_start.
 nl_after_access_spec            = 1        # unsigned number
@@ -1870,37 +2404,28 @@ nl_after_access_spec            = 1        # unsigned number
 # The number of newlines between a function definition and the function
 # comment, as in '// comment\n <here> void foo() {...}'.
 #
-# 0 = No change (default).
+# 0: No change (default).
 nl_comment_func_def             = 0        # unsigned number
 
 # The number of newlines after a try-catch-finally block that isn't followed
 # by a brace close.
 #
-# 0 = No change (default).
+# 0: No change (default).
 nl_after_try_catch_finally      = 0        # unsigned number
 
 # (C#) The number of newlines before and after a property, indexer or event
 # declaration.
 #
-# 0 = No change (default).
+# 0: No change (default).
 nl_around_cs_property           = 0        # unsigned number
 
 # (C#) The number of newlines between the get/set/add/remove handlers.
 #
-# 0 = No change (default).
+# 0: No change (default).
 nl_between_get_set              = 0        # unsigned number
 
 # (C#) Add or remove newline between property and the '{'.
-nl_property_brace               = ignore   # ignore/add/remove/force
-
-# The number of newlines after '{' of a namespace. This also adds newlines
-# before the matching '}'.
-#
-# 0 = Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
-#     applicable, otherwise no change.
-#
-# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
-nl_inside_namespace             = 0        # unsigned number
+nl_property_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to remove blank lines after '{'.
 eat_blanks_after_open_brace     = false    # true/false
@@ -1915,20 +2440,32 @@ eat_blanks_before_close_brace   = true     # true/false
 # 2: Remove all newlines and reformat completely by config
 nl_remove_extra_newlines        = 0        # unsigned number
 
-# Whether to put a blank line before 'return' statements, unless after an open
-# brace.
-nl_before_return                = false    # true/false
-
-# Whether to put a blank line after 'return' statements, unless followed by a
-# close brace.
-nl_after_return                 = false    # true/false
-
 # (Java) Add or remove newline after an annotation statement. Only affects
 # annotations that are after a newline.
-nl_after_annotation             = ignore   # ignore/add/remove/force
+nl_after_annotation             = ignore   # ignore/add/remove/force/not_defined
 
 # (Java) Add or remove newline between two annotations.
-nl_between_annotation           = ignore   # ignore/add/remove/force
+nl_between_annotation           = ignore   # ignore/add/remove/force/not_defined
+
+# The number of newlines before a whole-file #ifdef.
+#
+# 0: No change (default).
+nl_before_whole_file_ifdef      = 0        # unsigned number
+
+# The number of newlines after a whole-file #ifdef.
+#
+# 0: No change (default).
+nl_after_whole_file_ifdef       = 0        # unsigned number
+
+# The number of newlines before a whole-file #endif.
+#
+# 0: No change (default).
+nl_before_whole_file_endif      = 0        # unsigned number
+
+# The number of newlines after a whole-file #endif.
+#
+# 0: No change (default).
+nl_after_whole_file_endif       = 0        # unsigned number
 
 #
 # Positioning options
@@ -1973,6 +2510,9 @@ pos_class_colon                 = lead_force   # ignore/break/force/lead/trail/j
 # Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
 pos_constr_colon                = lead     # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
+# The position of shift operators in wrapped expressions.
+pos_shift                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
 #
 # Line splitting options
 #
@@ -1984,10 +2524,12 @@ code_width                      = 0        # unsigned number
 ls_for_split_full               = true     # true/false
 
 # Whether to fully split long function prototypes/calls at commas.
+# The option ls_code_width has priority over the option ls_func_split_full.
 ls_func_split_full              = true     # true/false
 
 # Whether to split lines as close to code_width as possible and ignore some
 # groupings.
+# The option ls_code_width has priority over the option ls_func_split_full.
 ls_code_width                   = false    # true/false
 
 #
@@ -2014,16 +2556,31 @@ align_func_params               = false    # true/false
 
 # The span for aligning parameter definitions in function on parameter name.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_func_params_span          = 0        # unsigned number
 
 # The threshold for aligning function parameter definitions.
+# Use a negative number for absolute thresholds.
 #
-# 0 = No limit (default).
-align_func_params_thresh        = 0        # unsigned number
+# 0: No limit (default).
+align_func_params_thresh        = 0        # number
 
 # The gap for aligning function parameter definitions.
 align_func_params_gap           = 0        # unsigned number
+
+# The span for aligning constructor value.
+#
+# 0: Don't align (default).
+align_constr_value_span         = 0        # unsigned number
+
+# The threshold for aligning constructor value.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_constr_value_thresh       = 0        # number
+
+# The gap for aligning constructor value.
+align_constr_value_gap          = 0        # unsigned number
 
 # Whether to align parameters in single-line functions that have the same
 # name. The function names must already be aligned with each other.
@@ -2031,38 +2588,42 @@ align_same_func_call_params     = false    # true/false
 
 # The span for aligning function-call parameters for single line functions.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_same_func_call_params_span = 0        # unsigned number
 
 # The threshold for aligning function-call parameters for single line
 # functions.
+# Use a negative number for absolute thresholds.
 #
-# 0 = No limit (default).
-align_same_func_call_params_thresh = 0        # unsigned number
+# 0: No limit (default).
+align_same_func_call_params_thresh = 0        # number
 
 # The span for aligning variable definitions.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_var_def_span              = 0        # unsigned number
 
-# How to align the '*' in variable definitions.
+# How to consider (or treat) the '*' in the alignment of variable definitions.
 #
 # 0: Part of the type     'void *   foo;' (default)
 # 1: Part of the variable 'void     *foo;'
 # 2: Dangling             'void    *foo;'
+# Dangling: the '*' will not be taken into account when aligning.
 align_var_def_star_style        = 1        # unsigned number
 
-# How to align the '&' in variable definitions.
+# How to consider (or treat) the '&' in the alignment of variable definitions.
 #
 # 0: Part of the type     'long &   foo;' (default)
 # 1: Part of the variable 'long     &foo;'
 # 2: Dangling             'long    &foo;'
+# Dangling: the '&' will not be taken into account when aligning.
 align_var_def_amp_style         = 0        # unsigned number
 
 # The threshold for aligning variable definitions.
+# Use a negative number for absolute thresholds.
 #
-# 0 = No limit (default).
-align_var_def_thresh            = 0        # unsigned number
+# 0: No limit (default).
+align_var_def_thresh            = 0        # number
 
 # The gap for aligning variable definitions.
 align_var_def_gap               = 0        # unsigned number
@@ -2081,13 +2642,35 @@ align_var_def_inline            = false    # true/false
 
 # The span for aligning on '=' in assignments.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_assign_span               = 0        # unsigned number
 
-# The threshold for aligning on '=' in assignments.
+# The span for aligning on '=' in function prototype modifier.
 #
-# 0 = No limit (default).
-align_assign_thresh             = 0        # unsigned number
+# 0: Don't align (default).
+align_assign_func_proto_span    = 0        # unsigned number
+
+# The threshold for aligning on '=' in assignments.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_assign_thresh             = 0        # number
+
+# Whether to align on the left most assignment when multiple
+# definitions are found on the same line.
+# Depends on 'align_assign_span' and 'align_assign_thresh' settings.
+align_assign_on_multi_var_defs  = false    # true/false
+
+# The span for aligning on '{' in braced init list.
+#
+# 0: Don't align (default).
+align_braced_init_list_span     = 0        # unsigned number
+
+# The threshold for aligning on '{' in braced init list.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_braced_init_list_thresh   = 0        # number
 
 # How to apply align_assign_span to function declaration "assignments", i.e.
 # 'virtual void foo() = 0' or '~foo() = {default|delete}'.
@@ -2099,52 +2682,55 @@ align_assign_decl_func          = 0        # unsigned number
 
 # The span for aligning on '=' in enums.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_enum_equ_span             = 0        # unsigned number
 
 # The threshold for aligning on '=' in enums.
+# Use a negative number for absolute thresholds.
 #
-# 0 = no limit (default).
-align_enum_equ_thresh           = 0        # unsigned number
+# 0: no limit (default).
+align_enum_equ_thresh           = 0        # number
 
 # The span for aligning class member definitions.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_var_class_span            = 0        # unsigned number
 
 # The threshold for aligning class member definitions.
+# Use a negative number for absolute thresholds.
 #
-# 0 = No limit (default).
-align_var_class_thresh          = 0        # unsigned number
+# 0: No limit (default).
+align_var_class_thresh          = 0        # number
 
 # The gap for aligning class member definitions.
 align_var_class_gap             = 0        # unsigned number
 
 # The span for aligning struct/union member definitions.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_var_struct_span           = 0        # unsigned number
 
 # The threshold for aligning struct/union member definitions.
+# Use a negative number for absolute thresholds.
 #
-# 0 = No limit (default).
-align_var_struct_thresh         = 0        # unsigned number
+# 0: No limit (default).
+align_var_struct_thresh         = 0        # number
 
 # The gap for aligning struct/union member definitions.
 align_var_struct_gap            = 0        # unsigned number
 
 # The span for aligning struct initializer values.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_struct_init_span          = 0        # unsigned number
-
-# The minimum space between the type and the synonym of a typedef.
-align_typedef_gap               = 0        # unsigned number
 
 # The span for aligning single-line typedefs.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_typedef_span              = 0        # unsigned number
+
+# The minimum space between the type and the synonym of a typedef.
+align_typedef_gap               = 0        # unsigned number
 
 # How to align typedef'd functions with other typedefs.
 #
@@ -2153,24 +2739,31 @@ align_typedef_span              = 0        # unsigned number
 # 2: Align the function type name with the other type names
 align_typedef_func              = 0        # unsigned number
 
-# How to align the '*' in typedefs.
+# How to consider (or treat) the '*' in the alignment of typedefs.
 #
-# 0: Align on typedef type, ignore '*' (default)
-# 1: The '*' is part of type name: 'typedef int  *pint;'
-# 2: The '*' is part of the type, but dangling: 'typedef int *pint;'
+# 0: Part of the typedef type, 'typedef int * pint;' (default)
+# 1: Part of type name:        'typedef int   *pint;'
+# 2: Dangling:                 'typedef int  *pint;'
+# Dangling: the '*' will not be taken into account when aligning.
 align_typedef_star_style        = 0        # unsigned number
 
-# How to align the '&' in typedefs.
+# How to consider (or treat) the '&' in the alignment of typedefs.
 #
-# 0: Align on typedef type, ignore '&' (default)
-# 1: The '&' is part of type name: 'typedef int  &pint;'
-# 2: The '&' is part of the type, but dangling: 'typedef int &pint;'
+# 0: Part of the typedef type, 'typedef int & intref;' (default)
+# 1: Part of type name:        'typedef int   &intref;'
+# 2: Dangling:                 'typedef int  &intref;'
+# Dangling: the '&' will not be taken into account when aligning.
 align_typedef_amp_style         = 0        # unsigned number
 
 # The span for aligning comments that end lines.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_right_cmt_span            = 2        # unsigned number
+
+# Minimum number of columns between preceding text and a trailing comment in
+# order for the comment to qualify for being aligned. Must be non-zero to have
+# an effect.
+align_right_cmt_gap             = 0        # unsigned number
 
 # If aligning comments, whether to mix with comments after '}' and #endif with
 # less than three spaces before the comment.
@@ -2179,22 +2772,39 @@ align_right_cmt_mix             = false    # true/false
 # Whether to only align trailing comments that are at the same brace level.
 align_right_cmt_same_level      = false    # true/false
 
-# Minimum number of columns between preceding text and a trailing comment in
-# order for the comment to qualify for being aligned. Must be non-zero to have
-# an effect.
-align_right_cmt_gap             = 0        # unsigned number
-
 # Minimum column at which to align trailing comments. Comments which are
 # aligned beyond this column, but which can be aligned in a lesser column,
 # may be "pulled in".
 #
-# 0 = Ignore (default).
+# 0: Ignore (default).
 align_right_cmt_at_col          = 0        # unsigned number
 
 # The span for aligning function prototypes.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_func_proto_span           = 0        # unsigned number
+
+# How to consider (or treat) the '*' in the alignment of function prototypes.
+#
+# 0: Part of the type     'void *   foo();' (default)
+# 1: Part of the function 'void     *foo();'
+# 2: Dangling             'void    *foo();'
+# Dangling: the '*' will not be taken into account when aligning.
+align_func_proto_star_style     = 0        # unsigned number
+
+# How to consider (or treat) the '&' in the alignment of function prototypes.
+#
+# 0: Part of the type     'long &   foo();' (default)
+# 1: Part of the function 'long     &foo();'
+# 2: Dangling             'long    &foo();'
+# Dangling: the '&' will not be taken into account when aligning.
+align_func_proto_amp_style      = 0        # unsigned number
+
+# The threshold for aligning function prototypes.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_func_proto_thresh         = 0        # number
 
 # Minimum gap between the return type and the function name.
 align_func_proto_gap            = 0        # unsigned number
@@ -2220,7 +2830,7 @@ align_single_line_brace_gap     = 0        # unsigned number
 
 # (OC) The span for aligning Objective-C message specifications.
 #
-# 0 = Don't align (default).
+# 0: Don't align (default).
 align_oc_msg_spec_span          = 0        # unsigned number
 
 # Whether to align macros wrapped with a backslash and a newline. This will
@@ -2230,19 +2840,23 @@ align_nl_cont                   = true     # true/false
 # Whether to align macro functions and variables together.
 align_pp_define_together        = false    # true/false
 
-# The minimum space between label and value of a preprocessor define.
-align_pp_define_gap             = 0        # unsigned number
-
 # The span for aligning on '#define' bodies.
 #
 # =0: Don't align (default)
 # >0: Number of lines (including comments) between blocks
 align_pp_define_span            = 0        # unsigned number
 
+# The minimum space between label and value of a preprocessor define.
+align_pp_define_gap             = 0        # unsigned number
+
 # Whether to align lines that start with '<<' with previous '<<'.
 #
 # Default: true
 align_left_shift                = true     # true/false
+
+# Whether to align comma-separated statements following '<<' (as used to
+# initialize Eigen matrices).
+align_eigen_comma_init          = false    # true/false
 
 # Whether to align text after 'asm volatile ()' colons.
 align_asm_colon                 = false    # true/false
@@ -2250,7 +2864,7 @@ align_asm_colon                 = false    # true/false
 # (OC) Span for aligning parameters in an Objective-C message call
 # on the ':'.
 #
-# 0 = Don't align.
+# 0: Don't align.
 align_oc_msg_colon_span         = 0        # unsigned number
 
 # (OC) Whether to always align with the first parameter, even if it is too
@@ -2260,6 +2874,11 @@ align_oc_msg_colon_first        = false    # true/false
 # (OC) Whether to align parameters in an Objective-C '+' or '-' declaration
 # on the ':'.
 align_oc_decl_colon             = false    # true/false
+
+# (OC) Whether to not align parameters in an Objectve-C message call if first
+# colon is not on next line of the message call (the same way Xcode does
+# alignment)
+align_oc_msg_colon_xcode_like   = false    # true/false
 
 #
 # Comment modification options
@@ -2272,8 +2891,43 @@ cmt_width                       = 0        # unsigned number
 #
 # 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
-# 2: Full reflow
+# 2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)
 cmt_reflow_mode                 = 0        # unsigned number
+
+# Path to a file that contains regular expressions describing patterns for
+# which the end of one line and the beginning of the next will be folded into
+# the same sentence or paragraph during full comment reflow. The regular
+# expressions are described using ECMAScript syntax. The syntax for this
+# specification is as follows, where "..." indicates the custom regular
+# expression and "n" indicates the nth end_of_prev_line_regex and
+# beg_of_next_line_regex regular expression pair:
+#
+# end_of_prev_line_regex[1] = "...$"
+# beg_of_next_line_regex[1] = "^..."
+# end_of_prev_line_regex[2] = "...$"
+# beg_of_next_line_regex[2] = "^..."
+#             .
+#             .
+#             .
+# end_of_prev_line_regex[n] = "...$"
+# beg_of_next_line_regex[n] = "^..."
+#
+# Note that use of this option overrides the default reflow fold regular
+# expressions, which are internally defined as follows:
+#
+# end_of_prev_line_regex[1] = "[\w,\]\)]$"
+# beg_of_next_line_regex[1] = "^[\w,\[\(]"
+# end_of_prev_line_regex[2] = "\.$"
+# beg_of_next_line_regex[2] = "^[A-Z]"
+cmt_reflow_fold_regex_file      = ""         # string
+
+# Whether to indent wrapped lines to the start of the encompassing paragraph
+# during full comment reflow (cmt_reflow_mode = 2). Overrides the value
+# specified by cmt_sp_after_star_cont.
+#
+# Note that cmt_align_doxygen_javadoc_tags overrides this option for
+# paragraphs associated with javadoc tags
+cmt_reflow_indent_to_paragraph_start = false    # true/false
 
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
@@ -2284,6 +2938,25 @@ cmt_convert_tab_to_spaces       = false    # true/false
 #
 # Default: true
 cmt_indent_multi                = false    # true/false
+
+# Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)
+# and corresponding fields such that groups of consecutive block tags,
+# parameter names, and descriptions align with one another. Overrides that
+# which is specified by the cmt_sp_after_star_cont. If cmt_width > 0, it may
+# be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2
+# in order to achieve the desired alignment for line-wrapping.
+cmt_align_doxygen_javadoc_tags  = false    # true/false
+
+# The number of spaces to insert after the star and before doxygen
+# javadoc-style tags (@param, @return, etc). Requires enabling
+# cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the
+# cmt_sp_after_star_cont.
+#
+# Default: 1
+cmt_sp_before_doxygen_javadoc_tags = 1        # unsigned number
+
+# Whether to change trailing, single-line c-comments into cpp-comments.
+cmt_trailing_single_line_c_to_cpp = false    # true/false
 
 # Whether to group c-comments that look like they are in a block.
 cmt_c_group                     = false    # true/false
@@ -2391,25 +3064,30 @@ cmt_insert_before_ctor_dtor     = false    # true/false
 #
 
 # Add or remove braces on a single-line 'do' statement.
-mod_full_brace_do               = ignore   # ignore/add/remove/force
+mod_full_brace_do               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove braces on a single-line 'for' statement.
-mod_full_brace_for              = ignore   # ignore/add/remove/force
+mod_full_brace_for              = ignore   # ignore/add/remove/force/not_defined
 
 # (Pawn) Add or remove braces on a single-line function definition.
-mod_full_brace_function         = ignore   # ignore/add/remove/force
+mod_full_brace_function         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove braces on a single-line 'if' statement. Braces will not be
 # removed if the braced statement contains an 'else'.
-mod_full_brace_if               = ignore   # ignore/add/remove/force
+mod_full_brace_if               = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either
-# have, or do not have, braces. If true, braces will be added if any block
-# needs braces, and will only be removed if they can be removed from all
-# blocks.
+# have, or do not have, braces. Overrides mod_full_brace_if.
 #
-# Overrides mod_full_brace_if.
-mod_full_brace_if_chain         = false    # true/false
+# 0: Don't override mod_full_brace_if
+# 1: Add braces to all blocks if any block needs braces and remove braces if
+#    they can be removed from all blocks
+# 2: Add braces to all blocks if any block already has braces, regardless of
+#    whether it needs them
+# 3: Add braces to all blocks if any block needs braces and remove braces if
+#    they can be removed from all blocks, except if all blocks have braces
+#    despite none needing them
+mod_full_brace_if_chain         = 0        # unsigned number
 
 # Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.
 # If true, mod_full_brace_if_chain will only remove braces from an 'if' that
@@ -2417,10 +3095,10 @@ mod_full_brace_if_chain         = false    # true/false
 mod_full_brace_if_chain_only    = false    # true/false
 
 # Add or remove braces on single-line 'while' statement.
-mod_full_brace_while            = ignore   # ignore/add/remove/force
+mod_full_brace_while            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove braces on single-line 'using ()' statement.
-mod_full_brace_using            = ignore   # ignore/add/remove/force
+mod_full_brace_using            = ignore   # ignore/add/remove/force/not_defined
 
 # Don't remove braces around statements that span N newlines
 mod_full_brace_nl               = 0        # unsigned number
@@ -2441,18 +3119,32 @@ mod_full_brace_nl               = 0        # unsigned number
 #   mod_full_brace_function
 mod_full_brace_nl_block_rem_mlcond = false    # true/false
 
-# Add or remove unnecessary parenthesis on 'return' statement.
-mod_paren_on_return             = ignore   # ignore/add/remove/force
+# Add or remove unnecessary parentheses on 'return' statement.
+mod_paren_on_return             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove unnecessary parentheses on 'throw' statement.
+mod_paren_on_throw              = ignore   # ignore/add/remove/force/not_defined
 
 # (Pawn) Whether to change optional semicolons to real semicolons.
 mod_pawn_semicolon              = false    # true/false
 
 # Whether to fully parenthesize Boolean expressions in 'while' and 'if'
-# statement, as in 'if (a && b > c)' → 'if (a && (b > c))'.
+# statement, as in 'if (a && b > c)' => 'if (a && (b > c))'.
 mod_full_paren_if_bool          = false    # true/false
+
+# Whether to fully parenthesize Boolean expressions after '='
+# statement, as in 'x = a && b > c;' => 'x = (a && (b > c));'.
+mod_full_paren_assign_bool      = false    # true/false
+
+# Whether to fully parenthesize Boolean expressions after '='
+# statement, as in 'return  a && b > c;' => 'return (a && (b > c));'.
+mod_full_paren_return_bool      = false    # true/false
 
 # Whether to remove superfluous semicolons.
 mod_remove_extra_semicolon      = true     # true/false
+
+# Whether to remove duplicate include.
+mod_remove_duplicate_include    = false    # true/false
 
 # If a function body exceeds the specified number of newlines and doesn't have
 # a comment after the close brace, a comment will be added.
@@ -2478,6 +3170,9 @@ mod_add_long_ifdef_endif_comment = 0        # unsigned number
 # doesn't have a comment after the #else, a comment will be added.
 mod_add_long_ifdef_else_comment = 0        # unsigned number
 
+# Whether to take care of the case by the mod_sort_xx options.
+mod_sort_case_sensitive         = false    # true/false
+
 # Whether to sort consecutive single-line 'import' statements.
 mod_sort_import                 = false    # true/false
 
@@ -2489,20 +3184,86 @@ mod_sort_using                  = false    # true/false
 # break your code if your includes/imports have ordering dependencies.
 mod_sort_include                = true     # true/false
 
+# Whether to prioritize '#include' and '#import' statements that contain
+# filename without extension when sorting is enabled.
+mod_sort_incl_import_prioritize_filename = false    # true/false
+
+# Whether to prioritize '#include' and '#import' statements that does not
+# contain extensions when sorting is enabled.
+mod_sort_incl_import_prioritize_extensionless = false    # true/false
+
+# Whether to prioritize '#include' and '#import' statements that contain
+# angle over quotes when sorting is enabled.
+mod_sort_incl_import_prioritize_angle_over_quotes = false    # true/false
+
+# Whether to ignore file extension in '#include' and '#import' statements
+# for sorting comparison.
+mod_sort_incl_import_ignore_extension = false    # true/false
+
+# Whether to group '#include' and '#import' statements when sorting is enabled.
+mod_sort_incl_import_grouping_enabled = false    # true/false
+
 # Whether to move a 'break' that appears after a fully braced 'case' before
-# the close brace, as in 'case X: { ... } break;' → 'case X: { ... break; }'.
+# the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false
+
+# Whether to move a 'return' that appears after a fully braced 'case' before
+# the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'.
+mod_move_case_return            = false    # true/false
 
 # Add or remove braces around a fully braced case statement. Will only remove
 # braces if there are no variable declarations in the block.
-mod_case_brace                  = ignore   # ignore/add/remove/force
+mod_case_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to remove a void 'return;' that appears as the last statement in a
 # function.
 mod_remove_empty_return         = false    # true/false
 
 # Add or remove the comma after the last value of an enumeration.
-mod_enum_last_comma             = ignore   # ignore/add/remove/force
+mod_enum_last_comma             = ignore   # ignore/add/remove/force/not_defined
+
+# Syntax to use for infinite loops.
+#
+# 0: Leave syntax alone (default)
+# 1: Rewrite as `for(;;)`
+# 2: Rewrite as `while(true)`
+# 3: Rewrite as `do`...`while(true);`
+# 4: Rewrite as `while(1)`
+# 5: Rewrite as `do`...`while(1);`
+#
+# Infinite loops that do not already match one of these syntaxes are ignored.
+# Other options that affect loop formatting will be applied after transforming
+# the syntax.
+mod_infinite_loop               = 0        # unsigned number
+
+# Add or remove the 'int' keyword in 'int short'.
+mod_int_short                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'short int'.
+mod_short_int                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int long'.
+mod_int_long                    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'long int'.
+mod_long_int                    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int signed'.
+mod_int_signed                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'signed int'.
+mod_signed_int                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int unsigned'.
+mod_int_unsigned                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'unsigned int'.
+mod_unsigned_int                = ignore   # ignore/add/remove/force/not_defined
+
+# If there is a situation where mod_int_* and mod_*_int would result in
+# multiple int keywords, whether to keep the rightmost int (the default) or the
+# leftmost int.
+mod_int_prefer_int_on_left      = false    # true/false
 
 # (OC) Whether to organize the properties. If true, properties will be
 # rearranged according to the mod_sort_oc_property_*_weight factors.
@@ -2535,13 +3296,27 @@ mod_sort_oc_property_nullability_weight = 0        # number
 # Preprocessor options
 #
 
+# How to use tabs when indenting preprocessor code.
+#
+# -1: Use 'indent_with_tabs' setting (default)
+#  0: Spaces only
+#  1: Indent with tabs to brace level, align with spaces
+#  2: Indent and align with tabs, using spaces when not on a tabstop
+#
+# Default: -1
+pp_indent_with_tabs             = -1       # number
+
 # Add or remove indentation of preprocessor directives inside #if blocks
 # at brace level 0 (file-level).
-pp_indent                       = ignore   # ignore/add/remove/force
+pp_indent                       = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to indent #if/#else/#endif at the brace level. If false, these are
 # indented from column 1.
 pp_indent_at_level              = false    # true/false
+
+# Whether to indent #if/#else/#endif at the parenthesis level if the brace
+# level is 0. If false, these are indented from column 1.
+pp_indent_at_level0             = false    # true/false
 
 # Specifies the number of columns to indent preprocessors per level
 # at brace level 0 (file-level). If pp_indent_at_level=false, also specifies
@@ -2551,10 +3326,10 @@ pp_indent_at_level              = false    # true/false
 # Default: 1
 pp_indent_count                 = 1        # unsigned number
 
-# Add or remove space after # based on pp_level of #if blocks.
-pp_space                        = ignore   # ignore/add/remove/force
+# Add or remove space after # based on pp level of #if blocks.
+pp_space_after                  = ignore   # ignore/add/remove/force/not_defined
 
-# Sets the number of spaces per level added with pp_space.
+# Sets the number of spaces per level added with pp_space_after.
 pp_space_count                  = 0        # unsigned number
 
 # The indent for '#region' and '#endregion' in C# and '#pragma region' in
@@ -2574,40 +3349,83 @@ pp_indent_if                    = 0        # number
 # Whether to indent the code between #if, #else and #endif.
 pp_if_indent_code               = false    # true/false
 
+# Whether to indent the body of an #if that encompasses all the code in the file.
+pp_indent_in_guard              = false    # true/false
+
 # Whether to indent '#define' at the brace level. If false, these are
 # indented from column 1.
 pp_define_at_level              = false    # true/false
 
+# Whether to indent '#include' at the brace level.
+pp_include_at_level             = false    # true/false
+
 # Whether to ignore the '#define' body while formatting.
 pp_ignore_define_body           = false    # true/false
 
+# An offset value that controls the indentation of the body of a multiline #define.
+# 'body' refers to all the lines of a multiline #define except the first line.
+# Requires 'pp_ignore_define_body = false'.
+#
+#  <0: Absolute column: the body indentation starts off at the specified column
+#      (ex. -3 ==> the body is indented starting from column 3)
+# >=0: Relative to the column of the '#' of '#define'
+#      (ex.  3 ==> the body is indented starting 3 columns at the right of '#')
+#
+# Default: 8
+pp_multiline_define_body_indent = 4        # number
+
 # Whether to indent case statements between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the case statements
+# Only applies to the indent of the preprocessor that the case statements
 # directly inside of.
 #
 # Default: true
 pp_indent_case                  = true     # true/false
 
 # Whether to indent whole function definitions between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the function definition
+# Only applies to the indent of the preprocessor that the function definition
 # is directly inside of.
 #
 # Default: true
 pp_indent_func_def              = true     # true/false
 
 # Whether to indent extern C blocks between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the extern block is
+# Only applies to the indent of the preprocessor that the extern block is
 # directly inside of.
 #
 # Default: true
 pp_indent_extern                = true     # true/false
 
-# Whether to indent braces directly inside #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the braces are directly
-# inside of.
+# How to indent braces directly inside #if, #else, and #endif.
+# Requires pp_if_indent_code=true and only applies to the indent of the
+# preprocessor that the braces are directly inside of.
+#  0: No extra indent
+#  1: Indent by one level
+# -1: Preserve original indentation
 #
-# Default: true
-pp_indent_brace                 = true     # true/false
+# Default: 1
+pp_indent_brace                 = 1        # number
+
+# Whether to print warning messages for unbalanced #if and #else blocks.
+# This will print a message in the following cases:
+# - if an #ifdef block ends on a different indent level than
+#   where it started from. Example:
+#
+#    #ifdef TEST
+#      int i;
+#      {
+#        int j;
+#    #endif
+#
+# - an #elif/#else block ends on a different indent level than
+#   the corresponding #ifdef block. Example:
+#
+#    #ifdef TEST
+#        int i;
+#    #else
+#        }
+#      int j;
+#    #endif
+pp_warn_unbalanced_if           = false    # true/false
 
 #
 # Sort includes options
@@ -2646,18 +3464,22 @@ use_indent_func_call_param      = true     # true/false
 #
 # true:  indent_continue will be used only once
 # false: indent_continue will be used every time (default)
+#
+# Requires indent_ignore_first_continue=false.
 use_indent_continue_only_once   = false    # true/false
 
-# The value might be used twice:
-# - at the assignment
-# - at the opening brace
+# The indentation can be:
+# - after the assignment, at the '[' character
+# - at the beginning of the lambda body
 #
-# To prevent the double use of the indentation value, use this option with the
-# value 'true'.
-#
-# true:  indentation will be used only once
-# false: indentation will be used every time (default)
+# true:  indentation will be at the beginning of the lambda body
+# false: indentation will be after the assignment (default)
 indent_cpp_lambda_only_once     = false    # true/false
+
+# Whether sp_after_angle takes precedence over sp_inside_fparen. This was the
+# historic behavior, but is probably not the desired behavior, so this is off
+# by default.
+use_sp_after_angle_always       = false    # true/false
 
 # Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,
 # this tries to format these so that they match Qt's normalized form (i.e. the
@@ -2670,6 +3492,10 @@ indent_cpp_lambda_only_once     = false    # true/false
 # Default: true
 use_options_overriding_for_qt_macros = true     # true/false
 
+# If true: the form feed character is removed from the list of whitespace
+# characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.
+use_form_feed_no_more_as_whitespace_character = false    # true/false
+
 #
 # Warn levels - 1: error, 2: warning (default), 3: note
 #
@@ -2679,6 +3505,37 @@ use_options_overriding_for_qt_macros = true     # true/false
 #
 # Default: 2
 warn_level_tabs_found_in_verbatim_string_literals = 2        # unsigned number
+
+# Limit the number of loops.
+# Used by uncrustify.cpp to exit from infinite loop.
+# 0: no limit.
+debug_max_number_of_loops       = 0        # number
+
+# Set the number of the line to protocol;
+# Used in the function prot_the_line if the 2. parameter is zero.
+# 0: nothing protocol.
+debug_line_number_to_protocol   = 0        # number
+
+# Set the number of second(s) before terminating formatting the current file,
+# 0: no timeout.
+# only for linux
+debug_timeout                   = 0        # number
+
+# Set the number of characters to be printed if the text is too long,
+# 0: do not truncate.
+debug_truncate                  = 0        # unsigned number
+
+# sort (or not) the tracking info.
+#
+# Default: true
+debug_sort_the_tracks           = true     # true/false
+
+# decode (or not) the flags as a new line.
+# only if the -p option is set.
+debug_decode_the_flags          = false    # true/false
+
+# insert the number of the line at the beginning of each line
+set_numbering_for_html_output   = false    # true/false
 
 # Meaning of the settings:
 #   Ignore - do not do any changes
@@ -2695,7 +3552,7 @@ warn_level_tabs_found_in_verbatim_string_literals = 2        # unsigned number
 #       `set BOOL __AND__ __OR__`
 #
 #     tokenTypes are defined in src/token_enum.h, use them without the
-#     'CT_' prefix: 'CT_BOOL' → 'BOOL'
+#     'CT_' prefix: 'CT_BOOL' => 'BOOL'
 #
 #
 # - Token(s) can be treated as type(s) with the 'type' option.
@@ -2719,7 +3576,7 @@ warn_level_tabs_found_in_verbatim_string_literals = 2        # unsigned number
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
 #     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
-#     them without the 'LANG_' prefix: 'LANG_CPP' → 'CPP'
+#     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #
 # - Custom macro-based indentation can be set up using 'macro-open',

--- a/tests/algorithm/multiway_merge_benchmark.cpp
+++ b/tests/algorithm/multiway_merge_benchmark.cpp
@@ -48,7 +48,7 @@ struct DataStruct {
     unsigned int key;
     char payload[32];
 
-    explicit DataStruct(unsigned int k = 0)
+    explicit DataStruct(unsigned int k = 0) noexcept
         : key(k)
     { }
 

--- a/tests/algorithm/multiway_merge_test.cpp
+++ b/tests/algorithm/multiway_merge_test.cpp
@@ -20,7 +20,7 @@
 struct Something {
     unsigned int a, b;
 
-    explicit Something(unsigned int x = 0)
+    explicit Something(unsigned int x = 0) noexcept
         : a(x), b(x * x)
     { }
 

--- a/tests/container/d_ary_heap_test.cpp
+++ b/tests/container/d_ary_heap_test.cpp
@@ -48,12 +48,12 @@ struct TestData {
     unsigned int a, b;
 
     // required by the heap
-    TestData()
+    TestData() noexcept
         : a(0), b(0)
     { }
 
     // also used as implicit conversion constructor
-    TestData(unsigned int _a)
+    TestData(unsigned int _a) noexcept
         : a(_a), b(0)
     { }
 

--- a/tests/container/loser_tree_test.cpp
+++ b/tests/container/loser_tree_test.cpp
@@ -116,7 +116,7 @@ void test_losertree(bool stable, size_t num_vectors) {
     using Vector = std::vector<MyIntPair>;
     std::vector<Vector> vecs;
 
-    std::default_random_engine rng(std::random_device { } ());
+    std::default_random_engine rng(std::random_device { }());
 
     std::vector<MyIntPair> correct;
 

--- a/tests/deprecated_test.cpp
+++ b/tests/deprecated_test.cpp
@@ -12,7 +12,8 @@
 #include <tlx/define/deprecated.hpp>
 
 TLX_DEPRECATED(void do_not_use_me_anymore());
-void do_not_use_me_anymore() { }
+void do_not_use_me_anymore() {
+}
 
 TLX_DEPRECATED_FUNC_DEF(int also_do_not_use()) {
     return 0;

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -237,7 +237,7 @@ static void test_power_to_the_real() {
     }
 
     if (D > 0)
-        test_power_to_the_real<(D > 0) ? D - 1 : 0>();
+        test_power_to_the_real < (D > 0) ? D - 1 : 0 > ();
 }
 
 template <unsigned D = 7>
@@ -255,7 +255,7 @@ static void test_power_to_the_int() {
     }
 
     if (D > 0)
-        test_power_to_the_real<(D > 0) ? D - 1 : 0>();
+        test_power_to_the_real < (D > 0) ? D - 1 : 0 > ();
 }
 
 static void test_rol() {

--- a/tests/sort_networks_test.cpp
+++ b/tests/sort_networks_test.cpp
@@ -23,7 +23,7 @@
 struct Something {
     int a, b;
 
-    explicit Something(int x = 0)
+    explicit Something(int x = 0) noexcept
         : a(x), b(x * x)
     { }
 

--- a/tests/sort_parallel_mergesort_test.cpp
+++ b/tests/sort_parallel_mergesort_test.cpp
@@ -23,7 +23,7 @@
 struct Something {
     int a, b;
 
-    explicit Something(int x = 0)
+    explicit Something(int x = 0) noexcept
         : a(x), b(x * x)
     { }
 

--- a/tlx/algorithm/multiway_merge.hpp
+++ b/tlx/algorithm/multiway_merge.hpp
@@ -418,15 +418,15 @@ RandomAccessIterator3 multiway_merge_3_variant(
             goto s210;
     }
 
-#define TLX_MERGE3CASE(a, b, c, c0, c1)               \
-    s ## a ## b ## c:                                 \
-    *target = *seq ## a;                              \
-    ++target;                                         \
-    --size;                                           \
-    ++seq ## a;                                       \
-    if (size == 0) goto finish;                       \
-    if (seq ## a c0 seq ## b) goto s ## a ## b ## c;  \
-    if (seq ## a c1 seq ## c) goto s ## b ## a ## c;  \
+#define TLX_MERGE3CASE(a, b, c, c0, c1)              \
+    s ## a ## b ## c:                                \
+    *target = *seq ## a;                             \
+    ++target;                                        \
+    --size;                                          \
+    ++seq ## a;                                      \
+    if (size == 0) goto finish;                      \
+    if (seq ## a c0 seq ## b) goto s ## a ## b ## c; \
+    if (seq ## a c1 seq ## c) goto s ## b ## a ## c; \
     goto s ## b ## c ## a;
 
     TLX_MERGE3CASE(0, 1, 2, <=, <=);
@@ -569,12 +569,12 @@ RandomAccessIterator3 multiway_merge_4_variant(
     seq2(seqs_begin[2].first, seqs_begin[2].second, comp),
     seq3(seqs_begin[3].first, seqs_begin[3].second, comp);
 
-#define TLX_DECISION(a, b, c, d) do {                         \
-        if (seq ## d < seq ## a) goto s ## d ## a ## b ## c;  \
-        if (seq ## d < seq ## b) goto s ## a ## d ## b ## c;  \
-        if (seq ## d < seq ## c) goto s ## a ## b ## d ## c;  \
-        goto s ## a ## b ## c ## d;                           \
-}                                                             \
+#define TLX_DECISION(a, b, c, d) do {                        \
+        if (seq ## d < seq ## a) goto s ## d ## a ## b ## c; \
+        if (seq ## d < seq ## b) goto s ## a ## d ## b ## c; \
+        if (seq ## d < seq ## c) goto s ## a ## b ## d ## c; \
+        goto s ## a ## b ## c ## d;                          \
+}                                                            \
     while (0)
 
     if (seq0 <= seq1)
@@ -599,16 +599,16 @@ RandomAccessIterator3 multiway_merge_4_variant(
             TLX_DECISION(2, 1, 0, 3);
     }
 
-#define TLX_MERGE4CASE(a, b, c, d, c0, c1, c2)             \
-    s ## a ## b ## c ## d:                                 \
-    *target = *seq ## a;                                   \
-    ++target;                                              \
-    --size;                                                \
-    ++seq ## a;                                            \
-    if (size == 0) goto finish;                            \
-    if (seq ## a c0 seq ## b) goto s ## a ## b ## c ## d;  \
-    if (seq ## a c1 seq ## c) goto s ## b ## a ## c ## d;  \
-    if (seq ## a c2 seq ## d) goto s ## b ## c ## a ## d;  \
+#define TLX_MERGE4CASE(a, b, c, d, c0, c1, c2)            \
+    s ## a ## b ## c ## d:                                \
+    *target = *seq ## a;                                  \
+    ++target;                                             \
+    --size;                                               \
+    ++seq ## a;                                           \
+    if (size == 0) goto finish;                           \
+    if (seq ## a c0 seq ## b) goto s ## a ## b ## c ## d; \
+    if (seq ## a c1 seq ## c) goto s ## b ## a ## c ## d; \
+    if (seq ## a c2 seq ## d) goto s ## b ## c ## a ## d; \
     goto s ## b ## c ## d ## a;
 
     TLX_MERGE4CASE(0, 1, 2, 3, <=, <=, <=);

--- a/tlx/algorithm/random_bipartition_shuffle.hpp
+++ b/tlx/algorithm/random_bipartition_shuffle.hpp
@@ -54,7 +54,7 @@ void random_bipartition_shuffle(RandomAccessIt begin, RandomAccessIt end,
     // variates uniform on [0, a) and [0, b) respectively.
     auto two_random_variates =
         [&urng](size_t a, size_t b) {
-            auto x = std::uniform_int_distribution<size_t>{ 0, (a * b) - 1 } (urng);
+            auto x = std::uniform_int_distribution<size_t>{ 0, (a * b) - 1 }(urng);
             return std::make_pair(x / b, x % b);
         };
 
@@ -76,7 +76,7 @@ void random_bipartition_shuffle(RandomAccessIt begin, RandomAccessIt end,
         // In case the partition contains an odd number of elements,
         // there's a special case for the last element
         if (size_left_partition % 2) {
-            auto x = std::uniform_int_distribution<size_t>{ size_left_partition - 1, size - 1 } (urng);
+            auto x = std::uniform_int_distribution<size_t>{ size_left_partition - 1, size - 1 }(urng);
             swap(*it, *std::next(begin, x));
         }
     }
@@ -91,7 +91,7 @@ void random_bipartition_shuffle(RandomAccessIt begin, RandomAccessIt end,
         }
 
         if (size_right_partition % 2) {
-            auto x = std::uniform_int_distribution<size_t>{ 0, size_left_partition } (urng);
+            auto x = std::uniform_int_distribution<size_t>{ 0, size_left_partition }(urng);
             swap(*it--, *std::next(begin, x));
         }
     }

--- a/tlx/allocator_base.hpp
+++ b/tlx/allocator_base.hpp
@@ -24,8 +24,8 @@ class AllocatorBase
 
 public:
     using value_type = Type;
-    using pointer = Type *;
-    using const_pointer = const Type *;
+    using pointer = Type*;
+    using const_pointer = const Type*;
     using reference = Type&;
     using const_reference = const Type&;
     using size_type = std::size_t;

--- a/tlx/container/btree.hpp
+++ b/tlx/container/btree.hpp
@@ -2256,7 +2256,7 @@ public:
                 "BTree::bulk_load, level " << level <<
                     ": " << num_children << " children in " <<
                     num_parents << " inner nodes with up to " <<
-                ((num_children + num_parents - 1) / num_parents) <<
+                    ((num_children + num_parents - 1) / num_parents) <<
                     " children per inner node.");
 
             size_t inner_index = 0;

--- a/tlx/container/loser_tree.hpp
+++ b/tlx/container/loser_tree.hpp
@@ -877,8 +877,8 @@ public:
 
 template <bool Stable, typename ValueType, typename Comparator>
 class LoserTreeSwitch<
-        Stable, ValueType, Comparator,
-        typename std::enable_if<sizeof(ValueType) <= 2 * sizeof(size_t)>::type>
+    Stable, ValueType, Comparator,
+    typename std::enable_if<sizeof(ValueType) <= 2 * sizeof(size_t)>::type>
 {
 public:
     using Type = LoserTreeCopy<Stable, ValueType, Comparator>;
@@ -899,8 +899,8 @@ public:
 
 template <bool Stable, typename ValueType, typename Comparator>
 class LoserTreeUnguardedSwitch<
-        Stable, ValueType, Comparator,
-        typename std::enable_if<sizeof(ValueType) <= 2 * sizeof(size_t)>::type>
+    Stable, ValueType, Comparator,
+    typename std::enable_if<sizeof(ValueType) <= 2 * sizeof(size_t)>::type>
 {
 public:
     using Type = LoserTreeCopyUnguarded<Stable, ValueType, Comparator>;

--- a/tlx/container/radix_heap.hpp
+++ b/tlx/container/radix_heap.hpp
@@ -104,7 +104,7 @@ class BitArrayRecursive<Size, false>
     using child_type = BitArrayRecursive<1llu << child_width, child_width <= 6>;
 
     static constexpr size_t root_size = div_ceil(Size, child_type::size);
-    using root_type = BitArrayRecursive<root_size <= 32 ? 32 : 64, true>;
+    using root_type = BitArrayRecursive < root_size <= 32 ? 32 : 64, true >;
 
     using child_array_type = std::array<child_type, root_size>;
 
@@ -652,9 +652,9 @@ template <typename DataType, unsigned Radix = 8, typename KeyExtract = void>
 auto make_radix_heap(KeyExtract&& key_extract)->
 RadixHeap<DataType, KeyExtract,
           decltype(key_extract(std::declval<DataType>())), Radix> {
-    return (RadixHeap < DataType,
-            KeyExtract,
-            decltype(key_extract(DataType{ })), Radix > {
+    return (RadixHeap<DataType,
+                      KeyExtract,
+                      decltype(key_extract(DataType{ })), Radix> {
                 key_extract
             });
 }

--- a/tlx/container/simple_vector.hpp
+++ b/tlx/container/simple_vector.hpp
@@ -63,8 +63,8 @@ protected:
 public:
     // *** simple pointer iterators
 
-    using iterator = value_type *;
-    using const_iterator = const value_type *;
+    using iterator = value_type*;
+    using const_iterator = const value_type*;
     using reference = value_type&;
     using const_reference = const value_type&;
 

--- a/tlx/define/deprecated.hpp
+++ b/tlx/define/deprecated.hpp
@@ -21,7 +21,7 @@ namespace tlx {
 #if TLX_NO_DEPRECATED
   #define TLX_DEPRECATED(x) x
 #elif defined(_MSC_VER)
-  #define TLX_DEPRECATED(x) __declspec(deprecated)x
+  #define TLX_DEPRECATED(x) __declspec(deprecated) x
 #elif defined(__clang__) || defined(__GNUG__)
   #define TLX_DEPRECATED(x) x __attribute__ ((deprecated))
 #endif

--- a/tlx/delegate.hpp
+++ b/tlx/delegate.hpp
@@ -110,7 +110,7 @@ public:
     //! \{
 
     //! construction from an immediate function with no object or pointer.
-    template <R(* const Function)(A...)>
+    template <R(*const Function)(A...)>
     static Delegate make() noexcept {
         return Delegate(function_caller<Function>, nullptr);
     }
@@ -123,7 +123,7 @@ public:
     //! constructor from a plain function pointer with no object.
     explicit Delegate(R(*const function_ptr)(A...)) noexcept
         : Delegate(function_ptr_caller,
-                   *reinterpret_cast<void* const*>(&function_ptr)) { }
+                   * reinterpret_cast<void* const*>(&function_ptr)) { }
 
     static_assert(sizeof(void*) == sizeof(void (*)(void)),
                   "object pointer and function pointer sizes must equal");
@@ -183,14 +183,14 @@ public:
         : store_(
               // allocate memory for T in shared_ptr with appropriate deleter
               typename std::allocator_traits<Allocator>::template rebind_alloc<
-                  typename std::decay<T>::type>{}.allocate(1),
+                  typename std::decay<T>::type>{ }.allocate(1),
               store_deleter<typename std::decay<T>::type>, Allocator()) {
 
         using Functor = typename std::decay<T>::type;
         using Rebind = typename std::allocator_traits<Allocator>::template rebind_alloc<Functor>;
 
         // copy-construct T into shared_ptr memory.
-        Rebind rebind{};
+        Rebind rebind{ };
         std::allocator_traits<Rebind>::construct(
             rebind, static_cast<Functor*>(store_.get()), Functor(std::forward<T>(f)));
 
@@ -334,7 +334,7 @@ private:
     template <typename T>
     static void store_deleter(void* const ptr) {
         using Rebind = typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
-        Rebind rebind{};
+        Rebind rebind{ };
 
         std::allocator_traits<Rebind>::destroy(rebind, static_cast<T*>(ptr));
         std::allocator_traits<Rebind>::deallocate(rebind, static_cast<T*>(ptr), 1);
@@ -344,14 +344,14 @@ private:
     //! \{
 
     //! caller for an immediate function with no object or pointer.
-    template <R(* Function)(A...)>
+    template <R(*Function)(A...)>
     static R function_caller(void* const, A&& ... args) {
         return Function(std::forward<A>(args) ...);
     }
 
     //! caller for a plain function pointer.
     static R function_ptr_caller(void* const object_ptr, A&& ... args) {
-        return (*reinterpret_cast<R(* const*)(A...)>(&object_ptr))(args...);
+        return (*reinterpret_cast<R(*const*)(A...)>(&object_ptr))(args...);
     }
 
     //! function caller for immediate class::method function calls

--- a/tlx/die/core.hpp
+++ b/tlx/die/core.hpp
@@ -129,13 +129,14 @@ inline bool die_equal_compare(double a, double b) {
 
 //! Check that X == Y or die miserably, but output the values of X and Y for
 //! better debugging.
-#define tlx_die_unequal(X, Y)                                                \
-    do {                                                                     \
-        auto x__ = (X);                                     /* NOLINT */     \
-        auto y__ = (Y);                                     /* NOLINT */     \
-        if (!::tlx::die_equal_compare(x__, y__))                             \
-            tlx_die_with_sstream("DIE-UNEQUAL: " #X " != " #Y " : "          \
-                                 "\"" << x__ << "\" != \"" << y__ << "\"");  \
+#define tlx_die_unequal(X, Y)                                               \
+    do {                                                                    \
+        auto x__ = (X);                                     /* NOLINT */    \
+        auto y__ = (Y);                                     /* NOLINT */    \
+        if (!::tlx::die_equal_compare(x__, y__)) {                          \
+            tlx_die_with_sstream("DIE-UNEQUAL: " #X " != " #Y " : "         \
+                                 "\"" << x__ << "\" != \"" << y__ << "\""); \
+        }                                                                   \
     } while (false)
 
 //! Check that X == Y or die miserably, but output the values of X and Y for
@@ -153,10 +154,11 @@ inline bool die_equal_compare(double a, double b) {
     do {                                                                       \
         auto x__ = (X);                                     /* NOLINT */       \
         auto y__ = (Y);                                     /* NOLINT */       \
-        if (!::tlx::die_equal_compare(x__, y__))                               \
+        if (!::tlx::die_equal_compare(x__, y__)) {                             \
             tlx_die_with_sstream("DIE-UNEQUAL: " #X " != " #Y " : "            \
                                  "\"" << x__ << "\" != \"" << y__ << "\"\n" << \
                                  msg << '\n');                                 \
+        }                                                                      \
     } while (false)
 
 /******************************************************************************/
@@ -181,10 +183,11 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps) {
     do {                                                                 \
         auto x__ = (X);                                     /* NOLINT */ \
         auto y__ = (Y);                                     /* NOLINT */ \
-        if (!::tlx::die_equal_eps_compare(x__, y__, eps))                \
+        if (!::tlx::die_equal_eps_compare(x__, y__, eps)) {              \
             tlx_die("DIE-UNEQUAL-EPS: " #X " != " #Y " : "               \
                     << std::setprecision(18)                             \
                     << "\"" << x__ << "\" != \"" << y__ << "\"");        \
+        }                                                                \
     } while (false)
 
 //! Check that ABS(X - Y) <= eps or die miserably, but output the values of X
@@ -194,11 +197,12 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps) {
     do {                                                                 \
         auto x__ = (X);                                     /* NOLINT */ \
         auto y__ = (Y);                                     /* NOLINT */ \
-        if (!::tlx::die_equal_eps_compare(x__, y__, eps))                \
+        if (!::tlx::die_equal_eps_compare(x__, y__, eps)) {              \
             tlx_die("DIE-UNEQUAL-EPS: " #X " != " #Y " : "               \
                     << std::setprecision(18)                             \
                     << "\"" << x__ << "\" != \"" << y__ << "\"\n" <<     \
                     msg << '\n');                                        \
+        }                                                                \
     } while (false)
 
 //! Check that ABS(X - Y) <= 0.000001 or die miserably, but output the values of
@@ -217,13 +221,14 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps) {
 
 //! Die miserably if X == Y, but first output the values of X and Y for better
 //! debugging.
-#define tlx_die_equal(X, Y)                                                  \
-    do {                                                                     \
-        auto x__ = (X);                                     /* NOLINT */     \
-        auto y__ = (Y);                                     /* NOLINT */     \
-        if (::tlx::die_equal_compare(x__, y__))                              \
-            tlx_die_with_sstream("DIE-EQUAL: " #X " == " #Y " : "            \
-                                 "\"" << x__ << "\" == \"" << y__ << "\"");  \
+#define tlx_die_equal(X, Y)                                                 \
+    do {                                                                    \
+        auto x__ = (X);                                     /* NOLINT */    \
+        auto y__ = (Y);                                     /* NOLINT */    \
+        if (::tlx::die_equal_compare(x__, y__)) {                           \
+            tlx_die_with_sstream("DIE-EQUAL: " #X " == " #Y " : "           \
+                                 "\"" << x__ << "\" == \"" << y__ << "\""); \
+        }                                                                   \
     } while (false)
 
 //! Die miserably if X == Y, but first output the values of X and Y for better
@@ -241,10 +246,11 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps) {
     do {                                                                       \
         auto x__ = (X);                                     /* NOLINT */       \
         auto y__ = (Y);                                     /* NOLINT */       \
-        if (::tlx::die_equal_compare(x__, y__))                                \
+        if (::tlx::die_equal_compare(x__, y__)) {                              \
             tlx_die_with_sstream("DIE-EQUAL: " #X " == " #Y " : "              \
                                  "\"" << x__ << "\" == \"" << y__ << "\"\n" << \
                                  msg << '\n');                                 \
+        }                                                                      \
     } while (false)
 
 /******************************************************************************/

--- a/tlx/logger/core.hpp
+++ b/tlx/logger/core.hpp
@@ -135,7 +135,7 @@ public:
 
 //! Explicitly specify the condition for logging
 #define TLX_LOGC(cond) \
-    !(cond) ? (void)0 : ::tlx::LoggerVoidify() & ::tlx::Logger()
+    !(cond) ? (void)0 : ::tlx::LoggerVoidify()& ::tlx::Logger()
 
 //! Default logging method: output if the local debug variable is true.
 #define TLX_LOG TLX_LOGC(debug)

--- a/tlx/meta/vexpand.hpp
+++ b/tlx/meta/vexpand.hpp
@@ -21,7 +21,8 @@ namespace tlx {
 // is obviously identical to tlx::unused() but used in a different context.
 
 template <typename... Types>
-void vexpand(Types&& ...) { }
+void vexpand(Types&& ...) {
+}
 
 //! \}
 

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -39,8 +39,7 @@ struct MultiTimer::Entry {
 MultiTimer::MultiTimer()
     : total_duration_(std::chrono::duration<double>::zero()),
       running_(nullptr),
-      running_hash_(0)
-{ }
+      running_hash_(0) { }
 
 MultiTimer::MultiTimer(const MultiTimer&) = default;
 MultiTimer& MultiTimer::operator = (const MultiTimer&) = default;

--- a/tlx/sort/parallel_mergesort.hpp
+++ b/tlx/sort/parallel_mergesort.hpp
@@ -131,7 +131,7 @@ void parallel_sort_mwms_pu(PMWMSSortingData<RandomAccessIterator>* sd,
     // length of this thread's chunk, before merging
     DiffType length_local = sd->starts[iam + 1] - sd->starts[iam];
 
-    using SortingPlacesIterator = ValueType *;
+    using SortingPlacesIterator = ValueType*;
 
     // sort in temporary storage, leave space for sentinel
     sd->temporary[iam] = static_cast<ValueType*>(

--- a/tlx/stack_allocator.hpp
+++ b/tlx/stack_allocator.hpp
@@ -115,8 +115,8 @@ class StackAllocator : public AllocatorBase<Type>
 {
 public:
     using value_type = Type;
-    using pointer = Type *;
-    using const_pointer = const Type *;
+    using pointer = Type*;
+    using const_pointer = const Type*;
     using reference = Type&;
     using const_reference = const Type&;
     using size_type = std::size_t;

--- a/tlx/unused.hpp
+++ b/tlx/unused.hpp
@@ -17,7 +17,8 @@ namespace tlx {
 // UNUSED(variables...)
 
 template <typename... Types>
-void unused(Types&& ...) { }
+void unused(Types&& ...) {
+}
 
 } // namespace tlx
 


### PR DESCRIPTION
* Fix CI to use use Ubuntu 20.04 and 22.04, omit MacOS and gcc 13 for now. Ubuntu 18.04 is no longer supported. The newer compilers will be reenabled when the code is fixed.
* Fix compilation by adding `noexcept` to test struct constructors
* Update uncrustify to Uncrustify-0.76.0_f and reformat