### PR TITLE
fix uintX_t usage by using std:: prefix and <cstdint> include

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,15 +43,19 @@ jobs:
           os: ubuntu-22.04
           build_type: "Debug"
 
-        # - name: "Ubuntu 22.04 gcc 13 Release GLIBCXX_DEBUG"
-        #   os: ubuntu-22.04
-        #   build_type: "Release"
-        #   gcc_install: "13"
-        #   cxx_flags: "-D_GLIBCXX_DEBUG"
+        - name: "Ubuntu 22.04 gcc 13 Release GLIBCXX_DEBUG"
+          os: ubuntu-22.04
+          build_type: "Release"
+          gcc_install: "13"
+          cxx_flags: "-D_GLIBCXX_DEBUG"
 
-        # - name: "macOS 12 clang X Debug"
-        #   os: macos-12
-        #   build_type: "Debug"
+        - name: "macOS 12 clang 14 Debug"
+          os: macos-12
+          build_type: "Debug"
+
+        - name: "macOS 13 clang 15 Release"
+          os: macos-13
+          build_type: "Release"
 
         # - name: "Window Latest"
         #   os: windows-latest

--- a/tests/algorithm/multiway_merge_benchmark.cpp
+++ b/tests/algorithm/multiway_merge_benchmark.cpp
@@ -91,14 +91,14 @@ protected:
     std::string message_;
 
     //! bytes processed
-    uint64_t bytes_;
+    std::uint64_t bytes_;
 
     //! timer
     double ts_;
 
 public:
     //! save message and start timer
-    explicit scoped_print_timer(const std::string& message, const uint64_t bytes = 0)
+    explicit scoped_print_timer(const std::string& message, const std::uint64_t bytes = 0)
         : message_(message),
           bytes_(bytes),
           ts_(tlx::timestamp()) {
@@ -121,7 +121,7 @@ public:
                  << message_
                  << " after " << elapsed << " seconds. "
                  << "Processed " << tlx::format_iec_units(bytes_) << "B"
-                 << " @ " << tlx::format_iec_units(static_cast<uint64_t>(bps)) << "B/s";
+                 << " @ " << tlx::format_iec_units(static_cast<std::uint64_t>(bps)) << "B/s";
         }
     }
 };
@@ -152,7 +152,7 @@ void test_multiway_merge(size_t seq_count, const size_t seq_size) {
 #pragma omp parallel
 #endif
         {
-            std::uniform_int_distribution<uint64_t> distr;
+            std::uniform_int_distribution<std::uint64_t> distr;
 
 #if defined(_OPENMP)
             unsigned int seed = 1234 * omp_get_thread_num() + seq_count + seq_size;
@@ -427,33 +427,33 @@ int main(int argc, char* argv[]) {
     // run individually for debugging
     if (0)
     {
-        test_repeat<uint64_t, PARA_GNU_MWM_EXACT>(2, 2 * 1024 * 1024);
-        test_repeat<uint64_t, PARA_MWM_EXACT_LT>(2, 2 * 1024 * 1024);
-        // test_repeat<uint64_t, PARA_MWM_EXACT_LT>(1024, 2 * 1024 * 1024);
-        // test_repeat<uint64_t, SEQ_MWM_LT>(2, 2 * 1024 * 1024);
-        // test_repeat<uint64_t, SEQ_GNU_MWM>(2, 2 * 1024 * 1024);
+        test_repeat<std::uint64_t, PARA_GNU_MWM_EXACT>(2, 2 * 1024 * 1024);
+        test_repeat<std::uint64_t, PARA_MWM_EXACT_LT>(2, 2 * 1024 * 1024);
+        // test_repeat<std::uint64_t, PARA_MWM_EXACT_LT>(1024, 2 * 1024 * 1024);
+        // test_repeat<std::uint64_t, SEQ_MWM_LT>(2, 2 * 1024 * 1024);
+        // test_repeat<std::uint64_t, SEQ_GNU_MWM>(2, 2 * 1024 * 1024);
         return 0;
     }
 
     if (benchset == "seq" || benchset == "sequential" ||
         benchset == "both" || benchset == "all")
     {
-        test_seqnum_sequential<uint64_t>();
+        test_seqnum_sequential<std::uint64_t>();
         test_seqnum_sequential<DataStruct>();
     }
     if (benchset == "para" || benchset == "parallel" ||
         benchset == "both" || benchset == "all")
     {
-        test_seqnum_parallel<uint64_t>();
+        test_seqnum_parallel<std::uint64_t>();
         test_seqnum_parallel<DataStruct>();
     }
     if (benchset == "seqsize" || benchset == "all")
     {
         // fastest sequential multiway merge
-        test_seqsize<uint64_t, SEQ_MWM_LT_COMBINED>();
+        test_seqsize<std::uint64_t, SEQ_MWM_LT_COMBINED>();
         test_seqsize<DataStruct, SEQ_MWM_LT_COMBINED>();
         // and parallel multiway merge
-        test_seqsize<uint64_t, PARA_MWM_EXACT_LT>();
+        test_seqsize<std::uint64_t, PARA_MWM_EXACT_LT>();
         test_seqsize<DataStruct, PARA_MWM_EXACT_LT>();
     }
 

--- a/tests/cmdline_parser_example.cpp
+++ b/tests/cmdline_parser_example.cpp
@@ -11,6 +11,7 @@
 // [example]
 #include <tlx/cmdline_parser.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 
@@ -29,7 +30,7 @@ int main(int argc, char* argv[]) {
                     "Run N rounds of the experiment.");
 
     // add a byte size argument which the user can enter like '1gi'
-    uint64_t a_size = 0;
+    std::uint64_t a_size = 0;
     cp.add_bytes('s', "size", a_size,
                  "Number of bytes to process.");
 

--- a/tests/container/btree_test.cpp
+++ b/tests/container/btree_test.cpp
@@ -17,6 +17,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <set>
 #include <vector>
@@ -209,11 +210,11 @@ struct SimpleTest {
     }
 
     static void test_set_100000_uint64() {
-        tlx::btree_map<uint64_t, uint8_t> bt;
+        tlx::btree_map<std::uint64_t, std::uint8_t> bt;
 
-        for (uint64_t i = 10; i < 100000; ++i)
+        for (std::uint64_t i = 10; i < 100000; ++i)
         {
-            uint64_t key = i % 1000;
+            std::uint64_t key = i % 1000;
 
             if (bt.find(key) == bt.end())
             {
@@ -225,11 +226,11 @@ struct SimpleTest {
     }
 
     static void test_multiset_100000_uint32() {
-        tlx::btree_multiset<uint32_t> bt;
+        tlx::btree_multiset<std::uint32_t> bt;
 
-        for (uint64_t i = 0; i < 100000; ++i)
+        for (std::uint64_t i = 0; i < 100000; ++i)
         {
-            uint32_t key = i % 1000;
+            std::uint32_t key = i % 1000;
 
             bt.insert(key);
         }

--- a/tests/container/d_ary_heap_speedtest.cpp
+++ b/tests/container/d_ary_heap_speedtest.cpp
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
@@ -111,17 +112,17 @@ template <template <typename HeapType> class TestClass>
 struct TestFactory_Heap {
     //! Test the binary heap from STL
     using StdQueue = TestClass<
-        std::priority_queue<uint32_t, std::vector<uint32_t>,
-                            std::greater<uint32_t> > >;
+        std::priority_queue<std::uint32_t, std::vector<std::uint32_t>,
+                            std::greater<std::uint32_t> > >;
 
     //! Test the d-ary heap with a specific arity
     template <int Arity>
-    using DAryHeap = TestClass<tlx::DAryHeap<uint32_t, Arity> >;
+    using DAryHeap = TestClass<tlx::DAryHeap<std::uint32_t, Arity> >;
 
     //! Test the d-ary heap with a specific arity
     template <int Arity>
     using DAryAIntHeap =
-        TestClass<tlx::DAryAddressableIntHeap<uint32_t, Arity> >;
+        TestClass<tlx::DAryAddressableIntHeap<std::uint32_t, Arity> >;
 
     //! Run tests on all heap types
     void call_testrunner(size_t items);

--- a/tests/container/d_ary_heap_test.cpp
+++ b/tests/container/d_ary_heap_test.cpp
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 #include <algorithm>
+#include <cstdint>
 #include <random>
 #include <set>
 #include <vector>
@@ -20,15 +21,15 @@
 // Force instantiation.
 namespace tlx {
 
-template class DAryHeap<uint8_t>;
-template class DAryHeap<uint16_t>;
-template class DAryHeap<uint32_t>;
-template class DAryHeap<uint64_t>;
+template class DAryHeap<std::uint8_t>;
+template class DAryHeap<std::uint16_t>;
+template class DAryHeap<std::uint32_t>;
+template class DAryHeap<std::uint64_t>;
 
-template class DAryAddressableIntHeap<uint8_t>;
-template class DAryAddressableIntHeap<uint16_t>;
-template class DAryAddressableIntHeap<uint32_t>;
-template class DAryAddressableIntHeap<uint64_t>;
+template class DAryAddressableIntHeap<std::uint8_t>;
+template class DAryAddressableIntHeap<std::uint16_t>;
+template class DAryAddressableIntHeap<std::uint32_t>;
+template class DAryAddressableIntHeap<std::uint64_t>;
 
 } // namespace tlx
 
@@ -79,7 +80,7 @@ struct TestCompare {
 };
 
 template <typename KeyType>
-std::vector<KeyType> get_shuffled_vector(size_t size, uint32_t r_seed) {
+std::vector<KeyType> get_shuffled_vector(size_t size, std::uint32_t r_seed) {
     std::vector<KeyType> keys(size);
     for (size_t key = 0; key < size; ++key) {
         keys[key] = KeyType(key);
@@ -118,7 +119,7 @@ void fill_heap_and_set(DAryHeap& heap, Set& set, KeysVector& keys) {
 //! Basic APIs: push(), top(), and pop().
 template <typename KeyType, unsigned Arity = 2,
           class Compare = std::less<KeyType> >
-void d_ary_heap_test(size_t size, uint32_t r_seed = 42) {
+void d_ary_heap_test(size_t size, std::uint32_t r_seed = 42) {
     tlx::DAryHeap<KeyType, Arity, Compare> x;
     die_unequal(x.size(), 0u);
     die_if(!x.empty());
@@ -156,7 +157,7 @@ void d_ary_heap_test(size_t size, uint32_t r_seed = 42) {
 //! Basic APIs: push(), top(), pop(), and remove().
 template <typename KeyType, unsigned Arity = 2,
           class Compare = std::less<KeyType> >
-void d_ary_addressable_int_heap_test(size_t size, uint32_t r_seed = 42) {
+void d_ary_addressable_int_heap_test(size_t size, std::uint32_t r_seed = 42) {
     tlx::DAryAddressableIntHeap<KeyType, Arity, Compare> x;
     die_unequal(x.size(), 0u);
     die_if(!x.empty());
@@ -207,7 +208,7 @@ void d_ary_addressable_int_heap_test(size_t size, uint32_t r_seed = 42) {
 //! Tests update().
 template <typename KeyType, unsigned Arity = 2>
 void d_ary_heap_test_update(size_t size, std::vector<double>& prio,
-                            uint32_t r_seed = 42) {
+                            std::uint32_t r_seed = 42) {
     tlx::DAryAddressableIntHeap<KeyType, Arity, Comparator<KeyType> > x{
         Comparator<KeyType>(prio) };
     die_unequal(x.size(), 0u);
@@ -261,59 +262,59 @@ void d_ary_heap_test_update(size_t size, std::vector<double>& prio,
 int main() {
     // Size of the tested heaps and random seed.
     size_t size = 100;
-    uint32_t r_seed = 42;
+    std::uint32_t r_seed = 42;
 
     // Basic heap APIs with default compare functions.
-    d_ary_heap_test<uint8_t, 1>(size, r_seed);
-    d_ary_heap_test<uint8_t, 2>(size, r_seed);
-    d_ary_heap_test<uint8_t, 3>(size, r_seed);
-    d_ary_heap_test<uint8_t, 4>(size, r_seed);
-    d_ary_heap_test<uint8_t, 6>(size, r_seed);
-    d_ary_heap_test<uint8_t, 13>(size, r_seed);
-    d_ary_heap_test<uint16_t, 1>(size, r_seed);
-    d_ary_heap_test<uint16_t, 2>(size, r_seed);
-    d_ary_heap_test<uint16_t, 3>(size, r_seed);
-    d_ary_heap_test<uint32_t, 1>(size, r_seed);
-    d_ary_heap_test<uint32_t, 2>(size, r_seed);
-    d_ary_heap_test<uint32_t, 3>(size, r_seed);
-    d_ary_heap_test<uint32_t, 2>(size, r_seed);
-    d_ary_heap_test<uint32_t, 3>(size, r_seed);
-    d_ary_heap_test<uint64_t, 1>(size, r_seed);
-    d_ary_heap_test<uint64_t, 2>(size, r_seed);
-    d_ary_heap_test<uint64_t, 3>(size, r_seed);
+    d_ary_heap_test<std::uint8_t, 1>(size, r_seed);
+    d_ary_heap_test<std::uint8_t, 2>(size, r_seed);
+    d_ary_heap_test<std::uint8_t, 3>(size, r_seed);
+    d_ary_heap_test<std::uint8_t, 4>(size, r_seed);
+    d_ary_heap_test<std::uint8_t, 6>(size, r_seed);
+    d_ary_heap_test<std::uint8_t, 13>(size, r_seed);
+    d_ary_heap_test<std::uint16_t, 1>(size, r_seed);
+    d_ary_heap_test<std::uint16_t, 2>(size, r_seed);
+    d_ary_heap_test<std::uint16_t, 3>(size, r_seed);
+    d_ary_heap_test<std::uint32_t, 1>(size, r_seed);
+    d_ary_heap_test<std::uint32_t, 2>(size, r_seed);
+    d_ary_heap_test<std::uint32_t, 3>(size, r_seed);
+    d_ary_heap_test<std::uint32_t, 2>(size, r_seed);
+    d_ary_heap_test<std::uint32_t, 3>(size, r_seed);
+    d_ary_heap_test<std::uint64_t, 1>(size, r_seed);
+    d_ary_heap_test<std::uint64_t, 2>(size, r_seed);
+    d_ary_heap_test<std::uint64_t, 3>(size, r_seed);
 
-    d_ary_heap_test<uint8_t, 2, std::greater<uint8_t> >(size, r_seed);
-    d_ary_heap_test<uint16_t, 2, std::greater<uint16_t> >(size, r_seed);
-    d_ary_heap_test<uint32_t, 2, std::greater<uint32_t> >(size, r_seed);
-    d_ary_heap_test<uint64_t, 2, std::greater<uint64_t> >(size, r_seed);
+    d_ary_heap_test<std::uint8_t, 2, std::greater<std::uint8_t> >(size, r_seed);
+    d_ary_heap_test<std::uint16_t, 2, std::greater<std::uint16_t> >(size, r_seed);
+    d_ary_heap_test<std::uint32_t, 2, std::greater<std::uint32_t> >(size, r_seed);
+    d_ary_heap_test<std::uint64_t, 2, std::greater<std::uint64_t> >(size, r_seed);
 
     // Basic heap API with custom struct.
     d_ary_heap_test<TestData, 2, TestCompare>(size, r_seed);
     d_ary_heap_test<TestData, 3, TestCompare>(size, r_seed);
 
     // Basic heap APIs with default compare functions.
-    d_ary_addressable_int_heap_test<uint8_t, 1>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint8_t, 2>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint8_t, 3>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint8_t, 4>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint8_t, 6>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint8_t, 13>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint16_t, 1>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint16_t, 2>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint16_t, 3>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint32_t, 1>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint32_t, 2>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint32_t, 3>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint32_t, 2>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint32_t, 3>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint64_t, 1>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint64_t, 2>(size, r_seed);
-    d_ary_addressable_int_heap_test<uint64_t, 3>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint8_t, 1>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint8_t, 2>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint8_t, 3>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint8_t, 4>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint8_t, 6>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint8_t, 13>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint16_t, 1>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint16_t, 2>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint16_t, 3>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint32_t, 1>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint32_t, 2>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint32_t, 3>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint32_t, 2>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint32_t, 3>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint64_t, 1>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint64_t, 2>(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint64_t, 3>(size, r_seed);
 
-    d_ary_addressable_int_heap_test<uint8_t, 2, std::greater<uint8_t> >(size, r_seed);
-    d_ary_addressable_int_heap_test<uint16_t, 2, std::greater<uint16_t> >(size, r_seed);
-    d_ary_addressable_int_heap_test<uint32_t, 2, std::greater<uint32_t> >(size, r_seed);
-    d_ary_addressable_int_heap_test<uint64_t, 2, std::greater<uint64_t> >(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint8_t, 2, std::greater<std::uint8_t> >(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint16_t, 2, std::greater<std::uint16_t> >(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint32_t, 2, std::greater<std::uint32_t> >(size, r_seed);
+    d_ary_addressable_int_heap_test<std::uint64_t, 2, std::greater<std::uint64_t> >(size, r_seed);
 
     // Custom compare function.
     std::vector<double> prio(size);
@@ -324,12 +325,12 @@ int main() {
     }
 
     // Test heaps with custom priorities.
-    d_ary_heap_test_update<uint8_t, 1>(size, prio, r_seed);
-    d_ary_heap_test_update<uint8_t, 2>(size, prio, r_seed);
-    d_ary_heap_test_update<uint8_t, 3>(size, prio, r_seed);
-    d_ary_heap_test_update<uint16_t>(size, prio, r_seed);
-    d_ary_heap_test_update<uint32_t>(size, prio, r_seed);
-    d_ary_heap_test_update<uint64_t>(size, prio, r_seed);
+    d_ary_heap_test_update<std::uint8_t, 1>(size, prio, r_seed);
+    d_ary_heap_test_update<std::uint8_t, 2>(size, prio, r_seed);
+    d_ary_heap_test_update<std::uint8_t, 3>(size, prio, r_seed);
+    d_ary_heap_test_update<std::uint16_t>(size, prio, r_seed);
+    d_ary_heap_test_update<std::uint32_t>(size, prio, r_seed);
+    d_ary_heap_test_update<std::uint64_t>(size, prio, r_seed);
 
     return 0;
 }

--- a/tests/container/loser_tree_test.cpp
+++ b/tests/container/loser_tree_test.cpp
@@ -329,7 +329,7 @@ int main(int argc, char* argv[]) {
     clp.add_size_t('R', "outer_repeat", outer_repeat,
                    "Number of outer repetitions, default: 1");
 
-    uint32_t vector_size = 1000000;
+    std::uint32_t vector_size = 1000000;
     clp.add_bytes('s', "vector_size", vector_size,
                   "Length of vectors to merge, default: 1000000");
 

--- a/tests/container/radix_heap_test.cpp
+++ b/tests/container/radix_heap_test.cpp
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -204,13 +205,13 @@ void int_rank_test(std::mt19937& prng) {
 }
 
 void test_main_int_rank(std::mt19937& prng) {
-    int_rank_test<uint16_t>(prng);
-    int_rank_test<uint32_t>(prng);
-    int_rank_test<uint64_t>(prng);
+    int_rank_test<std::uint16_t>(prng);
+    int_rank_test<std::uint32_t>(prng);
+    int_rank_test<std::uint64_t>(prng);
 
-    int_rank_test<int16_t>(prng);
-    int_rank_test<int32_t>(prng);
-    int_rank_test<int64_t>(prng);
+    int_rank_test<std::int16_t>(prng);
+    int_rank_test<std::int32_t>(prng);
+    int_rank_test<std::int64_t>(prng);
 }
 
 /******************************************************************************/
@@ -252,29 +253,29 @@ void test_bucket_bounds() {
 }
 
 void test_main_bucket(std::mt19937&) {
-    test_bucket_bounds<2, uint32_t>();
-    test_bucket_bounds<8, uint32_t>();
-    test_bucket_bounds<64, uint32_t>();
-    test_bucket_bounds<2, uint64_t>();
-    test_bucket_bounds<8, uint64_t>();
-    test_bucket_bounds<64, uint64_t>();
+    test_bucket_bounds<2, std::uint32_t>();
+    test_bucket_bounds<8, std::uint32_t>();
+    test_bucket_bounds<64, std::uint32_t>();
+    test_bucket_bounds<2, std::uint64_t>();
+    test_bucket_bounds<8, std::uint64_t>();
+    test_bucket_bounds<64, std::uint64_t>();
 }
 
 /******************************************************************************/
 
 namespace tlx {
 
-using payload_type = uint64_t;
-using value_type = std::tuple<int64_t, payload_type>;
+using payload_type = std::uint64_t;
+using value_type = std::tuple<std::int64_t, payload_type>;
 
 class KeyExtractor
 {
 public:
-    int64_t operator () (const value_type& p) const { return std::get<0>(p); }
+    std::int64_t operator () (const value_type& p) const { return std::get<0>(p); }
 };
 
 // force instantiations
-template class RadixHeap<value_type, KeyExtractor, int64_t, /* Radix */ 64>;
+template class RadixHeap<value_type, KeyExtractor, std::int64_t, /* Radix */ 64>;
 
 } // namespace tlx
 
@@ -292,7 +293,7 @@ void allin_allout(std::mt19937& prng, KeyType min, KeyType max, size_t n) {
         "max=" << max << ", "
         "n=" << n << ")\n";
 
-    using payload_type = uint64_t;
+    using payload_type = std::uint64_t;
     using value_type = std::tuple<KeyType, payload_type>;
 
     auto heap = tlx::make_radix_heap<value_type, Radix>(
@@ -347,7 +348,7 @@ void allin_allout_pair(std::mt19937& prng, KeyType min, KeyType max, size_t n) {
         "max=" << max << ", "
         "n=" << n << ")\n";
 
-    using payload_type = uint64_t;
+    using payload_type = std::uint64_t;
 
     tlx::RadixHeapPair<KeyType, payload_type, Radix> heap;
     std::vector<std::pair<KeyType, payload_type> > values;
@@ -408,7 +409,7 @@ void random_inout(std::mt19937& prng, const KeyType min, const KeyType max,
         "prefill_n=" << prefill_n << ", "
         "pm=" << static_cast<int>(pm) << ")\n";
 
-    using payload_type = uint32_t;
+    using payload_type = std::uint32_t;
     using value_type = std::tuple<KeyType, payload_type>;
 
     auto heap = tlx::make_radix_heap<value_type, Radix>(
@@ -440,9 +441,9 @@ void random_inout(std::mt19937& prng, const KeyType min, const KeyType max,
 
     std::vector<payload_type> ref_data, heap_data;
 
-    for (int64_t i = 0; i < static_cast<int64_t>(iters) || !pq.empty(); i++) {
-        while (i < static_cast<int64_t>(iters) && rdist(prng) < insert_prob)
-            insert(running_min, max - std::max<int64_t>(0, iters - i));
+    for (std::int64_t i = 0; i < static_cast<std::int64_t>(iters) || !pq.empty(); i++) {
+        while (i < static_cast<std::int64_t>(iters) && rdist(prng) < insert_prob)
+            insert(running_min, max - std::max<std::int64_t>(0, iters - i));
 
         die_unequal(pq.empty(), heap.empty());
 
@@ -515,7 +516,7 @@ void random_inout_pair(std::mt19937& prng,
         "prefill_n=" << prefill_n << ", "
         "pm=" << static_cast<int>(pm) << ")\n";
 
-    using payload_type = uint32_t;
+    using payload_type = std::uint32_t;
     using pq_type = std::pair<KeyType, payload_type>;
     std::priority_queue<pq_type, std::vector<pq_type>, std::greater<pq_type> > pq;
     using heap_type = tlx::RadixHeapPair<KeyType, payload_type, Radix>;
@@ -543,10 +544,10 @@ void random_inout_pair(std::mt19937& prng,
 
     std::vector<payload_type> ref_data, heap_data;
 
-    for (int64_t i = 0; i < static_cast<int64_t>(iters) || !pq.empty(); i++) {
-        while (i < static_cast<int64_t>(iters) && rdist(prng) < insert_prob) {
+    for (std::int64_t i = 0; i < static_cast<std::int64_t>(iters) || !pq.empty(); i++) {
+        while (i < static_cast<std::int64_t>(iters) && rdist(prng) < insert_prob) {
             insert(running_min,
-                   static_cast<KeyType>(max - std::max<int64_t>(0, iters - i)));
+                   static_cast<KeyType>(max - std::max<std::int64_t>(0, iters - i)));
         }
 
         die_unequal(pq.empty(), heap.empty());
@@ -603,7 +604,7 @@ void random_inout_pair(std::mt19937& prng,
 }
 
 void random_inout_all(std::mt19937& prng,
-                      const int64_t min, const int64_t max,
+                      const std::int64_t min, const std::int64_t max,
                       const size_t iters, const double insert_prob,
                       const size_t prefill_n, const PullMode pm) {
 #define RADIXHEAP_TESTSET(T)                                                 \
@@ -619,17 +620,17 @@ void random_inout_all(std::mt19937& prng,
     die_unless(min < max);
 
     if (min >= 0 && max >= 0) {
-        RADIXHEAP_TESTSET(uint32_t)
-        RADIXHEAP_TESTSET(uint64_t)
+        RADIXHEAP_TESTSET(std::uint32_t)
+        RADIXHEAP_TESTSET(std::uint64_t)
     }
 
-    RADIXHEAP_TESTSET(int32_t)
-    RADIXHEAP_TESTSET(int64_t)
+    RADIXHEAP_TESTSET(std::int32_t)
+    RADIXHEAP_TESTSET(std::int64_t)
 
 #undef RADIXHEAP_TESTSET
 }
 
-void allin_allout_all(std::mt19937& prng, int64_t min, int64_t max, size_t n) {
+void allin_allout_all(std::mt19937& prng, std::int64_t min, std::int64_t max, size_t n) {
 #define RADIXHEAP_TESTSET(T)                                                    \
     allin_allout<T, 2>(prng, static_cast<T>(min), static_cast<T>(max), n);      \
     allin_allout<T, 64>(prng, static_cast<T>(min), static_cast<T>(max), n);     \
@@ -637,18 +638,18 @@ void allin_allout_all(std::mt19937& prng, int64_t min, int64_t max, size_t n) {
     allin_allout_pair<T, 64>(prng, static_cast<T>(min), static_cast<T>(max), n);
 
     if (min >= 0) {
-        RADIXHEAP_TESTSET(uint32_t);
-        RADIXHEAP_TESTSET(uint64_t);
+        RADIXHEAP_TESTSET(std::uint32_t);
+        RADIXHEAP_TESTSET(std::uint64_t);
     }
 
-    RADIXHEAP_TESTSET(int32_t);
-    RADIXHEAP_TESTSET(int64_t);
+    RADIXHEAP_TESTSET(std::int32_t);
+    RADIXHEAP_TESTSET(std::int64_t);
 
 #undef RADIXHEAP_TESTSET
 }
 
 void test_main_radix_heap_pair(std::mt19937& prng) {
-    for (int64_t min : { 0, 1000000, -1000000 }) {
+    for (std::int64_t min : { 0, 1000000, -1000000 }) {
         for (size_t x : { 1000, 1000000 }) {
             allin_allout_all(prng, min, min + x, 500);
         }
@@ -656,8 +657,8 @@ void test_main_radix_heap_pair(std::mt19937& prng) {
 
     for (PullMode pm : { PullMode::Single, PullMode::AllOfKey,
                          PullMode::ExtractBucket }) {
-        for (int64_t prefill : { 0, 100 }) {
-            for (int64_t min : { 0, 10000000, -10000000, -250 }) {
+        for (std::int64_t prefill : { 0, 100 }) {
+            for (std::int64_t min : { 0, 10000000, -10000000, -250 }) {
                 for (size_t length : { 500 }) {
                     random_inout_all(prng, min, min + length, 200, 0.9, prefill, pm);
                 }

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <random>
 #include <vector>
 
@@ -30,16 +31,16 @@ static void test_bswap() {
 
 static void test_clz() {
 
-    die_unequal(tlx::clz_template<uint8_t>(0), 8u);
-    die_unequal(tlx::clz_template<uint16_t>(0), 16u);
-    die_unequal(tlx::clz_template<uint32_t>(0), 32u);
-    die_unequal(tlx::clz_template<uint64_t>(0), 64u);
+    die_unequal(tlx::clz_template<std::uint8_t>(0), 8u);
+    die_unequal(tlx::clz_template<std::uint16_t>(0), 16u);
+    die_unequal(tlx::clz_template<std::uint32_t>(0), 32u);
+    die_unequal(tlx::clz_template<std::uint64_t>(0), 64u);
 
-    die_unequal(tlx::clz<uint32_t>(0), 32u);
-    die_unequal(tlx::clz<uint64_t>(0), 64u);
+    die_unequal(tlx::clz<std::uint32_t>(0), 32u);
+    die_unequal(tlx::clz<std::uint64_t>(0), 64u);
 
     unsigned bitpos = 0;
-    for (uint64_t i = 1llu << 63; i != 0; i >>= 1, ++bitpos)
+    for (std::uint64_t i = 1llu << 63; i != 0; i >>= 1, ++bitpos)
     {
         if (i > 1) {
             die_unequal(tlx::clz(i - 1), bitpos + 1);
@@ -55,35 +56,35 @@ static void test_clz() {
         }
     }
 
-    die_unequal(tlx::clz<uint32_t>(0x0100), 31u - 8u);
-    die_unequal(tlx::clz<uint64_t>(0x0100), 63u - 8u);
+    die_unequal(tlx::clz<std::uint32_t>(0x0100), 31u - 8u);
+    die_unequal(tlx::clz<std::uint64_t>(0x0100), 63u - 8u);
 
-    die_unequal(tlx::clz_template<uint32_t>(0x0100), 31u - 8u);
-    die_unequal(tlx::clz_template<uint64_t>(0x0100), 63u - 8u);
+    die_unequal(tlx::clz_template<std::uint32_t>(0x0100), 31u - 8u);
+    die_unequal(tlx::clz_template<std::uint64_t>(0x0100), 63u - 8u);
 }
 
 static void test_ctz() {
 
-    die_unequal(tlx::ctz_template<uint8_t>(0), 8u);
-    die_unequal(tlx::ctz_template<uint16_t>(0), 16u);
-    die_unequal(tlx::ctz_template<uint32_t>(0), 32u);
-    die_unequal(tlx::ctz_template<uint64_t>(0), 64u);
+    die_unequal(tlx::ctz_template<std::uint8_t>(0), 8u);
+    die_unequal(tlx::ctz_template<std::uint16_t>(0), 16u);
+    die_unequal(tlx::ctz_template<std::uint32_t>(0), 32u);
+    die_unequal(tlx::ctz_template<std::uint64_t>(0), 64u);
 
-    die_unequal(tlx::ctz<uint32_t>(0), 32u);
-    die_unequal(tlx::ctz<uint64_t>(0), 64u);
+    die_unequal(tlx::ctz<std::uint32_t>(0), 32u);
+    die_unequal(tlx::ctz<std::uint64_t>(0), 64u);
 
     unsigned bitpos = 0;
-    for (uint64_t i = (~0llu); i != 0; i <<= 1, ++bitpos)
+    for (std::uint64_t i = (~0llu); i != 0; i <<= 1, ++bitpos)
     {
         die_unequal(tlx::ctz(i), bitpos);
         die_unequal(tlx::ctz_template(i), bitpos);
     }
 
-    die_unequal(tlx::ctz<uint32_t>(0x0100), 8u);
-    die_unequal(tlx::ctz<uint64_t>(0x0100), 8u);
+    die_unequal(tlx::ctz<std::uint32_t>(0x0100), 8u);
+    die_unequal(tlx::ctz<std::uint64_t>(0x0100), 8u);
 
-    die_unequal(tlx::ctz_template<uint32_t>(0x0100), 8u);
-    die_unequal(tlx::ctz_template<uint64_t>(0x0100), 8u);
+    die_unequal(tlx::ctz_template<std::uint32_t>(0x0100), 8u);
+    die_unequal(tlx::ctz_template<std::uint64_t>(0x0100), 8u);
 }
 
 static void test_ffs() {
@@ -92,7 +93,7 @@ static void test_ffs() {
     die_unequal(tlx::ffs_template(0), 0u);
 
     unsigned power = 0;
-    for (uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
+    for (std::uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
     {
         if (i > 1) {
             die_unequal(tlx::ffs(i - 1), 1u);
@@ -112,7 +113,7 @@ static void test_ffs() {
 static void test_integer_log2() {
 
     unsigned power = 0;
-    for (uint32_t i = 1; i < (1lu << 31); i <<= 1, ++power)
+    for (std::uint32_t i = 1; i < (1lu << 31); i <<= 1, ++power)
     {
         if (i > 1) {
             die_unequal(tlx::integer_log2_floor(i - 1), power - 1);
@@ -136,7 +137,7 @@ static void test_integer_log2() {
     }
 
     power = 0;
-    for (int64_t i = 1; i < (1ll << 62); i <<= 1, ++power)
+    for (std::int64_t i = 1; i < (1ll << 62); i <<= 1, ++power)
     {
         if (i > 1) {
             die_unequal(tlx::integer_log2_floor(i - 1), power - 1);
@@ -160,7 +161,7 @@ static void test_integer_log2() {
     }
 
     power = 0;
-    for (uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
+    for (std::uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
     {
         if (i > 1) {
             die_unequal(tlx::integer_log2_floor(i - 1), power - 1);
@@ -187,7 +188,7 @@ static void test_integer_log2() {
 static void test_is_power_of_two() {
 
     unsigned power = 0;
-    for (uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
+    for (std::uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
     {
         die_if(tlx::is_power_of_two(i - 1) && i != 2);
         die_unless(tlx::is_power_of_two(i));
@@ -212,7 +213,7 @@ static void test_popcount() {
     // for (size_t i = 0; i < 0xFFFFFFFFFF; ++i)
     //     die_unequal(tlx::popcount(i), tlx::popcount_generic64(i));
 
-    std::vector<uint8_t> data;
+    std::vector<std::uint8_t> data;
     for (size_t i = 0; i < 20; ++i) {
         die_unequal(tlx::popcount(data.data(), data.size()), 2 * i);
         data.push_back(0x11);
@@ -242,7 +243,7 @@ static void test_power_to_the_real() {
 
 template <unsigned D = 7>
 static void test_power_to_the_int() {
-    using T = int64_t;
+    using T = std::int64_t;
 
     for (auto x = T{ -100 }; x < 100; ++x) {
         const auto tested = tlx::power_to_the<D>(x);
@@ -307,7 +308,7 @@ static void test_ror() {
 static void test_round_to_power_of_two() {
 
     unsigned power = 0;
-    for (uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
+    for (std::uint64_t i = 1; i < (1llu << 63); i <<= 1, ++power)
     {
         if (i > 2)
             die_unequal(tlx::round_up_to_power_of_two(i - 1), i);

--- a/tests/siphash_test.cpp
+++ b/tests/siphash_test.cpp
@@ -15,7 +15,7 @@
 
 #include <tlx/die.hpp>
 
-static const uint64_t test_vectors_data[64] = {
+static const std::uint64_t test_vectors_data[64] = {
     0x726fdb47dd0e0e31ull, 0x74f839c593dc67fdull, 0x0d6c8009d9a94f5aull,
     0x85676696d7fb7e2dull, 0xcf2794e0277187b7ull, 0x18765564cd99a68dull,
     0xcbc9466e58fee3ceull, 0xab0200f58b01d137ull, 0x93f5f5799a932462ull,
@@ -49,10 +49,10 @@ void test_vectors() {
 
     for (size_t i = 0; i < 64; i++) {
         msg[i] = i;
-        uint64_t res1 = tlx::siphash(key, msg, i);
+        std::uint64_t res1 = tlx::siphash(key, msg, i);
         die_unequal(res1, test_vectors_data[i]);
 
-        uint64_t res2 = tlx::siphash_plain(key, msg, i);
+        std::uint64_t res2 = tlx::siphash_plain(key, msg, i);
         die_unequal(res2, test_vectors_data[i]);
     }
 }

--- a/tests/sort_strings_example.cpp
+++ b/tests/sort_strings_example.cpp
@@ -16,6 +16,7 @@
 #include <tlx/sort/strings.hpp>
 #include <tlx/sort/strings_parallel.hpp>
 
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -52,8 +53,8 @@ int main(int argc, char* argv[]) {
     size_t size = in.tellg();
 
     // allocate uninitialized memory area and string pointer array
-    tlx::simple_vector<uint8_t> data(size + 8);
-    std::vector<uint8_t*> strings;
+    tlx::simple_vector<std::uint8_t> data(size + 8);
+    std::vector<std::uint8_t*> strings;
 
     // read file and make string pointer array
     double ts1_read = tlx::timestamp();
@@ -69,7 +70,7 @@ int main(int argc, char* argv[]) {
         size_t rem = std::min<size_t>(2 * 1024 * 1024u, size - pos);
         in.read(reinterpret_cast<char*>(data.data() + pos), rem);
 
-        uint8_t* chunk = data.data() + pos;
+        std::uint8_t* chunk = data.data() + pos;
 
         for (size_t i = 0; i < rem; ++i) {
             if (chunk[i] == '\n') {

--- a/tests/sort_strings_parallel_test.cpp
+++ b/tests/sort_strings_parallel_test.cpp
@@ -48,14 +48,14 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
          << " uint8_t* strings";
 
     // array of string pointers
-    tlx::simple_vector<uint8_t*> cstrings(num_strings);
+    tlx::simple_vector<std::uint8_t*> cstrings(num_strings);
 
     // generate random strings of length num_chars
     for (size_t i = 0; i < num_strings; ++i)
     {
         size_t slen = num_chars + (rng() >> 8) % (num_chars / 4);
 
-        cstrings[i] = new uint8_t[slen + 1];
+        cstrings[i] = new std::uint8_t[slen + 1];
         fill_random(rng, letters, cstrings[i], cstrings[i] + slen);
         cstrings[i][slen] = 0;
     }
@@ -79,7 +79,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
     }
 
     // array of const string pointers
-    tlx::simple_vector<const uint8_t*> ccstrings(num_strings);
+    tlx::simple_vector<const std::uint8_t*> ccstrings(num_strings);
 
     for (size_t i = 0; i < num_strings; ++i)
         ccstrings[i] = cstrings[i];
@@ -112,7 +112,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
     {
         double ts1 = tlx::timestamp();
 
-        tlx::simple_vector<uint32_t> lcp(num_strings);
+        tlx::simple_vector<std::uint32_t> lcp(num_strings);
 
         tlx::sort_strings_parallel_lcp(
             ccstrings.data(), num_strings, lcp.data());

--- a/tests/sort_strings_test.cpp
+++ b/tests/sort_strings_test.cpp
@@ -16,6 +16,7 @@
 #include <tlx/sort/strings/multikey_quicksort.hpp>
 #include <tlx/sort/strings/radix_sort.hpp>
 
+#include <cstdint>
 #include <tlx/sort/strings.hpp>
 
 void TestFrontend(const size_t num_strings, const size_t num_chars,
@@ -27,14 +28,14 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
          << " uint8_t* strings";
 
     // array of string pointers
-    tlx::simple_vector<uint8_t*> cstrings(num_strings);
+    tlx::simple_vector<std::uint8_t*> cstrings(num_strings);
 
     // generate random strings of length num_chars
     for (size_t i = 0; i < num_strings; ++i)
     {
         size_t slen = num_chars + (rng() >> 8) % (num_chars / 4);
 
-        cstrings[i] = new uint8_t[slen + 1];
+        cstrings[i] = new std::uint8_t[slen + 1];
         fill_random(rng, letters, cstrings[i], cstrings[i] + slen);
         cstrings[i][slen] = 0;
     }
@@ -58,7 +59,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
     }
 
     // array of const string pointers
-    tlx::simple_vector<const uint8_t*> ccstrings(num_strings);
+    tlx::simple_vector<const std::uint8_t*> ccstrings(num_strings);
 
     for (size_t i = 0; i < num_strings; ++i)
         ccstrings[i] = cstrings[i];
@@ -91,7 +92,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
     {
         double ts1 = tlx::timestamp();
 
-        tlx::simple_vector<uint32_t> lcp(num_strings);
+        tlx::simple_vector<std::uint32_t> lcp(num_strings);
 
         tlx::sort_strings_lcp(
             ccstrings.data(), num_strings, lcp.data(), /* memory */ 0);

--- a/tests/sort_strings_test.hpp
+++ b/tests/sort_strings_test.hpp
@@ -20,6 +20,7 @@
 #include <tlx/timestamp.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <random>
 
 #if TLX_MORE_TESTS
@@ -98,14 +99,14 @@ void TestUCharString(const char* name,
          << " uint8_t* strings" << (with_lcp ? " with lcps" : "");
 
     // array of string pointers
-    tlx::simple_vector<uint8_t*> cstrings(num_strings);
+    tlx::simple_vector<std::uint8_t*> cstrings(num_strings);
 
     // generate random strings of length num_chars
     for (size_t i = 0; i < num_strings; ++i)
     {
         size_t slen = num_chars + (rng() >> 8) % (num_chars / 4);
 
-        cstrings[i] = new uint8_t[slen + 1];
+        cstrings[i] = new std::uint8_t[slen + 1];
         fill_random_lognormal(rng, letters, cstrings[i], cstrings[i] + slen);
         cstrings[i][slen] = 0;
     }
@@ -131,10 +132,10 @@ void TestUCharString(const char* name,
         // run sorting algorithm with lcp output
         double ts1 = tlx::timestamp();
 
-        tlx::simple_vector<uint32_t> lcp(num_strings);
+        tlx::simple_vector<std::uint32_t> lcp(num_strings);
 
         UCharStringSet ss(cstrings.data(), cstrings.data() + num_strings);
-        lcp_sorter(StringLcpPtr<UCharStringSet, uint32_t>(ss, lcp.data()),
+        lcp_sorter(StringLcpPtr<UCharStringSet, std::uint32_t>(ss, lcp.data()),
                    /* depth */ 0, /* memory */ 0);
         if (0) ss.print();
 
@@ -206,10 +207,10 @@ void TestVectorStdString(const char* name,
         // run sorting algorithm with lcp output
         double ts1 = tlx::timestamp();
 
-        tlx::simple_vector<uint32_t> lcp(num_strings);
+        tlx::simple_vector<std::uint32_t> lcp(num_strings);
 
         StdStringSet ss(strings.data(), strings.data() + strings.size());
-        lcp_sorter(StringLcpPtr<StdStringSet, uint32_t>(ss, lcp.data()),
+        lcp_sorter(StringLcpPtr<StdStringSet, std::uint32_t>(ss, lcp.data()),
                    /* depth */ 0, /* memory */ 0);
         if (0) ss.print();
 
@@ -274,10 +275,10 @@ void TestUPtrStdString(const char* name,
         // run sorting algorithm with lcp output
         double ts1 = tlx::timestamp();
 
-        tlx::simple_vector<uint32_t> lcp(num_strings);
+        tlx::simple_vector<std::uint32_t> lcp(num_strings);
 
         UPtrStdStringSet ss(strings.data(), strings.data() + strings.size());
-        lcp_sorter(StringLcpPtr<UPtrStdStringSet, uint32_t>(ss, lcp.data()),
+        lcp_sorter(StringLcpPtr<UPtrStdStringSet, std::uint32_t>(ss, lcp.data()),
                    /* depth */ 0, /* memory */ 0);
         if (0) ss.print();
 
@@ -333,21 +334,21 @@ static const char* letters_alnum
       "\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF";
 
 // use macro because one cannot pass template functions as template parameters:
-#define run_tests(func)                                          \
-    TestUCharString<UCharStringSet, func, uint32_t, func>(       \
-        #func, num_strings, 16, letters_alnum, /* lcp */ false); \
-    TestUCharString<UCharStringSet, func, uint32_t, func>(       \
-        #func, num_strings, 17, letters_alnum, /* lcp */ true);  \
-    TestVectorStdString<StdStringSet, func, uint32_t, func>(     \
-        #func, num_strings, 16, letters_alnum, /* lcp */ false); \
-    TestVectorStdString<StdStringSet, func, uint32_t, func>(     \
-        #func, num_strings, 17, letters_alnum, /* lcp */ true);  \
-    TestUPtrStdString<UPtrStdStringSet, func, uint32_t, func>(   \
-        #func, num_strings, 16, letters_alnum, /* lcp */ false); \
-    TestUPtrStdString<UPtrStdStringSet, func, uint32_t, func>(   \
-        #func, num_strings, 18, letters_alnum, /* lcp */ true);  \
-    TestStringSuffixString<StringSuffixSet, func>(               \
-        #func, num_strings, letters_alnum);                      \
+#define run_tests(func)                                             \
+    TestUCharString<UCharStringSet, func, std::uint32_t, func>(     \
+        #func, num_strings, 16, letters_alnum, /* lcp */ false);    \
+    TestUCharString<UCharStringSet, func, std::uint32_t, func>(     \
+        #func, num_strings, 17, letters_alnum, /* lcp */ true);     \
+    TestVectorStdString<StdStringSet, func, std::uint32_t, func>(   \
+        #func, num_strings, 16, letters_alnum, /* lcp */ false);    \
+    TestVectorStdString<StdStringSet, func, std::uint32_t, func>(   \
+        #func, num_strings, 17, letters_alnum, /* lcp */ true);     \
+    TestUPtrStdString<UPtrStdStringSet, func, std::uint32_t, func>( \
+        #func, num_strings, 16, letters_alnum, /* lcp */ false);    \
+    TestUPtrStdString<UPtrStdStringSet, func, std::uint32_t, func>( \
+        #func, num_strings, 18, letters_alnum, /* lcp */ true);     \
+    TestStringSuffixString<StringSuffixSet, func>(                  \
+        #func, num_strings, letters_alnum);                         \
 
 #endif // !TLX_TESTS_SORT_STRINGS_TEST_HEADER
 

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -8,6 +8,7 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <cstdint>
 #include <random>
 #include <stdexcept>
 
@@ -138,14 +139,14 @@ static void test_bitdump() {
                 "00001100 10001100 01001100 11001100");
 
 #if TLX_LITTLE_ENDIAN
-    die_unequal(tlx::bitdump_8_msb_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_8_msb_type(std::uint16_t(0x1234)),
                 "00110100 00010010");
-    die_unequal(tlx::bitdump_8_lsb_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_8_lsb_type(std::uint16_t(0x1234)),
                 "00101100 01001000");
 #else
-    die_unequal(tlx::bitdump_8_msb_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_8_msb_type(std::uint16_t(0x1234)),
                 "00010010 00110100");
-    die_unequal(tlx::bitdump_8_lsb_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_8_lsb_type(std::uint16_t(0x1234)),
                 "01001000 00101100");
 #endif
 
@@ -156,14 +157,14 @@ static void test_bitdump() {
                 "00001100 10001100 01001100 11001100");
 
 #if TLX_LITTLE_ENDIAN
-    die_unequal(tlx::bitdump_le8_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_le8_type(std::uint16_t(0x1234)),
                 "00110100 00010010");
-    die_unequal(tlx::bitdump_be8_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_be8_type(std::uint16_t(0x1234)),
                 "00101100 01001000");
 #else
-    die_unequal(tlx::bitdump_le8_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_le8_type(std::uint16_t(0x1234)),
                 "00010010 00110100");
-    die_unequal(tlx::bitdump_be8_type(uint16_t(0x1234)),
+    die_unequal(tlx::bitdump_be8_type(std::uint16_t(0x1234)),
                 "01001000 00101100");
 #endif
 }
@@ -314,16 +315,17 @@ static void test_hexdump() {
     // hexdump_sourcecode())
     std::string hexsource = tlx::hexdump_sourcecode(hexdata, "abc");
 
-    const unsigned char hexsourcecmp[68] = {
-        0x63, 0x6F, 0x6E, 0x73, 0x74, 0x20, 0x75, 0x69,
-        0x6E, 0x74, 0x38, 0x5F, 0x74, 0x20, 0x61, 0x62,
-        0x63, 0x5B, 0x38, 0x5D, 0x20, 0x3D, 0x20, 0x7B,
-        0x0A, 0x30, 0x78, 0x38, 0x44, 0x2C, 0x30, 0x78,
-        0x45, 0x32, 0x2C, 0x30, 0x78, 0x38, 0x35, 0x2C,
-        0x30, 0x78, 0x44, 0x34, 0x2C, 0x30, 0x78, 0x42,
-        0x46, 0x2C, 0x30, 0x78, 0x39, 0x38, 0x2C, 0x30,
-        0x78, 0x45, 0x36, 0x2C, 0x30, 0x78, 0x30, 0x33,
-        0x0A, 0x7D, 0x3B, 0x0A
+    const unsigned char hexsourcecmp[73] = {
+        0x63, 0x6F, 0x6E, 0x73, 0x74, 0x20, 0x73, 0x74,
+        0x64, 0x3A, 0x3A, 0x75, 0x69, 0x6E, 0x74, 0x38,
+        0x5F, 0x74, 0x20, 0x61, 0x62, 0x63, 0x5B, 0x38,
+        0x5D, 0x20, 0x3D, 0x20, 0x7B, 0x0A, 0x30, 0x78,
+        0x38, 0x44, 0x2C, 0x30, 0x78, 0x45, 0x32, 0x2C,
+        0x30, 0x78, 0x38, 0x35, 0x2C, 0x30, 0x78, 0x44,
+        0x34, 0x2C, 0x30, 0x78, 0x42, 0x46, 0x2C, 0x30,
+        0x78, 0x39, 0x38, 0x2C, 0x30, 0x78, 0x45, 0x36,
+        0x2C, 0x30, 0x78, 0x30, 0x33, 0x0A, 0x7D, 0x3B,
+        0x0A
     };
 
     die_unequal(hexsource, ARRAY_AS_STRING(hexsourcecmp));
@@ -362,7 +364,7 @@ static void test_levenshtein() {
 
 static void test_parse_si_iec_units() {
 
-    uint64_t size;
+    std::uint64_t size;
     die_unless(tlx::parse_si_iec_units(" 33 GiB ", &size));
     die_unequal(33 * 1024 * 1024 * 1024LLU, size);
 

--- a/tests/thread_barrier_test.cpp
+++ b/tests/thread_barrier_test.cpp
@@ -13,6 +13,7 @@
 // this makes yield() available in older GCC versions
 #define _GLIBCXX_USE_SCHED_YIELD
 
+#include <cstdint>
 #include <random>
 #include <thread>
 
@@ -28,7 +29,7 @@ static void TestWaitFor(int count, int slowThread = -1) {
 
     ThreadBarrier barrier(count);
 
-    tlx::simple_vector<uint8_t> flags(count);
+    tlx::simple_vector<std::uint8_t> flags(count);
     tlx::simple_vector<std::thread> threads(count);
 
     for (int i = 0; i < count; i++) {

--- a/tlx/cmdline_parser.cpp
+++ b/tlx/cmdline_parser.cpp
@@ -11,6 +11,7 @@
 #include <tlx/cmdline_parser.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>
@@ -302,13 +303,13 @@ class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentBytes32 final
     : public Argument
 {
 protected:
-    uint32_t& dest_;
+    std::uint32_t& dest_;
 
 public:
     //! contructor filling most attributes
     ArgumentBytes32(char key, const std::string& longkey,
                     const std::string& keytype, const std::string& desc,
-                    bool required, uint32_t& dest) // NOLINT
+                    bool required, std::uint32_t& dest)     // NOLINT
         : Argument(key, longkey, keytype, desc, required), dest_(dest) { }
 
     const char * type_name() const final { return "bytes"; }
@@ -317,10 +318,10 @@ public:
     bool process(int& argc, const char* const*& argv) final { // NOLINT
         if (argc == 0)
             return false;
-        uint64_t dest;
+        std::uint64_t dest;
         if (parse_si_iec_units(argv[0], &dest) &&
-            static_cast<uint64_t>(
-                dest_ = static_cast<uint32_t>(dest)) == dest) {
+            static_cast<std::uint64_t>(
+                dest_ = static_cast<std::uint32_t>(dest)) == dest) {
             --argc, ++argv;
             return true;
         }
@@ -337,13 +338,13 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentBytes64 final : public Argument
 {
 protected:
-    uint64_t& dest_;
+    std::uint64_t& dest_;
 
 public:
     //! contructor filling most attributes
     ArgumentBytes64(char key, const std::string& longkey,
                     const std::string& keytype, const std::string& desc,
-                    bool required, uint64_t& dest) // NOLINT
+                    bool required, std::uint64_t& dest)         // NOLINT
         : Argument(key, longkey, keytype, desc, required), dest_(dest) { }
 
     const char * type_name() const final { return "bytes"; }
@@ -574,7 +575,7 @@ void CmdlineParser::add_double(char key, const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              const std::string& keytype, uint32_t& dest,
+                              const std::string& keytype, std::uint32_t& dest,
                               const std::string& desc) {
     option_list_.emplace_back(
         new ArgumentBytes32(key, longkey, keytype, desc, false, dest));
@@ -582,7 +583,7 @@ void CmdlineParser::add_bytes(char key, const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              const std::string& keytype, uint64_t& dest,
+                              const std::string& keytype, std::uint64_t& dest,
                               const std::string& desc) {
     option_list_.emplace_back(
         new ArgumentBytes64(key, longkey, keytype, desc, false, dest));
@@ -650,12 +651,12 @@ void CmdlineParser::add_double(char key, const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              uint32_t& dest, const std::string& desc) {
+                              std::uint32_t& dest, const std::string& desc) {
     return add_bytes(key, longkey, "", dest, desc);
 }
 
 void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              uint64_t& dest, const std::string& desc) {
+                              std::uint64_t& dest, const std::string& desc) {
     return add_bytes(key, longkey, "", dest, desc);
 }
 
@@ -713,12 +714,12 @@ void CmdlineParser::add_double(const std::string& longkey,
 }
 
 void CmdlineParser::add_bytes(const std::string& longkey,
-                              uint32_t& dest, const std::string& desc) {
+                              std::uint32_t& dest, const std::string& desc) {
     return add_bytes(0, longkey, "", dest, desc);
 }
 
 void CmdlineParser::add_bytes(const std::string& longkey,
-                              uint64_t& dest, const std::string& desc) {
+                              std::uint64_t& dest, const std::string& desc) {
     return add_bytes(0, longkey, "", dest, desc);
 }
 
@@ -772,14 +773,14 @@ void CmdlineParser::add_param_double(
 }
 
 void CmdlineParser::add_param_bytes(
-    const std::string& name, uint32_t& dest, const std::string& desc) {
+    const std::string& name, std::uint32_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes32(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
 void CmdlineParser::add_param_bytes(
-    const std::string& name, uint64_t& dest, const std::string& desc) {
+    const std::string& name, std::uint64_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes64(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
@@ -839,14 +840,14 @@ void CmdlineParser::add_opt_param_double(
 }
 
 void CmdlineParser::add_opt_param_bytes(
-    const std::string& name, uint32_t& dest, const std::string& desc) {
+    const std::string& name, std::uint32_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes32(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
 void CmdlineParser::add_opt_param_bytes(
-    const std::string& name, uint64_t& dest, const std::string& desc) {
+    const std::string& name, std::uint64_t& dest, const std::string& desc) {
     param_list_.emplace_back(
         new ArgumentBytes64(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());

--- a/tlx/cmdline_parser.hpp
+++ b/tlx/cmdline_parser.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_CMDLINE_PARSER_HEADER
 #define TLX_CMDLINE_PARSER_HEADER
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -198,12 +199,12 @@ public:
     //! add SI/IEC suffixes byte size option -key, --longkey and store to 32-bit
     //! dest
     void add_bytes(char key, const std::string& longkey,
-                   uint32_t& dest, const std::string& desc); // NOLINT
+                   std::uint32_t& dest, const std::string& desc); // NOLINT
 
     //! add SI/IEC suffixes byte size option -key, --longkey and store to 64-bit
     //! dest
     void add_bytes(char key, const std::string& longkey,
-                   uint64_t& dest, const std::string& desc); // NOLINT
+                   std::uint64_t& dest, const std::string& desc); // NOLINT
 
     //! add string option -key, --longkey and store to dest
     void add_string(char key, const std::string& longkey,
@@ -257,11 +258,11 @@ public:
 
     //! add SI/IEC suffixes byte size option --longkey and store to 32-bit dest
     void add_bytes(const std::string& longkey,
-                   uint32_t& dest, const std::string& desc); // NOLINT
+                   std::uint32_t& dest, const std::string& desc); // NOLINT
 
     //! add SI/IEC suffixes byte size option --longkey and store to 64-bit dest
     void add_bytes(const std::string& longkey,
-                   uint64_t& dest, const std::string& desc); // NOLINT
+                   std::uint64_t& dest, const std::string& desc); // NOLINT
 
     //! add string option --longkey and store to dest
     void add_string(const std::string& longkey,
@@ -339,14 +340,14 @@ public:
     //! store to 64-bit dest
     void add_bytes(
         char key, const std::string& longkey,
-        const std::string& keytype, uint32_t& dest, // NOLINT
+        const std::string& keytype, std::uint32_t& dest, // NOLINT
         const std::string& desc);
 
     //! add SI/IEC suffixes byte size option -key, --longkey [keytype] and
     //! store to 64-bit dest
     void add_bytes(
         char key, const std::string& longkey,
-        const std::string& keytype, uint64_t& dest, // NOLINT
+        const std::string& keytype, std::uint64_t& dest, // NOLINT
         const std::string& desc);
 
     //! add string option -key, --longkey [keytype] and store to dest
@@ -401,13 +402,13 @@ public:
     //! add SI/IEC suffixes byte size parameter [name] with description and
     //! store to dest
     void add_param_bytes(
-        const std::string& name, uint32_t& dest, // NOLINT
+        const std::string& name, std::uint32_t& dest, // NOLINT
         const std::string& desc);
 
     //! add SI/IEC suffixes byte size parameter [name] with description and
     //! store to dest
     void add_param_bytes(
-        const std::string& name, uint64_t& dest, // NOLINT
+        const std::string& name, std::uint64_t& dest, // NOLINT
         const std::string& desc);
 
     //! add string parameter [name] with description and store to dest
@@ -464,13 +465,13 @@ public:
     //! add optional SI/IEC suffixes byte size parameter [name] with
     //! description and store to dest
     void add_opt_param_bytes(
-        const std::string& name, uint32_t& dest, // NOLINT
+        const std::string& name, std::uint32_t& dest, // NOLINT
         const std::string& desc);
 
     //! add optional SI/IEC suffixes byte size parameter [name] with
     //! description and store to dest
     void add_opt_param_bytes(
-        const std::string& name, uint64_t& dest, // NOLINT
+        const std::string& name, std::uint64_t& dest, // NOLINT
         const std::string& desc);
 
     //! add optional string parameter [name] with description and store to dest

--- a/tlx/container/loser_tree.hpp
+++ b/tlx/container/loser_tree.hpp
@@ -56,7 +56,7 @@ class LoserTreeCopyBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);
@@ -308,7 +308,7 @@ class LoserTreePointerBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);
@@ -530,7 +530,7 @@ class LoserTreeCopyUnguardedBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);
@@ -706,7 +706,7 @@ class LoserTreePointerUnguardedBase
 {
 public:
     //! size of counters and array indexes
-    using Source = uint32_t;
+    using Source = std::uint32_t;
 
     //! sentinel for invalid or finished Sources
     static constexpr Source invalid_ = Source(-1);

--- a/tlx/container/radix_heap.hpp
+++ b/tlx/container/radix_heap.hpp
@@ -14,6 +14,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 #include <utility>
@@ -169,7 +170,7 @@ class BitArrayRecursive<Size, true>
 {
     static_assert(Size <= 64, "Support at most 64 bits");
     using uint_type = typename std::conditional<
-        Size <= 32, uint32_t, uint64_t>::type;
+        Size <= 32, std::uint32_t, std::uint64_t>::type;
 
 public:
     static constexpr size_t size = Size;

--- a/tlx/container/ring_buffer.hpp
+++ b/tlx/container/ring_buffer.hpp
@@ -313,7 +313,7 @@ public:
 
     template <class Archive>
     void save(Archive& ar) const { // NOLINT
-        uint32_t ar_size = size();
+        std::uint32_t ar_size = size();
         ar(max_size_, ar_size);
         for (size_t i = 0; i < ar_size; ++i) ar(operator [] (i));
     }
@@ -334,7 +334,7 @@ public:
         begin_ = end_ = 0;
 
         // load items
-        uint32_t ar_size;
+        std::uint32_t ar_size;
         ar(ar_size);
 
         for (size_t i = 0; i < ar_size; ++i) {

--- a/tlx/delegate.hpp
+++ b/tlx/delegate.hpp
@@ -279,7 +279,7 @@ public:
     //! compare delegate with another
     bool operator < (Delegate const& rhs) const noexcept {
         return (object_ptr_ < rhs.object_ptr_) ||
-               ((object_ptr_ == rhs.object_ptr_) && (caller_ < rhs.caller_));
+               ((object_ptr_ == rhs.object_ptr_) && (reinterpret_cast<const void*>(caller_) < reinterpret_cast<const void*>(rhs.caller_)));
     }
 
     //! compare delegate with another

--- a/tlx/digest/md5.cpp
+++ b/tlx/digest/md5.cpp
@@ -13,6 +13,7 @@
 
 #include <tlx/digest/md5.hpp>
 
+#include <cstdint>
 #include <tlx/math/rol.hpp>
 #include <tlx/string/hexdump.hpp>
 
@@ -29,83 +30,83 @@ namespace tlx {
 
 namespace digest_detail {
 
-static inline uint32_t min(uint32_t x, uint32_t y) {
+static inline std::uint32_t min(std::uint32_t x, std::uint32_t y) {
     return x < y ? x : y;
 }
 
-static inline uint32_t load32l(const uint8_t* y) {
-    uint32_t res = 0;
+static inline std::uint32_t load32l(const std::uint8_t* y) {
+    std::uint32_t res = 0;
     for (size_t i = 0; i != 4; ++i)
-        res |= uint32_t(y[i]) << (i * 8);
+        res |= std::uint32_t(y[i]) << (i * 8);
     return res;
 }
 
-static inline void store32l(uint32_t x, uint8_t* y) {
+static inline void store32l(std::uint32_t x, std::uint8_t* y) {
     for (size_t i = 0; i != 4; ++i)
         y[i] = (x >> (i * 8)) & 255;
 }
 
-static inline void store64l(uint64_t x, uint8_t* y) {
+static inline void store64l(std::uint64_t x, std::uint8_t* y) {
     for (size_t i = 0; i != 8; ++i)
         y[i] = (x >> (i * 8)) & 255;
 }
 
 static inline
-uint32_t F(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (z ^ (x & (y ^ z)));
 }
 static inline
-uint32_t G(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t G(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (y ^ (z & (y ^ x)));
 }
 static inline
-uint32_t H(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t H(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (x ^ y ^ z);
 }
 static inline
-uint32_t I(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t I(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (y ^ (x | (~z)));
 }
 
-static inline void FF(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void FF(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + F(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static inline void GG(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void GG(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + G(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static inline void HH(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void HH(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + H(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static inline void II(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d,
-                      uint32_t M, uint32_t s, uint32_t t) {
+static inline void II(std::uint32_t& a, std::uint32_t& b, std::uint32_t& c, std::uint32_t& d,
+                      std::uint32_t M, std::uint32_t s, std::uint32_t t) {
     a = (a + I(b, c, d) + M + t);
     a = rol32(a, s) + b;
 }
 
-static const uint8_t Worder[64] = {
+static const std::uint8_t Worder[64] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     1, 6, 11, 0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12,
     5, 8, 11, 14, 1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15, 2,
     0, 7, 14, 5, 12, 3, 10, 1, 8, 15, 6, 13, 4, 11, 2, 9
 };
 
-static const uint8_t Rorder[64] = {
+static const std::uint8_t Rorder[64] = {
     7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
     5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
     4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
     6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21
 };
 
-static const uint32_t Korder[64] = {
+static const std::uint32_t Korder[64] = {
     0xd76aa478UL, 0xe8c7b756UL, 0x242070dbUL, 0xc1bdceeeUL, 0xf57c0fafUL,
     0x4787c62aUL, 0xa8304613UL, 0xfd469501UL, 0x698098d8UL, 0x8b44f7afUL,
     0xffff5bb1UL, 0x895cd7beUL, 0x6b901122UL, 0xfd987193UL, 0xa679438eUL,
@@ -121,8 +122,8 @@ static const uint32_t Korder[64] = {
     0xf7537e82UL, 0xbd3af235UL, 0x2ad7d2bbUL, 0xeb86d391UL
 };
 
-static void md5_compress(uint32_t state[4], const uint8_t* buf) {
-    uint32_t i, W[16], a, b, c, d, t;
+static void md5_compress(std::uint32_t state[4], const std::uint8_t* buf) {
+    std::uint32_t i, W[16], a, b, c, d, t;
 
     // copy the state into 512-bits into W[0..15]
     for (i = 0; i < 16; i++) {
@@ -172,7 +173,7 @@ MD5::MD5() {
     state_[3] = 0x10325476UL;
 }
 
-MD5::MD5(const void* data, uint32_t size) : MD5() {
+MD5::MD5(const void* data, std::uint32_t size) : MD5() {
     process(data, size);
 }
 
@@ -180,9 +181,9 @@ MD5::MD5(const std::string& str) : MD5() {
     process(str);
 }
 
-void MD5::process(const void* data, uint32_t size) {
-    const uint32_t block_size = sizeof(MD5::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+void MD5::process(const void* data, std::uint32_t size) {
+    const std::uint32_t block_size = sizeof(MD5::buf_);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -195,9 +196,9 @@ void MD5::process(const void* data, uint32_t size) {
         }
         else
         {
-            uint32_t n = digest_detail::min(size, (block_size - curlen_));
-            uint8_t* b = buf_ + curlen_;
-            for (const uint8_t* a = in; a != in + n; ++a, ++b) {
+            std::uint32_t n = digest_detail::min(size, (block_size - curlen_));
+            std::uint8_t* b = buf_ + curlen_;
+            for (const std::uint8_t* a = in; a != in + n; ++a, ++b) {
                 *b = *a;
             }
             curlen_ += n;
@@ -223,7 +224,7 @@ void MD5::finalize(void* digest) {
     length_ += curlen_ * 8;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length_ is currently above 56 bytes we append zeros then
     // md5_compress().  Then we can fall back to padding zeros and length
@@ -246,7 +247,7 @@ void MD5::finalize(void* digest) {
     // Copy output
     for (size_t i = 0; i < 4; i++) {
         digest_detail::store32l(
-            state_[i], static_cast<uint8_t*>(digest) + (4 * i));
+            state_[i], static_cast<std::uint8_t*>(digest) + (4 * i));
     }
 }
 
@@ -257,18 +258,18 @@ std::string MD5::digest() {
 }
 
 std::string MD5::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string MD5::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string md5_hex(const void* data, uint32_t size) {
+std::string md5_hex(const void* data, std::uint32_t size) {
     return MD5(data, size).digest_hex();
 }
 
@@ -276,7 +277,7 @@ std::string md5_hex(const std::string& str) {
     return MD5(str).digest_hex();
 }
 
-std::string md5_hex_uc(const void* data, uint32_t size) {
+std::string md5_hex_uc(const void* data, std::uint32_t size) {
     return MD5(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/md5.hpp
+++ b/tlx/digest/md5.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     MD5();
     //! construct context and process data range
-    MD5(const void* data, uint32_t size);
+    MD5(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit MD5(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint32_t state_[4];
-    uint32_t curlen_;
-    uint8_t buf_[64];
+    std::uint64_t length_;
+    std::uint32_t state_[4];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[64];
 };
 
 //! process data and return 16 byte (128 bit) digest hex encoded
-std::string md5_hex(const void* data, uint32_t size);
+std::string md5_hex(const void* data, std::uint32_t size);
 //! process data and return 16 byte (128 bit) digest hex encoded
 std::string md5_hex(const std::string& str);
 
 //! process data and return 16 byte (128 bit) digest upper-case hex encoded
-std::string md5_hex_uc(const void* data, uint32_t size);
+std::string md5_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 16 byte (128 bit) digest upper-case hex encoded
 std::string md5_hex_uc(const std::string& str);
 

--- a/tlx/digest/sha1.cpp
+++ b/tlx/digest/sha1.cpp
@@ -13,6 +13,7 @@
 
 #include <tlx/digest/sha1.hpp>
 
+#include <cstdint>
 #include <tlx/math/rol.hpp>
 #include <tlx/string/hexdump.hpp>
 
@@ -29,42 +30,42 @@ namespace tlx {
 
 namespace digest_detail {
 
-static inline uint32_t min(uint32_t x, uint32_t y) {
+static inline std::uint32_t min(std::uint32_t x, std::uint32_t y) {
     return x < y ? x : y;
 }
 
-static inline void store64h(uint64_t x, unsigned char* y) {
+static inline void store64h(std::uint64_t x, unsigned char* y) {
     for (int i = 0; i != 8; ++i)
         y[i] = (x >> ((7 - i) * 8)) & 255;
 }
-static inline uint32_t load32h(const uint8_t* y) {
-    return (uint32_t(y[0]) << 24) | (uint32_t(y[1]) << 16) |
-           (uint32_t(y[2]) << 8) | (uint32_t(y[3]) << 0);
+static inline std::uint32_t load32h(const std::uint8_t* y) {
+    return (std::uint32_t(y[0]) << 24) | (std::uint32_t(y[1]) << 16) |
+           (std::uint32_t(y[2]) << 8) | (std::uint32_t(y[3]) << 0);
 }
-static inline void store32h(uint32_t x, uint8_t* y) {
+static inline void store32h(std::uint32_t x, std::uint8_t* y) {
     for (int i = 0; i != 4; ++i)
         y[i] = (x >> ((3 - i) * 8)) & 255;
 }
 
 static inline
-uint32_t F0(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F0(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (z ^ (x & (y ^ z)));
 }
 static inline
-uint32_t F1(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F1(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (x ^ y ^ z);
 }
 static inline
-uint32_t F2(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F2(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return ((x & y) | (z & (x | y)));
 }
 static inline
-uint32_t F3(const uint32_t& x, const uint32_t& y, const uint32_t& z) {
+std::uint32_t F3(const std::uint32_t& x, const std::uint32_t& y, const std::uint32_t& z) {
     return (x ^ y ^ z);
 }
 
-static void sha1_compress(uint32_t state[4], const uint8_t* buf) {
-    uint32_t a, b, c, d, e, W[80], i, t;
+static void sha1_compress(std::uint32_t state[4], const std::uint8_t* buf) {
+    std::uint32_t a, b, c, d, e, W[80], i, t;
 
     /* copy the state into 512-bits into W[0..15] */
     for (i = 0; i < 16; i++) {
@@ -125,7 +126,7 @@ SHA1::SHA1() {
     state_[4] = 0xc3d2e1f0UL;
 }
 
-SHA1::SHA1(const void* data, uint32_t size) : SHA1() {
+SHA1::SHA1(const void* data, std::uint32_t size) : SHA1() {
     process(data, size);
 }
 
@@ -133,9 +134,9 @@ SHA1::SHA1(const std::string& str) : SHA1() {
     process(str);
 }
 
-void SHA1::process(const void* data, uint32_t size) {
-    const uint32_t block_size = sizeof(SHA1::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+void SHA1::process(const void* data, std::uint32_t size) {
+    const std::uint32_t block_size = sizeof(SHA1::buf_);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -148,9 +149,9 @@ void SHA1::process(const void* data, uint32_t size) {
         }
         else
         {
-            uint32_t n = digest_detail::min(size, (block_size - curlen_));
-            uint8_t* b = buf_ + curlen_;
-            for (const uint8_t* a = in; a != in + n; ++a, ++b) {
+            std::uint32_t n = digest_detail::min(size, (block_size - curlen_));
+            std::uint8_t* b = buf_ + curlen_;
+            for (const std::uint8_t* a = in; a != in + n; ++a, ++b) {
                 *b = *a;
             }
             curlen_ += n;
@@ -176,7 +177,7 @@ void SHA1::finalize(void* digest) {
     length_ += curlen_ * 8;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length_ is currently above 56 bytes we append zeros then
     // sha1_compress().  Then we can fall back to padding zeros and length
@@ -198,7 +199,7 @@ void SHA1::finalize(void* digest) {
 
     // Copy output
     for (size_t i = 0; i < 5; i++)
-        digest_detail::store32h(state_[i], static_cast<uint8_t*>(digest) + (4 * i));
+        digest_detail::store32h(state_[i], static_cast<std::uint8_t*>(digest) + (4 * i));
 }
 
 std::string SHA1::digest() {
@@ -208,18 +209,18 @@ std::string SHA1::digest() {
 }
 
 std::string SHA1::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string SHA1::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string sha1_hex(const void* data, uint32_t size) {
+std::string sha1_hex(const void* data, std::uint32_t size) {
     return SHA1(data, size).digest_hex();
 }
 
@@ -227,7 +228,7 @@ std::string sha1_hex(const std::string& str) {
     return SHA1(str).digest_hex();
 }
 
-std::string sha1_hex_uc(const void* data, uint32_t size) {
+std::string sha1_hex_uc(const void* data, std::uint32_t size) {
     return SHA1(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/sha1.hpp
+++ b/tlx/digest/sha1.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     SHA1();
     //! construct context and process data range
-    SHA1(const void* data, uint32_t size);
+    SHA1(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit SHA1(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint32_t state_[5];
-    uint32_t curlen_;
-    uint8_t buf_[64];
+    std::uint64_t length_;
+    std::uint32_t state_[5];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[64];
 };
 
 //! process data and return 20 byte (160 bit) digest hex encoded
-std::string sha1_hex(const void* data, uint32_t size);
+std::string sha1_hex(const void* data, std::uint32_t size);
 //! process data and return 20 byte (160 bit) digest hex encoded
 std::string sha1_hex(const std::string& str);
 
 //! process data and return 20 byte (160 bit) digest upper-case hex encoded
-std::string sha1_hex_uc(const void* data, uint32_t size);
+std::string sha1_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 20 byte (160 bit) digest upper-case hex encoded
 std::string sha1_hex_uc(const std::string& str);
 

--- a/tlx/digest/sha256.cpp
+++ b/tlx/digest/sha256.cpp
@@ -17,6 +17,7 @@
 #include <tlx/string/hexdump.hpp>
 
 #include <algorithm>
+#include <cstdint>
 
 namespace tlx {
 
@@ -29,8 +30,8 @@ namespace tlx {
  * The library is free for all purposes without any express guarantee it works.
  */
 
-typedef uint32_t u32;
-typedef uint64_t u64;
+typedef std::uint32_t u32;
+typedef std::uint64_t u64;
 
 namespace {
 
@@ -54,15 +55,15 @@ static inline u32 min(u32 x, u32 y) {
     return x < y ? x : y;
 }
 
-static inline u32 load32(const uint8_t* y) {
+static inline u32 load32(const std::uint8_t* y) {
     return (u32(y[0]) << 24) | (u32(y[1]) << 16) |
            (u32(y[2]) << 8) | (u32(y[3]) << 0);
 }
-static inline void store64(u64 x, uint8_t* y) {
+static inline void store64(u64 x, std::uint8_t* y) {
     for (int i = 0; i != 8; ++i)
         y[i] = (x >> ((7 - i) * 8)) & 255;
 }
-static inline void store32(u32 x, uint8_t* y) {
+static inline void store32(u32 x, std::uint8_t* y) {
     for (int i = 0; i != 4; ++i)
         y[i] = (x >> ((3 - i) * 8)) & 255;
 }
@@ -89,7 +90,7 @@ static inline u32 Gamma1(u32 x) {
     return ror32(x, 17) ^ ror32(x, 19) ^ Sh(x, 10);
 }
 
-static void sha256_compress(uint32_t state[8], const uint8_t* buf) {
+static void sha256_compress(std::uint32_t state[8], const std::uint8_t* buf) {
     u32 S[8], W[64], t0, t1, t;
 
     // Copy state into S
@@ -141,7 +142,7 @@ SHA256::SHA256() {
     state_[7] = 0x5BE0CD19UL;
 }
 
-SHA256::SHA256(const void* data, uint32_t size)
+SHA256::SHA256(const void* data, std::uint32_t size)
     : SHA256() {
     process(data, size);
 }
@@ -153,7 +154,7 @@ SHA256::SHA256(const std::string& str)
 
 void SHA256::process(const void* data, u32 size) {
     const u32 block_size = sizeof(SHA256::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -191,7 +192,7 @@ void SHA256::finalize(void* digest) {
     length_ += curlen_ * 8;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length_ is currently above 56 bytes we append zeros then
     // sha256_compress().  Then we can fall back to padding zeros and length
@@ -214,7 +215,7 @@ void SHA256::finalize(void* digest) {
 
     // Copy output
     for (size_t i = 0; i < 8; i++)
-        store32(state_[i], static_cast<uint8_t*>(digest) + (4 * i));
+        store32(state_[i], static_cast<std::uint8_t*>(digest) + (4 * i));
 }
 
 std::string SHA256::digest() {
@@ -224,18 +225,18 @@ std::string SHA256::digest() {
 }
 
 std::string SHA256::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string SHA256::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string sha256_hex(const void* data, uint32_t size) {
+std::string sha256_hex(const void* data, std::uint32_t size) {
     return SHA256(data, size).digest_hex();
 }
 
@@ -243,7 +244,7 @@ std::string sha256_hex(const std::string& str) {
     return SHA256(str).digest_hex();
 }
 
-std::string sha256_hex_uc(const void* data, uint32_t size) {
+std::string sha256_hex_uc(const void* data, std::uint32_t size) {
     return SHA256(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/sha256.hpp
+++ b/tlx/digest/sha256.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     SHA256();
     //! construct context and process data range
-    SHA256(const void* data, uint32_t size);
+    SHA256(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit SHA256(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint32_t state_[8];
-    uint32_t curlen_;
-    uint8_t buf_[64];
+    std::uint64_t length_;
+    std::uint32_t state_[8];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[64];
 };
 
 //! process data and return 32 byte (256 bit) digest hex encoded
-std::string sha256_hex(const void* data, uint32_t size);
+std::string sha256_hex(const void* data, std::uint32_t size);
 //! process data and return 32 byte (256 bit) digest hex encoded
 std::string sha256_hex(const std::string& str);
 
 //! process data and return 32 byte (256 bit) digest upper-case hex encoded
-std::string sha256_hex_uc(const void* data, uint32_t size);
+std::string sha256_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 32 byte (256 bit) digest upper-case hex encoded
 std::string sha256_hex_uc(const std::string& str);
 

--- a/tlx/digest/sha512.cpp
+++ b/tlx/digest/sha512.cpp
@@ -13,6 +13,7 @@
 
 #include <tlx/digest/sha512.hpp>
 
+#include <cstdint>
 #include <tlx/math/ror.hpp>
 #include <tlx/string/hexdump.hpp>
 
@@ -29,7 +30,7 @@ namespace tlx {
 
 namespace digest_detail {
 
-static const uint64_t K[80] = {
+static const std::uint64_t K[80] = {
     0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL,
     0xe9b5dba58189dbbcULL, 0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL,
     0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL, 0xd807aa98a3030242ULL,
@@ -59,47 +60,47 @@ static const uint64_t K[80] = {
     0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
 };
 
-static inline uint32_t min(uint32_t x, uint32_t y) {
+static inline std::uint32_t min(std::uint32_t x, std::uint32_t y) {
     return x < y ? x : y;
 }
 
-static inline void store64(uint64_t x, unsigned char* y) {
+static inline void store64(std::uint64_t x, unsigned char* y) {
     for (int i = 0; i != 8; ++i)
         y[i] = (x >> ((7 - i) * 8)) & 255;
 }
-static inline uint64_t load64(const unsigned char* y) {
-    uint64_t res = 0;
+static inline std::uint64_t load64(const unsigned char* y) {
+    std::uint64_t res = 0;
     for (int i = 0; i != 8; ++i)
-        res |= uint64_t(y[i]) << ((7 - i) * 8);
+        res |= std::uint64_t(y[i]) << ((7 - i) * 8);
     return res;
 }
 
 static inline
-uint64_t Ch(const uint64_t& x, const uint64_t& y, const uint64_t& z) {
+std::uint64_t Ch(const std::uint64_t& x, const std::uint64_t& y, const std::uint64_t& z) {
     return z ^ (x & (y ^ z));
 }
 static inline
-uint64_t Maj(const uint64_t& x, const uint64_t& y, const uint64_t& z) {
+std::uint64_t Maj(const std::uint64_t& x, const std::uint64_t& y, const std::uint64_t& z) {
     return ((x | y) & z) | (x & y);
 }
-static inline uint64_t Sh(uint64_t x, uint64_t n) {
+static inline std::uint64_t Sh(std::uint64_t x, std::uint64_t n) {
     return x >> n;
 }
-static inline uint64_t Sigma0(uint64_t x) {
+static inline std::uint64_t Sigma0(std::uint64_t x) {
     return ror64(x, 28) ^ ror64(x, 34) ^ ror64(x, 39);
 }
-static inline uint64_t Sigma1(uint64_t x) {
+static inline std::uint64_t Sigma1(std::uint64_t x) {
     return ror64(x, 14) ^ ror64(x, 18) ^ ror64(x, 41);
 }
-static inline uint64_t Gamma0(uint64_t x) {
+static inline std::uint64_t Gamma0(std::uint64_t x) {
     return ror64(x, 1) ^ ror64(x, 8) ^ Sh(x, 7);
 }
-static inline uint64_t Gamma1(uint64_t x) {
+static inline std::uint64_t Gamma1(std::uint64_t x) {
     return ror64(x, 19) ^ ror64(x, 61) ^ Sh(x, 6);
 }
 
-static void sha512_compress(uint64_t state[8], const uint8_t* buf) {
-    uint64_t S[8], W[80], t0, t1;
+static void sha512_compress(std::uint64_t state[8], const std::uint8_t* buf) {
+    std::uint64_t S[8], W[80], t0, t1;
 
     // Copy state_ into S
     for (int i = 0; i < 8; i++)
@@ -115,8 +116,8 @@ static void sha512_compress(uint64_t state[8], const uint8_t* buf) {
 
     // Compress
     auto RND =
-        [&](uint64_t a, uint64_t b, uint64_t c, uint64_t& d, uint64_t e,
-            uint64_t f, uint64_t g, uint64_t& h, uint64_t i)
+        [&](std::uint64_t a, std::uint64_t b, std::uint64_t c, std::uint64_t& d, std::uint64_t e,
+            std::uint64_t f, std::uint64_t g, std::uint64_t& h, std::uint64_t i)
         {
             t0 = h + Sigma1(e) + Ch(e, f, g) + K[i] + W[i];
             t1 = Sigma0(a) + Maj(a, b, c);
@@ -156,7 +157,7 @@ SHA512::SHA512() {
     state_[7] = 0x5be0cd19137e2179ULL;
 }
 
-SHA512::SHA512(const void* data, uint32_t size) : SHA512() {
+SHA512::SHA512(const void* data, std::uint32_t size) : SHA512() {
     process(data, size);
 }
 
@@ -164,9 +165,9 @@ SHA512::SHA512(const std::string& str) : SHA512() {
     process(str);
 }
 
-void SHA512::process(const void* data, uint32_t size) {
-    const uint32_t block_size = sizeof(SHA512::buf_);
-    auto in = static_cast<const uint8_t*>(data);
+void SHA512::process(const void* data, std::uint32_t size) {
+    const std::uint32_t block_size = sizeof(SHA512::buf_);
+    auto in = static_cast<const std::uint8_t*>(data);
 
     while (size > 0)
     {
@@ -179,9 +180,9 @@ void SHA512::process(const void* data, uint32_t size) {
         }
         else
         {
-            uint32_t n = digest_detail::min(size, (block_size - curlen_));
-            uint8_t* b = buf_ + curlen_;
-            for (const uint8_t* a = in; a != in + n; ++a, ++b) {
+            std::uint32_t n = digest_detail::min(size, (block_size - curlen_));
+            std::uint8_t* b = buf_ + curlen_;
+            for (const std::uint8_t* a = in; a != in + n; ++a, ++b) {
                 *b = *a;
             }
             curlen_ += n;
@@ -207,7 +208,7 @@ void SHA512::finalize(void* digest) {
     length_ += curlen_ * 8ULL;
 
     // Append the '1' bit
-    buf_[curlen_++] = static_cast<uint8_t>(0x80);
+    buf_[curlen_++] = static_cast<std::uint8_t>(0x80);
 
     // If the length is currently above 112 bytes we append zeros then compress.
     // Then we can fall back to padding zeros and length encoding like normal.
@@ -232,7 +233,7 @@ void SHA512::finalize(void* digest) {
     // Copy output
     for (int i = 0; i < 8; i++) {
         digest_detail::store64(
-            state_[i], static_cast<uint8_t*>(digest) + (8 * i));
+            state_[i], static_cast<std::uint8_t*>(digest) + (8 * i));
     }
 }
 
@@ -243,18 +244,18 @@ std::string SHA512::digest() {
 }
 
 std::string SHA512::digest_hex() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump_lc(digest, kDigestLength);
 }
 
 std::string SHA512::digest_hex_uc() {
-    uint8_t digest[kDigestLength];
+    std::uint8_t digest[kDigestLength];
     finalize(digest);
     return hexdump(digest, kDigestLength);
 }
 
-std::string sha512_hex(const void* data, uint32_t size) {
+std::string sha512_hex(const void* data, std::uint32_t size) {
     return SHA512(data, size).digest_hex();
 }
 
@@ -262,7 +263,7 @@ std::string sha512_hex(const std::string& str) {
     return SHA512(str).digest_hex();
 }
 
-std::string sha512_hex_uc(const void* data, uint32_t size) {
+std::string sha512_hex_uc(const void* data, std::uint32_t size) {
     return SHA512(data, size).digest_hex_uc();
 }
 

--- a/tlx/digest/sha512.hpp
+++ b/tlx/digest/sha512.hpp
@@ -31,12 +31,12 @@ public:
     //! construct empty object.
     SHA512();
     //! construct context and process data range
-    SHA512(const void* data, uint32_t size);
+    SHA512(const void* data, std::uint32_t size);
     //! construct context and process string
     explicit SHA512(const std::string& str);
 
     //! process more data
-    void process(const void* data, uint32_t size);
+    void process(const void* data, std::uint32_t size);
     //! process more data
     void process(const std::string& str);
 
@@ -54,19 +54,19 @@ public:
     std::string digest_hex_uc();
 
 private:
-    uint64_t length_;
-    uint64_t state_[8];
-    uint32_t curlen_;
-    uint8_t buf_[128];
+    std::uint64_t length_;
+    std::uint64_t state_[8];
+    std::uint32_t curlen_;
+    std::uint8_t buf_[128];
 };
 
 //! process data and return 64 byte (512 bit) digest hex encoded
-std::string sha512_hex(const void* data, uint32_t size);
+std::string sha512_hex(const void* data, std::uint32_t size);
 //! process data and return 64 byte (512 bit) digest hex encoded
 std::string sha512_hex(const std::string& str);
 
 //! process data and return 64 byte (512 bit) digest upper-case hex encoded
-std::string sha512_hex_uc(const void* data, uint32_t size);
+std::string sha512_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 64 byte (512 bit) digest upper-case hex encoded
 std::string sha512_hex_uc(const std::string& str);
 

--- a/tlx/math/bswap.hpp
+++ b/tlx/math/bswap.hpp
@@ -28,28 +28,28 @@ namespace tlx {
 // bswap16() - swap 16-bit integers
 
 //! bswap16 - generic implementation
-static inline uint16_t bswap16_generic(const uint16_t& x) {
+static inline std::uint16_t bswap16_generic(const std::uint16_t& x) {
     return ((x >> 8) & 0x00FFUL) | ((x << 8) & 0xFF00UL);
 }
 
 #if defined(__GNUC__) || defined(__clang__)
 
 //! bswap16 - gcc/clang intrinsic
-static inline uint16_t bswap16(const uint16_t& v) {
+static inline std::uint16_t bswap16(const std::uint16_t& v) {
     return __builtin_bswap16(v);
 }
 
 #elif defined(_MSC_VER)
 
 //! bswap16 - MSVC intrinsic
-static inline uint16_t bswap16(const uint16_t& v) {
+static inline std::uint16_t bswap16(const std::uint16_t& v) {
     return _byteswap_ushort(v);
 }
 
 #else
 
 //! bswap16 - generic
-static inline uint16_t bswap16(const uint16_t& v) {
+static inline std::uint16_t bswap16(const std::uint16_t& v) {
     return bswap16_generic(v);
 }
 
@@ -59,7 +59,7 @@ static inline uint16_t bswap16(const uint16_t& v) {
 // bswap32() - swap 32-bit integers
 
 //! bswap32 - generic implementation
-static inline uint32_t bswap32_generic(const uint32_t& x) {
+static inline std::uint32_t bswap32_generic(const std::uint32_t& x) {
     return ((x >> 24) & 0x000000FFUL) | ((x << 24) & 0xFF000000UL) |
            ((x >> 8) & 0x0000FF00UL) | ((x << 8) & 0x00FF0000UL);
 }
@@ -67,21 +67,21 @@ static inline uint32_t bswap32_generic(const uint32_t& x) {
 #if defined(__GNUC__) || defined(__clang__)
 
 //! bswap32 - gcc/clang intrinsic
-static inline uint32_t bswap32(const uint32_t& v) {
+static inline std::uint32_t bswap32(const std::uint32_t& v) {
     return __builtin_bswap32(v);
 }
 
 #elif defined(_MSC_VER)
 
 //! bswap32 - MSVC intrinsic
-static inline uint32_t bswap32(const uint32_t& v) {
+static inline std::uint32_t bswap32(const std::uint32_t& v) {
     return _byteswap_ulong(v);
 }
 
 #else
 
 //! bswap32 - generic
-static inline uint32_t bswap32(const uint32_t& v) {
+static inline std::uint32_t bswap32(const std::uint32_t& v) {
     return bswap32_generic(v);
 }
 
@@ -91,7 +91,7 @@ static inline uint32_t bswap32(const uint32_t& v) {
 // bswap64() - swap 64-bit integers
 
 //! bswap64 - generic implementation
-static inline uint64_t bswap64_generic(const uint64_t& x) {
+static inline std::uint64_t bswap64_generic(const std::uint64_t& x) {
     return ((x >> 56) & 0x00000000000000FFull) |
            ((x >> 40) & 0x000000000000FF00ull) |
            ((x >> 24) & 0x0000000000FF0000ull) |
@@ -105,21 +105,21 @@ static inline uint64_t bswap64_generic(const uint64_t& x) {
 #if defined(__GNUC__) || defined(__clang__)
 
 //! bswap64 - gcc/clang intrinsic
-static inline uint64_t bswap64(const uint64_t& v) {
+static inline std::uint64_t bswap64(const std::uint64_t& v) {
     return __builtin_bswap64(v);
 }
 
 #elif defined(_MSC_VER)
 
 //! bswap64 - MSVC intrinsic
-static inline uint64_t bswap64(const uint64_t& v) {
+static inline std::uint64_t bswap64(const std::uint64_t& v) {
     return _byteswap_uint64(v);
 }
 
 #else
 
 //! bswap64 - generic
-static inline uint64_t bswap64(const uint64_t& v) {
+static inline std::uint64_t bswap64(const std::uint64_t& v) {
     return bswap64_generic(v);
 }
 

--- a/tlx/math/bswap_be.hpp
+++ b/tlx/math/bswap_be.hpp
@@ -14,6 +14,7 @@
 #ifndef TLX_MATH_BSWAP_BE_HEADER
 #define TLX_MATH_BSWAP_BE_HEADER
 
+#include <cstdint>
 #include <tlx/define/endian.hpp>
 #include <tlx/math/bswap.hpp>
 
@@ -26,11 +27,11 @@ namespace tlx {
 // bswap16_be() - swap 16-bit integers to big-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint16_t bswap16_be(const uint16_t& v) {
+static inline std::uint16_t bswap16_be(const std::uint16_t& v) {
     return bswap16(v);
 }
 #elif TLX_BIG_ENDIAN
-static inline uint16_t bswap16_be(const uint16_t& v) {
+static inline std::uint16_t bswap16_be(const std::uint16_t& v) {
     return v;
 }
 #endif
@@ -39,11 +40,11 @@ static inline uint16_t bswap16_be(const uint16_t& v) {
 // bswap32_be() - swap 32-bit integers to big-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint32_t bswap32_be(const uint32_t& v) {
+static inline std::uint32_t bswap32_be(const std::uint32_t& v) {
     return bswap32(v);
 }
 #elif TLX_BIG_ENDIAN
-static inline uint32_t bswap32_be(const uint32_t& v) {
+static inline std::uint32_t bswap32_be(const std::uint32_t& v) {
     return v;
 }
 #endif
@@ -52,11 +53,11 @@ static inline uint32_t bswap32_be(const uint32_t& v) {
 // bswap64_be() - swap 64-bit integers to big-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint64_t bswap64_be(const uint64_t& v) {
+static inline std::uint64_t bswap64_be(const std::uint64_t& v) {
     return bswap64(v);
 }
 #elif TLX_BIG_ENDIAN
-static inline uint64_t bswap64_be(const uint64_t& v) {
+static inline std::uint64_t bswap64_be(const std::uint64_t& v) {
     return v;
 }
 #endif

--- a/tlx/math/bswap_le.hpp
+++ b/tlx/math/bswap_le.hpp
@@ -14,6 +14,7 @@
 #ifndef TLX_MATH_BSWAP_LE_HEADER
 #define TLX_MATH_BSWAP_LE_HEADER
 
+#include <cstdint>
 #include <tlx/define/endian.hpp>
 #include <tlx/math/bswap.hpp>
 
@@ -26,11 +27,11 @@ namespace tlx {
 // bswap16_le() - swap 16-bit integers to little-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint16_t bswap16_le(const uint16_t& v) {
+static inline std::uint16_t bswap16_le(const std::uint16_t& v) {
     return v;
 }
 #elif TLX_BIG_ENDIAN
-static inline uint16_t bswap16_le(const uint16_t& v) {
+static inline std::uint16_t bswap16_le(const std::uint16_t& v) {
     return bswap16(v);
 }
 #endif
@@ -39,11 +40,11 @@ static inline uint16_t bswap16_le(const uint16_t& v) {
 // bswap32_le() - swap 32-bit integers to little-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint32_t bswap32_le(const uint32_t& v) {
+static inline std::uint32_t bswap32_le(const std::uint32_t& v) {
     return v;
 }
 #elif TLX_BIG_ENDIAN
-static inline uint32_t bswap32_le(const uint32_t& v) {
+static inline std::uint32_t bswap32_le(const std::uint32_t& v) {
     return bswap32(v);
 }
 #endif
@@ -52,11 +53,11 @@ static inline uint32_t bswap32_le(const uint32_t& v) {
 // bswap64_le() - swap 64-bit integers to little-endian
 
 #if TLX_LITTLE_ENDIAN
-static inline uint64_t bswap64_le(const uint64_t& v) {
+static inline std::uint64_t bswap64_le(const std::uint64_t& v) {
     return v;
 }
 #elif TLX_BIG_ENDIAN
-static inline uint64_t bswap64_le(const uint64_t& v) {
+static inline std::uint64_t bswap64_le(const std::uint64_t& v) {
     return bswap64(v);
 }
 #endif

--- a/tlx/math/popcount.hpp
+++ b/tlx/math/popcount.hpp
@@ -29,29 +29,29 @@ namespace tlx {
 // popcount() - count one bits
 
 //! popcount (count one bits) - generic SWAR implementation
-static inline unsigned popcount_generic8(uint8_t x) {
+static inline unsigned popcount_generic8(std::uint8_t x) {
     x = x - ((x >> 1) & 0x55);
     x = (x & 0x33) + ((x >> 2) & 0x33);
-    return static_cast<uint8_t>((x + (x >> 4)) & 0x0F);
+    return static_cast<std::uint8_t>((x + (x >> 4)) & 0x0F);
 }
 
 //! popcount (count one bits) - generic SWAR implementation
-static inline unsigned popcount_generic16(uint16_t x) {
+static inline unsigned popcount_generic16(std::uint16_t x) {
     x = x - ((x >> 1) & 0x5555);
     x = (x & 0x3333) + ((x >> 2) & 0x3333);
-    return static_cast<uint16_t>(((x + (x >> 4)) & 0x0F0F) * 0x0101) >> 8;
+    return static_cast<std::uint16_t>(((x + (x >> 4)) & 0x0F0F) * 0x0101) >> 8;
 }
 
 //! popcount (count one bits) -
 //! generic SWAR implementation from https://stackoverflow.com/questions/109023
-static inline unsigned popcount_generic32(uint32_t x) {
+static inline unsigned popcount_generic32(std::uint32_t x) {
     x = x - ((x >> 1) & 0x55555555);
     x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
     return (((x + (x >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
 }
 
 //! popcount (count one bits) - generic SWAR implementation
-static inline unsigned popcount_generic64(uint64_t x) {
+static inline unsigned popcount_generic64(std::uint64_t x) {
     x = x - ((x >> 1) & 0x5555555555555555);
     x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333);
     return (((x + (x >> 4)) & 0x0F0F0F0F0F0F0F0F) * 0x0101010101010101) >> 56;
@@ -112,13 +112,13 @@ inline unsigned popcount(Integral i) {
 //! popcount (count one bits)
 template <typename Integral>
 inline unsigned popcount(Integral i) {
-    if (sizeof(i) <= sizeof(uint8_t))
+    if (sizeof(i) <= sizeof(std::uint8_t))
         return popcount_generic8(i);
-    else if (sizeof(i) <= sizeof(uint16_t))
+    else if (sizeof(i) <= sizeof(std::uint16_t))
         return popcount_generic16(i);
-    else if (sizeof(i) <= sizeof(uint32_t))
+    else if (sizeof(i) <= sizeof(std::uint32_t))
         return popcount_generic32(i);
-    else if (sizeof(i) <= sizeof(uint64_t))
+    else if (sizeof(i) <= sizeof(std::uint64_t))
         return popcount_generic64(i);
     else
         abort();
@@ -131,15 +131,15 @@ inline unsigned popcount(Integral i) {
 
 static inline
 size_t popcount(const void* data, size_t size) {
-    const uint8_t* begin = reinterpret_cast<const uint8_t*>(data);
-    const uint8_t* end = begin + size;
+    const std::uint8_t* begin = reinterpret_cast<const std::uint8_t*>(data);
+    const std::uint8_t* end = begin + size;
     size_t total = 0;
     while (begin + 7 < end) {
-        total += popcount(*reinterpret_cast<const uint64_t*>(begin));
+        total += popcount(*reinterpret_cast<const std::uint64_t*>(begin));
         begin += 8;
     }
     if (begin + 3 < end) {
-        total += popcount(*reinterpret_cast<const uint32_t*>(begin));
+        total += popcount(*reinterpret_cast<const std::uint32_t*>(begin));
         begin += 4;
     }
     while (begin < end) {

--- a/tlx/math/rol.hpp
+++ b/tlx/math/rol.hpp
@@ -28,16 +28,16 @@ namespace tlx {
 // rol32() - rotate bits left in 32-bit integers
 
 //! rol32 - generic implementation
-static inline uint32_t rol32_generic(const uint32_t& x, int i) {
-    return (x << static_cast<uint32_t>(i & 31)) |
-           (x >> static_cast<uint32_t>((32 - (i & 31)) & 31));
+static inline std::uint32_t rol32_generic(const std::uint32_t& x, int i) {
+    return (x << static_cast<std::uint32_t>(i & 31)) |
+           (x >> static_cast<std::uint32_t>((32 - (i & 31)) & 31));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))
 
 //! rol32 - gcc/clang assembler
-static inline uint32_t rol32(const uint32_t& x, int i) {
-    uint32_t x1 = x;
+static inline std::uint32_t rol32(const std::uint32_t& x, int i) {
+    std::uint32_t x1 = x;
     asm ("roll %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -45,14 +45,14 @@ static inline uint32_t rol32(const uint32_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! rol32 - MSVC intrinsic
-static inline uint32_t rol32(const uint32_t& x, int i) {
+static inline std::uint32_t rol32(const std::uint32_t& x, int i) {
     return _rotl(x, i);
 }
 
 #else
 
 //! rol32 - generic
-static inline uint32_t rol32(const uint32_t& x, int i) {
+static inline std::uint32_t rol32(const std::uint32_t& x, int i) {
     return rol32_generic(x, i);
 }
 
@@ -62,16 +62,16 @@ static inline uint32_t rol32(const uint32_t& x, int i) {
 // rol64() - rotate bits left in 64-bit integers
 
 //! rol64 - generic implementation
-static inline uint64_t rol64_generic(const uint64_t& x, int i) {
-    return (x << static_cast<uint64_t>(i & 63)) |
-           (x >> static_cast<uint64_t>((64 - (i & 63)) & 63));
+static inline std::uint64_t rol64_generic(const std::uint64_t& x, int i) {
+    return (x << static_cast<std::uint64_t>(i & 63)) |
+           (x >> static_cast<std::uint64_t>((64 - (i & 63)) & 63));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
 
 //! rol64 - gcc/clang assembler
-static inline uint64_t rol64(const uint64_t& x, int i) {
-    uint64_t x1 = x;
+static inline std::uint64_t rol64(const std::uint64_t& x, int i) {
+    std::uint64_t x1 = x;
     asm ("rolq %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -79,14 +79,14 @@ static inline uint64_t rol64(const uint64_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! rol64 - MSVC intrinsic
-static inline uint64_t rol64(const uint64_t& x, int i) {
+static inline std::uint64_t rol64(const std::uint64_t& x, int i) {
     return _rotl64(x, i);
 }
 
 #else
 
 //! rol64 - generic
-static inline uint64_t rol64(const uint64_t& x, int i) {
+static inline std::uint64_t rol64(const std::uint64_t& x, int i) {
     return rol64_generic(x, i);
 }
 

--- a/tlx/math/ror.hpp
+++ b/tlx/math/ror.hpp
@@ -28,16 +28,16 @@ namespace tlx {
 // ror32() - rotate bits right in 32-bit integers
 
 //! ror32 - generic implementation
-static inline uint32_t ror32_generic(const uint32_t& x, int i) {
-    return (x >> static_cast<uint32_t>(i & 31)) |
-           (x << static_cast<uint32_t>((32 - (i & 31)) & 31));
+static inline std::uint32_t ror32_generic(const std::uint32_t& x, int i) {
+    return (x >> static_cast<std::uint32_t>(i & 31)) |
+           (x << static_cast<std::uint32_t>((32 - (i & 31)) & 31));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))
 
 //! ror32 - gcc/clang assembler
-static inline uint32_t ror32(const uint32_t& x, int i) {
-    uint32_t x1 = x;
+static inline std::uint32_t ror32(const std::uint32_t& x, int i) {
+    std::uint32_t x1 = x;
     asm ("rorl %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -45,14 +45,14 @@ static inline uint32_t ror32(const uint32_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! ror32 - MSVC intrinsic
-static inline uint32_t ror32(const uint32_t& x, int i) {
+static inline std::uint32_t ror32(const std::uint32_t& x, int i) {
     return _rotr(x, i);
 }
 
 #else
 
 //! ror32 - generic
-static inline uint32_t ror32(const uint32_t& x, int i) {
+static inline std::uint32_t ror32(const std::uint32_t& x, int i) {
     return ror32_generic(x, i);
 }
 
@@ -62,16 +62,16 @@ static inline uint32_t ror32(const uint32_t& x, int i) {
 // ror64() - rotate bits right in 64-bit integers
 
 //! ror64 - generic implementation
-static inline uint64_t ror64_generic(const uint64_t& x, int i) {
-    return (x >> static_cast<uint64_t>(i & 63)) |
-           (x << static_cast<uint64_t>((64 - (i & 63)) & 63));
+static inline std::uint64_t ror64_generic(const std::uint64_t& x, int i) {
+    return (x >> static_cast<std::uint64_t>(i & 63)) |
+           (x << static_cast<std::uint64_t>((64 - (i & 63)) & 63));
 }
 
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
 
 //! ror64 - gcc/clang assembler
-static inline uint64_t ror64(const uint64_t& x, int i) {
-    uint64_t x1 = x;
+static inline std::uint64_t ror64(const std::uint64_t& x, int i) {
+    std::uint64_t x1 = x;
     asm ("rorq %%cl,%0" : "=r" (x1) : "0" (x1), "c" (i));
     return x1;
 }
@@ -79,14 +79,14 @@ static inline uint64_t ror64(const uint64_t& x, int i) {
 #elif defined(_MSC_VER)
 
 //! ror64 - MSVC intrinsic
-static inline uint64_t ror64(const uint64_t& x, int i) {
+static inline std::uint64_t ror64(const std::uint64_t& x, int i) {
     return _rotr64(x, i);
 }
 
 #else
 
 //! ror64 - generic
-static inline uint64_t ror64(const uint64_t& x, int i) {
+static inline std::uint64_t ror64(const std::uint64_t& x, int i) {
     return ror64_generic(x, i);
 }
 

--- a/tlx/meta/log2.hpp
+++ b/tlx/meta/log2.hpp
@@ -26,7 +26,7 @@ namespace tlx {
 /******************************************************************************/
 // Log2Floor<Value>::value
 
-template <uint64_t Input>
+template <std::uint64_t Input>
 class Log2Floor
 {
 public:
@@ -52,7 +52,7 @@ public:
 /******************************************************************************/
 // Log2<Value>::floor and Log2<Value>::ceil
 
-template <uint64_t Input>
+template <std::uint64_t Input>
 class Log2
 {
 public:

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -26,7 +26,7 @@ static std::mutex s_timer_add_mutex;
 
 struct MultiTimer::Entry {
     //! hash of name for faster search
-    uint32_t hash;
+    std::uint32_t hash;
     //! reference to original string for comparison
     const char* name;
     //! duration of this timer
@@ -49,7 +49,7 @@ MultiTimer& MultiTimer::operator = (MultiTimer&&) = default;
 MultiTimer::~MultiTimer() = default;
 
 MultiTimer::Entry& MultiTimer::find_or_create(const char* name) {
-    uint32_t hash = hash_djb2(name);
+    std::uint32_t hash = hash_djb2(name);
     for (size_t i = 0; i < timers_.size(); ++i) {
         if (timers_[i].hash == hash && strcmp(timers_[i].name, name) == 0)
             return timers_[i];
@@ -64,7 +64,7 @@ MultiTimer::Entry& MultiTimer::find_or_create(const char* name) {
 
 void MultiTimer::start(const char* timer) {
     tlx_die_unless(timer);
-    uint32_t hash = hash_djb2(timer);
+    std::uint32_t hash = hash_djb2(timer);
     if (running_ && hash == running_hash_ && strcmp(running_, timer) == 0) {
         static bool warning_shown = false;
         if (!warning_shown) {

--- a/tlx/multi_timer.hpp
+++ b/tlx/multi_timer.hpp
@@ -12,6 +12,7 @@
 #define TLX_MULTI_TIMER_HEADER
 
 #include <chrono>
+#include <cstdint>
 #include <ostream>
 #include <vector>
 
@@ -94,7 +95,7 @@ private:
     //! currently running timer name
     const char* running_;
     //! hash of running_
-    uint32_t running_hash_;
+    std::uint32_t running_hash_;
     //! start of currently running timer name
     std::chrono::time_point<std::chrono::high_resolution_clock> time_point_;
 

--- a/tlx/siphash.hpp
+++ b/tlx/siphash.hpp
@@ -39,21 +39,21 @@
 namespace tlx {
 
 static inline
-uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
+std::uint64_t siphash_plain(const std::uint8_t key[16], const std::uint8_t* m, size_t len) {
 
-    uint64_t v0, v1, v2, v3;
-    uint64_t mi, k0, k1;
-    uint64_t last7;
+    std::uint64_t v0, v1, v2, v3;
+    std::uint64_t mi, k0, k1;
+    std::uint64_t last7;
     size_t i, blocks;
 
-    k0 = bswap64_le(*reinterpret_cast<const uint64_t*>(key + 0));
-    k1 = bswap64_le(*reinterpret_cast<const uint64_t*>(key + 8));
+    k0 = bswap64_le(*reinterpret_cast<const std::uint64_t*>(key + 0));
+    k1 = bswap64_le(*reinterpret_cast<const std::uint64_t*>(key + 8));
     v0 = k0 ^ 0x736f6d6570736575ull;
     v1 = k1 ^ 0x646f72616e646f6dull;
     v2 = k0 ^ 0x6c7967656e657261ull;
     v3 = k1 ^ 0x7465646279746573ull;
 
-    last7 = static_cast<uint64_t>(len & 0xff) << 56;
+    last7 = static_cast<std::uint64_t>(len & 0xff) << 56;
 
 #define TLX_SIPCOMPRESS() \
     v0 += v1; v2 += v3;   \
@@ -68,7 +68,7 @@ uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
     v2 = rol64(v2, 32);
 
     for (i = 0, blocks = (len & ~7); i < blocks; i += 8) {
-        mi = bswap64_le(*reinterpret_cast<const uint64_t*>(m + i));
+        mi = bswap64_le(*reinterpret_cast<const std::uint64_t*>(m + i));
         v3 ^= mi;
         TLX_SIPCOMPRESS();
         TLX_SIPCOMPRESS();
@@ -77,25 +77,25 @@ uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
 
     switch (len - blocks) {
     case 7:
-        last7 |= static_cast<uint64_t>(m[i + 6]) << 48;
+        last7 |= static_cast<std::uint64_t>(m[i + 6]) << 48;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 6:
-        last7 |= static_cast<uint64_t>(m[i + 5]) << 40;
+        last7 |= static_cast<std::uint64_t>(m[i + 5]) << 40;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 5:
-        last7 |= static_cast<uint64_t>(m[i + 4]) << 32;
+        last7 |= static_cast<std::uint64_t>(m[i + 4]) << 32;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 4:
-        last7 |= static_cast<uint64_t>(m[i + 3]) << 24;
+        last7 |= static_cast<std::uint64_t>(m[i + 3]) << 24;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 3:
-        last7 |= static_cast<uint64_t>(m[i + 2]) << 16;
+        last7 |= static_cast<std::uint64_t>(m[i + 2]) << 16;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 2:
-        last7 |= static_cast<uint64_t>(m[i + 1]) << 8;
+        last7 |= static_cast<std::uint64_t>(m[i + 1]) << 8;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 1:
-        last7 |= static_cast<uint64_t>(m[i + 0]);
+        last7 |= static_cast<std::uint64_t>(m[i + 0]);
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 0:
     default:;
@@ -122,7 +122,7 @@ uint64_t siphash_plain(const uint8_t key[16], const uint8_t* m, size_t len) {
 #if defined(__SSE2__)
 
 union siphash_packedelem64 {
-    uint64_t u[2];
+    std::uint64_t u[2];
     __m128i v;
 };
 
@@ -141,11 +141,11 @@ static const siphash_packedelem64 siphash_final = {
 };
 
 static inline
-uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
+std::uint64_t siphash_sse2(const std::uint8_t key[16], const std::uint8_t* m, size_t len) {
 
     __m128i k, v02, v20, v13, v11, v33, mi;
-    uint64_t last7;
-    uint32_t lo, hi;
+    std::uint64_t last7;
+    std::uint32_t lo, hi;
     size_t i, blocks;
 
     k = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key + 0));
@@ -154,7 +154,7 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
     v02 = _mm_xor_si128(v02, _mm_unpacklo_epi64(k, k));
     v13 = _mm_xor_si128(v13, _mm_unpackhi_epi64(k, k));
 
-    last7 = static_cast<uint64_t>(len & 0xff) << 56;
+    last7 = static_cast<std::uint64_t>(len & 0xff) << 56;
 
 #define TLX_SIPCOMPRESS()                                                      \
     v11 = v13;                                                                 \
@@ -184,33 +184,33 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
 
     switch (len - blocks) {
     case 7:
-        last7 |= static_cast<uint64_t>(m[i + 6]) << 48;
+        last7 |= static_cast<std::uint64_t>(m[i + 6]) << 48;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 6:
-        last7 |= static_cast<uint64_t>(m[i + 5]) << 40;
+        last7 |= static_cast<std::uint64_t>(m[i + 5]) << 40;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 5:
-        last7 |= static_cast<uint64_t>(m[i + 4]) << 32;
+        last7 |= static_cast<std::uint64_t>(m[i + 4]) << 32;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 4:
-        last7 |= static_cast<uint64_t>(m[i + 3]) << 24;
+        last7 |= static_cast<std::uint64_t>(m[i + 3]) << 24;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 3:
-        last7 |= static_cast<uint64_t>(m[i + 2]) << 16;
+        last7 |= static_cast<std::uint64_t>(m[i + 2]) << 16;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 2:
-        last7 |= static_cast<uint64_t>(m[i + 1]) << 8;
+        last7 |= static_cast<std::uint64_t>(m[i + 1]) << 8;
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 1:
-        last7 |= static_cast<uint64_t>(m[i + 0]);
+        last7 |= static_cast<std::uint64_t>(m[i + 0]);
         TLX_ATTRIBUTE_FALLTHROUGH;
     case 0:
     default:;
     }
 
     mi = _mm_unpacklo_epi32(
-        _mm_cvtsi32_si128(static_cast<uint32_t>(last7)),
-        _mm_cvtsi32_si128(static_cast<uint32_t>(last7 >> 32)));
+        _mm_cvtsi32_si128(static_cast<std::uint32_t>(last7)),
+        _mm_cvtsi32_si128(static_cast<std::uint32_t>(last7 >> 32)));
     v13 = _mm_xor_si128(v13, _mm_slli_si128(mi, 8));
     TLX_SIPCOMPRESS();
     TLX_SIPCOMPRESS();
@@ -228,7 +228,7 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
 
 #undef TLX_SIPCOMPRESS
 
-    return (static_cast<uint64_t>(hi) << 32) | lo;
+    return (static_cast<std::uint64_t>(hi) << 32) | lo;
 }
 
 #endif  // defined(__SSE2__)
@@ -237,7 +237,7 @@ uint64_t siphash_sse2(const uint8_t key[16], const uint8_t* m, size_t len) {
 // Switch between available implementations
 
 static inline
-uint64_t siphash(const uint8_t key[16], const uint8_t* msg, size_t size) {
+std::uint64_t siphash(const std::uint8_t key[16], const std::uint8_t* msg, size_t size) {
 #if defined(__SSE2__)
     return siphash_sse2(key, msg, size);
 #else
@@ -246,7 +246,7 @@ uint64_t siphash(const uint8_t key[16], const uint8_t* msg, size_t size) {
 }
 
 static inline
-uint64_t siphash(const uint8_t* msg, size_t size) {
+std::uint64_t siphash(const std::uint8_t* msg, size_t size) {
     const unsigned char key[16] = {
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
     };
@@ -254,19 +254,19 @@ uint64_t siphash(const uint8_t* msg, size_t size) {
 }
 
 static inline
-uint64_t siphash(const char* msg, size_t size) {
-    return siphash(reinterpret_cast<const uint8_t*>(msg), size);
+std::uint64_t siphash(const char* msg, size_t size) {
+    return siphash(reinterpret_cast<const std::uint8_t*>(msg), size);
 }
 
 static inline
-uint64_t siphash(const std::string& str) {
+std::uint64_t siphash(const std::string& str) {
     return siphash(str.data(), str.size());
 }
 
 template <typename Type>
 static inline
-uint64_t siphash(const Type& value) {
-    return siphash(reinterpret_cast<const uint8_t*>(&value), sizeof(value));
+std::uint64_t siphash(const Type& value) {
+    return siphash(reinterpret_cast<const std::uint8_t*>(&value), sizeof(value));
 }
 
 #undef rol64

--- a/tlx/sort/strings.hpp
+++ b/tlx/sort/strings.hpp
@@ -174,11 +174,11 @@ void sort_strings(std::vector<std::string>& strings, size_t memory = 0) {
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(unsigned char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(unsigned char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     sort_strings_detail::radixsort_CE3(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::UCharStringSet, uint32_t>(
+            sort_strings_detail::UCharStringSet, std::uint32_t>(
             sort_strings_detail::UCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -191,7 +191,7 @@ void sort_strings_lcp(unsigned char** strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(
         reinterpret_cast<unsigned char**>(strings), size, lcp, memory);
@@ -204,11 +204,11 @@ void sort_strings_lcp(char** strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(const unsigned char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(const unsigned char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     sort_strings_detail::radixsort_CE3(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::CUCharStringSet, uint32_t>(
+            sort_strings_detail::CUCharStringSet, std::uint32_t>(
             sort_strings_detail::CUCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -221,7 +221,7 @@ void sort_strings_lcp(const unsigned char** strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(const char** strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(const char** strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(
         reinterpret_cast<const unsigned char**>(strings), size, lcp, memory);
@@ -237,7 +237,7 @@ void sort_strings_lcp(const char** strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
@@ -249,7 +249,7 @@ void sort_strings_lcp(std::vector<char*>& strings, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<unsigned char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<unsigned char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
@@ -262,7 +262,7 @@ void sort_strings_lcp(std::vector<unsigned char*>& strings, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<const char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<const char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
@@ -274,7 +274,7 @@ void sort_strings_lcp(std::vector<const char*>& strings, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<const unsigned char*>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<const unsigned char*>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }
@@ -289,11 +289,11 @@ void sort_strings_lcp(std::vector<const unsigned char*>& strings, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::string* strings, size_t size, uint32_t* lcp,
+void sort_strings_lcp(std::string* strings, size_t size, std::uint32_t* lcp,
                       size_t memory = 0) {
     sort_strings_detail::radixsort_CE3(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::StdStringSet, uint32_t>(
+            sort_strings_detail::StdStringSet, std::uint32_t>(
             sort_strings_detail::StdStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -306,7 +306,7 @@ void sort_strings_lcp(std::string* strings, size_t size, uint32_t* lcp,
  * to stay within the memory limit.
  */
 static inline
-void sort_strings_lcp(std::vector<std::string>& strings, uint32_t* lcp,
+void sort_strings_lcp(std::vector<std::string>& strings, std::uint32_t* lcp,
                       size_t memory = 0) {
     return sort_strings_lcp(strings.data(), strings.size(), lcp, memory);
 }

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <random>
@@ -317,7 +318,7 @@ public:
         ctx_.mtimer.add(mtimer_);
     }
 
-    simple_vector<uint8_t> bktcache_;
+    simple_vector<std::uint8_t> bktcache_;
     size_t bktcache_size_ = 0;
 
     void run() {
@@ -333,7 +334,7 @@ public:
 
         if (ctx_.enable_sequential_sample_sort && n >= ctx_.smallsort_threshold)
         {
-            bktcache_.resize(n * sizeof(uint16_t));
+            bktcache_.resize(n * sizeof(std::uint16_t));
             sort_sample_sort(strptr_, depth_);
         }
         else
@@ -368,7 +369,7 @@ public:
         bktsize_type bkt[bktnum + 1];
 
         SeqSampleSortStep(Context& ctx, const StringPtr& strptr, size_t depth,
-                          uint16_t* bktcache)
+                          std::uint16_t* bktcache)
             : strptr_(strptr), idx_(0), depth_(depth) {
             size_t n = strptr_.size();
 
@@ -447,7 +448,7 @@ public:
         assert(ss_front_ == 0);
         assert(ss_stack_.size() == 0);
 
-        uint16_t* bktcache = reinterpret_cast<uint16_t*>(bktcache_.data());
+        std::uint16_t* bktcache = reinterpret_cast<std::uint16_t*>(bktcache_.data());
 
         // sort first level
         ss_stack_.emplace_back(ctx_, strptr, depth, bktcache);
@@ -755,7 +756,7 @@ public:
         size_t idx_;
         unsigned char eq_recurse_;
         // typename StringPtr::StringSet::Char dchar_eq_, dchar_gt_;
-        uint8_t lcp_lt_, lcp_eq_, lcp_gt_;
+        std::uint8_t lcp_lt_, lcp_eq_, lcp_gt_;
 
         MKQSStep(Context& ctx, const StringPtr& strptr,
                  key_type* cache, size_t depth, bool CacheDirty)
@@ -1129,7 +1130,7 @@ public:
     //! individual bucket array of threads, keep bkt[0] for DistributeJob
     simple_vector<simple_vector<size_t> > bkt_;
     //! bucket ids cache, created by classifier and later counted
-    simple_vector<simple_vector<uint16_t> > bktcache_;
+    simple_vector<simple_vector<std::uint16_t> > bktcache_;
 
     /*------------------------------------------------------------------------*/
     // Constructor
@@ -1204,14 +1205,14 @@ public:
         if (strE < strB) strE = strB;
 
         bktcache_[p].resize(strE - strB);
-        uint16_t* bktcache = bktcache_[p].data();
+        std::uint16_t* bktcache = bktcache_[p].data();
         classifier_.classify(strset, strB, strE, bktcache, depth_);
 
         bkt_[p].resize(bktnum_ + (p == 0 ? 1 : 0));
         size_t* bkt = bkt_[p].data();
         memset(bkt, 0, bktnum_ * sizeof(size_t));
 
-        for (uint16_t* bc = bktcache; bc != bktcache + (strE - strB); ++bc)
+        for (std::uint16_t* bc = bktcache; bc != bktcache + (strE - strB); ++bc)
             ++bkt[*bc];
 
         if (--pwork_ == 0)
@@ -1259,7 +1260,7 @@ public:
         const StringSet& sorted = strptr_.shadow();
         typename StringSet::Iterator sbegin = sorted.begin();
 
-        uint16_t* bktcache = bktcache_[p].data();
+        std::uint16_t* bktcache = bktcache_[p].data();
         size_t* bkt = bkt_[p].data();
 
         for (StrIterator str = strB; str != strE; ++str, ++bktcache)
@@ -1400,12 +1401,12 @@ void PS5Context<Parameters>::enqueue(
     }
     else {
         if (strptr.size() < (1LLU << 32)) {
-            auto j = new PS5SmallsortJob<PS5Context, StringPtr, uint32_t>(
+            auto j = new PS5SmallsortJob<PS5Context, StringPtr, std::uint32_t>(
                 *this, pstep, strptr, depth);
             threads_.enqueue([j]() { j->run(); });
         }
         else {
-            auto j = new PS5SmallsortJob<PS5Context, StringPtr, uint64_t>(
+            auto j = new PS5SmallsortJob<PS5Context, StringPtr, std::uint64_t>(
                 *this, pstep, strptr, depth);
             threads_.enqueue([j]() { j->run(); });
         }

--- a/tlx/sort/strings/sample_sort_tools.hpp
+++ b/tlx/sort/strings/sample_sort_tools.hpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 
 namespace tlx {
 namespace sort_strings_detail {
@@ -60,7 +61,7 @@ struct PerfectTreeCalculations {
 
         static const int bitmask = num_nodes;
 
-        int hi = treebits - 32 + clz<uint32_t>(id);
+        int hi = treebits - 32 + clz<std::uint32_t>(id);
         TLX_LOG << "high zero: " << hi;
 
         unsigned int bkt = ((id << (hi + 1)) & bitmask) | (1 << hi);
@@ -75,7 +76,7 @@ struct PerfectTreeCalculations {
 
         static const int bitmask = num_nodes;
 
-        int lo = ctz<uint32_t>(id) + 1;
+        int lo = ctz<std::uint32_t>(id) + 1;
         TLX_LOG << "low zero: " << lo;
 
         unsigned int bkt = ((id >> lo) & bitmask) | (1 << (treebits - lo));
@@ -374,7 +375,7 @@ public:
     //! search in splitter tree for bucket number, unrolled for Rollout keys at
     //! once.
     void find_bkt_unroll(
-        const key_type key[Rollout], uint16_t obkt[Rollout]) const {
+        const key_type key[Rollout], std::uint16_t obkt[Rollout]) const {
         // binary tree traversal without left branch
 
         unsigned int i[Rollout];
@@ -441,7 +442,7 @@ public:
     void classify(
         const StringSet& strset,
         typename StringSet::Iterator begin, typename StringSet::Iterator end,
-        uint16_t* bktout, size_t depth) const {
+        std::uint16_t* bktout, size_t depth) const {
         while (begin != end)
         {
             if (begin + Rollout <= end)
@@ -550,7 +551,7 @@ public:
     void classify(
         const StringSet& strset,
         typename StringSet::Iterator begin, typename StringSet::Iterator end,
-        uint16_t* bktout, size_t depth) const {
+        std::uint16_t* bktout, size_t depth) const {
         while (begin != end)
         {
             key_type key = get_key<key_type>(strset, *begin++, depth);
@@ -619,7 +620,7 @@ public:
     //! search in splitter tree for bucket number, unrolled for Rollout keys at
     //! once.
     void find_bkt_unroll(
-        const key_type key[Rollout], uint16_t obkt[Rollout]) const {
+        const key_type key[Rollout], std::uint16_t obkt[Rollout]) const {
         // binary tree traversal without left branch
 
         unsigned int i[Rollout];
@@ -687,7 +688,7 @@ public:
     void classify(
         const StringSet& strset,
         typename StringSet::Iterator begin, typename StringSet::Iterator end,
-        uint16_t* bktout, size_t depth) const {
+        std::uint16_t* bktout, size_t depth) const {
         while (begin != end)
         {
             if (begin + Rollout <= end)

--- a/tlx/sort/strings/string_set.hpp
+++ b/tlx/sort/strings/string_set.hpp
@@ -99,99 +99,99 @@ public:
 
     //! Return up to 1 characters of string s at iterator i packed into a
     //! uint8_t (only works correctly for 8-bit characters)
-    uint8_t get_uint8(
+    std::uint8_t get_uint8(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
         if (ss.is_end(s, i)) return 0;
-        return uint8_t(*i);
+        return std::uint8_t(*i);
     }
 
     //! Return up to 2 characters of string s at iterator i packed into a
     //! uint16_t (only works correctly for 8-bit characters)
-    uint16_t get_uint16(
+    std::uint16_t get_uint16(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
-        uint16_t v = 0;
+        std::uint16_t v = 0;
         if (ss.is_end(s, i)) return v;
-        v = (uint16_t(*i) << 8);
+        v = (std::uint16_t(*i) << 8);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint16_t(*i) << 0);
+        v |= (std::uint16_t(*i) << 0);
         return v;
     }
 
     //! Return up to 4 characters of string s at iterator i packed into a
     //! uint32_t (only works correctly for 8-bit characters)
-    uint32_t get_uint32(
+    std::uint32_t get_uint32(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
-        uint32_t v = 0;
+        std::uint32_t v = 0;
         if (ss.is_end(s, i)) return v;
-        v = (uint32_t(*i) << 24);
+        v = (std::uint32_t(*i) << 24);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint32_t(*i) << 16);
+        v |= (std::uint32_t(*i) << 16);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint32_t(*i) << 8);
+        v |= (std::uint32_t(*i) << 8);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint32_t(*i) << 0);
+        v |= (std::uint32_t(*i) << 0);
         return v;
     }
 
     //! Return up to 8 characters of string s at iterator i packed into a
     //! uint64_t (only works correctly for 8-bit characters)
-    uint64_t get_uint64(
+    std::uint64_t get_uint64(
         const typename Traits::String& s, typename Traits::CharIterator i) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
 
-        uint64_t v = 0;
+        std::uint64_t v = 0;
         if (ss.is_end(s, i)) return v;
-        v = (uint64_t(*i) << 56);
+        v = (std::uint64_t(*i) << 56);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 48);
+        v |= (std::uint64_t(*i) << 48);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 40);
+        v |= (std::uint64_t(*i) << 40);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 32);
+        v |= (std::uint64_t(*i) << 32);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 24);
+        v |= (std::uint64_t(*i) << 24);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 16);
+        v |= (std::uint64_t(*i) << 16);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 8);
+        v |= (std::uint64_t(*i) << 8);
         ++i;
         if (ss.is_end(s, i)) return v;
-        v |= (uint64_t(*i) << 0);
+        v |= (std::uint64_t(*i) << 0);
         return v;
     }
 
-    uint8_t get_uint8(const typename Traits::String& s, size_t depth) const {
+    std::uint8_t get_uint8(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint8(s, ss.get_chars(s, depth));
     }
 
-    uint16_t get_uint16(const typename Traits::String& s, size_t depth) const {
+    std::uint16_t get_uint16(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint16(s, ss.get_chars(s, depth));
     }
 
-    uint32_t get_uint32(const typename Traits::String& s, size_t depth) const {
+    std::uint32_t get_uint32(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint32(s, ss.get_chars(s, depth));
     }
 
-    uint64_t get_uint64(const typename Traits::String& s, size_t depth) const {
+    std::uint64_t get_uint64(const typename Traits::String& s, size_t depth) const {
         const StringSet& ss = *static_cast<const StringSet*>(this);
         return get_uint64(s, ss.get_chars(s, depth));
     }
@@ -244,7 +244,7 @@ public:
 
 template <typename Type, typename StringSet>
 inline
-typename enable_if<sizeof(Type) == 4, uint32_t>::type
+typename enable_if<sizeof(Type) == 4, std::uint32_t>::type
 get_key(const StringSet& strset,
         const typename StringSet::String& s, size_t depth) {
     return strset.get_uint32(s, depth);
@@ -252,7 +252,7 @@ get_key(const StringSet& strset,
 
 template <typename Type, typename StringSet>
 inline
-typename enable_if<sizeof(Type) == 8, uint64_t>::type
+typename enable_if<sizeof(Type) == 8, std::uint64_t>::type
 get_key(const StringSet& strset,
         const typename StringSet::String& s, size_t depth) {
     return strset.get_uint64(s, depth);
@@ -373,7 +373,7 @@ class StdStringSetTraits
 {
 public:
     //! exported alias for character type
-    typedef uint8_t Char;
+    typedef std::uint8_t Char;
 
     //! String reference: std::string, which should be reference counted.
     typedef std::string String;
@@ -456,7 +456,7 @@ class UPtrStdStringSetTraits
 {
 public:
     //! exported alias for character type
-    typedef uint8_t Char;
+    typedef std::uint8_t Char;
 
     //! String reference: std::string, which should be reference counted.
     typedef std::unique_ptr<std::string> String;
@@ -552,7 +552,7 @@ public:
     typedef std::string Text;
 
     //! exported alias for character type
-    typedef uint8_t Char;
+    typedef std::uint8_t Char;
 
     //! String reference: suffix index of the text.
     typedef typename Text::size_type String;

--- a/tlx/sort/strings_parallel.hpp
+++ b/tlx/sort/strings_parallel.hpp
@@ -168,10 +168,10 @@ void sort_strings_parallel(std::vector<std::string>& strings,
  */
 static inline
 void sort_strings_parallel_lcp(unsigned char** strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     sort_strings_detail::parallel_sample_sort(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::UCharStringSet, uint32_t>(
+            sort_strings_detail::UCharStringSet, std::uint32_t>(
             sort_strings_detail::UCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -183,7 +183,7 @@ void sort_strings_parallel_lcp(unsigned char** strings, size_t size,
  * The memory limit is currently not used.
  */
 static inline
-void sort_strings_parallel_lcp(char** strings, size_t size, uint32_t* lcp,
+void sort_strings_parallel_lcp(char** strings, size_t size, std::uint32_t* lcp,
                                size_t memory = 0) {
     return sort_strings_parallel_lcp(
         reinterpret_cast<unsigned char**>(strings), size, lcp, memory);
@@ -196,10 +196,10 @@ void sort_strings_parallel_lcp(char** strings, size_t size, uint32_t* lcp,
  */
 static inline
 void sort_strings_parallel_lcp(const unsigned char** strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     sort_strings_detail::parallel_sample_sort(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::CUCharStringSet, uint32_t>(
+            sort_strings_detail::CUCharStringSet, std::uint32_t>(
             sort_strings_detail::CUCharStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -212,7 +212,7 @@ void sort_strings_parallel_lcp(const unsigned char** strings, size_t size,
  */
 static inline
 void sort_strings_parallel_lcp(const char** strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         reinterpret_cast<const unsigned char**>(strings), size, lcp, memory);
 }
@@ -226,7 +226,7 @@ void sort_strings_parallel_lcp(const char** strings, size_t size,
  * The memory limit is currently not used.
  */
 static inline
-void sort_strings_parallel_lcp(std::vector<char*>& strings, uint32_t* lcp,
+void sort_strings_parallel_lcp(std::vector<char*>& strings, std::uint32_t* lcp,
                                size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
@@ -239,7 +239,7 @@ void sort_strings_parallel_lcp(std::vector<char*>& strings, uint32_t* lcp,
  */
 static inline
 void sort_strings_parallel_lcp(std::vector<unsigned char*>& strings,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }
@@ -251,7 +251,7 @@ void sort_strings_parallel_lcp(std::vector<unsigned char*>& strings,
  * The memory limit is currently not used.
  */
 static inline
-void sort_strings_parallel_lcp(std::vector<const char*>& strings, uint32_t* lcp,
+void sort_strings_parallel_lcp(std::vector<const char*>& strings, std::uint32_t* lcp,
                                size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
@@ -264,7 +264,7 @@ void sort_strings_parallel_lcp(std::vector<const char*>& strings, uint32_t* lcp,
  */
 static inline
 void sort_strings_parallel_lcp(std::vector<const unsigned char*>& strings,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }
@@ -279,10 +279,10 @@ void sort_strings_parallel_lcp(std::vector<const unsigned char*>& strings,
  */
 static inline
 void sort_strings_parallel_lcp(std::string* strings, size_t size,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     sort_strings_detail::parallel_sample_sort(
         sort_strings_detail::StringLcpPtr<
-            sort_strings_detail::StdStringSet, uint32_t>(
+            sort_strings_detail::StdStringSet, std::uint32_t>(
             sort_strings_detail::StdStringSet(strings, strings + size), lcp),
         /* depth */ 0, memory);
 }
@@ -295,7 +295,7 @@ void sort_strings_parallel_lcp(std::string* strings, size_t size,
  */
 static inline
 void sort_strings_parallel_lcp(std::vector<std::string>& strings,
-                               uint32_t* lcp, size_t memory = 0) {
+                               std::uint32_t* lcp, size_t memory = 0) {
     return sort_strings_parallel_lcp(
         strings.data(), strings.size(), lcp, memory);
 }

--- a/tlx/string/base64.cpp
+++ b/tlx/string/base64.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/base64.hpp>
 
+#include <cstdint>
 #include <stdexcept>
 
 namespace tlx {
@@ -23,8 +24,8 @@ namespace tlx {
 // Base64 Encoding and Decoding
 
 std::string base64_encode(const void* data, size_t size, size_t line_break) {
-    const uint8_t* in = reinterpret_cast<const uint8_t*>(data);
-    const uint8_t* in_end = in + size;
+    const std::uint8_t* in = reinterpret_cast<const std::uint8_t*>(data);
+    const std::uint8_t* in_end = in + size;
     std::string out;
 
     if (size == 0) return out;
@@ -42,7 +43,7 @@ std::string base64_encode(const void* data, size_t size, size_t line_break) {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
     };
 
-    uint8_t result = 0;
+    std::uint8_t result = 0;
     size_t line_begin = 0;
 
     while (true)
@@ -53,10 +54,10 @@ std::string base64_encode(const void* data, size_t size, size_t line_break) {
         }
 
         // step 0: process first byte, write first letter
-        uint8_t fragment = *in++;
+        std::uint8_t fragment = *in++;
         result = (fragment & 0xFC) >> 2;
         out += encoding64[result];
-        result = static_cast<uint8_t>((fragment & 0x03) << 4);
+        result = static_cast<std::uint8_t>((fragment & 0x03) << 4);
 
         // step 1: if string finished here, add two padding '='s
         if (in == in_end) {
@@ -71,7 +72,7 @@ std::string base64_encode(const void* data, size_t size, size_t line_break) {
         fragment = *in++;
         result |= (fragment & 0xF0) >> 4;
         out += encoding64[result];
-        result = static_cast<uint8_t>((fragment & 0x0F) << 2);
+        result = static_cast<std::uint8_t>((fragment & 0x0F) << 2);
 
         // step 2: if string finished here, add one padding '='
         if (in == in_end) {
@@ -106,18 +107,18 @@ std::string base64_encode(const std::string& str, size_t line_break) {
 /******************************************************************************/
 
 std::string base64_decode(const void* data, size_t size, bool strict) {
-    const uint8_t* in = reinterpret_cast<const uint8_t*>(data);
-    const uint8_t* in_end = in + size;
+    const std::uint8_t* in = reinterpret_cast<const std::uint8_t*>(data);
+    const std::uint8_t* in_end = in + size;
     std::string out;
 
     // estimate the output size, assume that the whole input string is
     // base64 encoded.
     out.reserve(size * 3 / 4);
 
-    static constexpr uint8_t ex = 255;
-    static constexpr uint8_t ws = 254;
+    static constexpr std::uint8_t ex = 255;
+    static constexpr std::uint8_t ws = 254;
     // value lookup table: -1 -> exception, -2 -> skip whitespace
-    static const uint8_t decoding64[256] = {
+    static const std::uint8_t decoding64[256] = {
         ex, ex, ex, ex, ex, ex, ex, ex, ex, ws, ws, ex, ex, ws, ex, ex,
         ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex,
         ws, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, 62, ex, ex, ex, 63,
@@ -136,7 +137,7 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
         ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex, ex
     };
 
-    uint8_t outchar, fragment;
+    std::uint8_t outchar, fragment;
 
     static const char* ex_message =
         "Invalid character encountered during base64 decoding.";
@@ -153,7 +154,7 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>((fragment & 0x3F) << 2);
+        outchar = static_cast<std::uint8_t>((fragment & 0x3F) << 2);
 
         // step 1: get second valid letter. output the first byte.
         do {
@@ -165,10 +166,10 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>(outchar | ((fragment & 0x30) >> 4));
+        outchar = static_cast<std::uint8_t>(outchar | ((fragment & 0x30) >> 4));
         out += static_cast<char>(outchar);
 
-        outchar = static_cast<uint8_t>((fragment & 0x0F) << 4);
+        outchar = static_cast<std::uint8_t>((fragment & 0x0F) << 4);
 
         // step 2: get third valid letter. output the second byte.
         do {
@@ -180,10 +181,10 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>(outchar | ((fragment & 0x3C) >> 2));
+        outchar = static_cast<std::uint8_t>(outchar | ((fragment & 0x3C) >> 2));
         out += static_cast<char>(outchar);
 
-        outchar = static_cast<uint8_t>((fragment & 0x03) << 6);
+        outchar = static_cast<std::uint8_t>((fragment & 0x03) << 6);
 
         // step 3: get fourth valid letter. output the third byte.
         do {
@@ -195,7 +196,7 @@ std::string base64_decode(const void* data, size_t size, bool strict) {
                 throw std::runtime_error(ex_message);
         } while (fragment >= ws);
 
-        outchar = static_cast<uint8_t>(outchar | ((fragment & 0x3F) >> 0));
+        outchar = static_cast<std::uint8_t>(outchar | ((fragment & 0x3F) >> 0));
         out += static_cast<char>(outchar);
     }
 }

--- a/tlx/string/format_iec_units.hpp
+++ b/tlx/string/format_iec_units.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_FORMAT_IEC_UNITS_HEADER
 #define TLX_STRING_FORMAT_IEC_UNITS_HEADER
 
+#include <cstdint>
 #include <string>
 
 namespace tlx {
@@ -20,7 +21,7 @@ namespace tlx {
 
 //! Format a byte size using IEC (Ki, Mi, Gi, Ti) suffixes (powers of
 //! two). Returns "123 Ki" or similar.
-std::string format_iec_units(uint64_t number, int precision = 3);
+std::string format_iec_units(std::uint64_t number, int precision = 3);
 
 //! \}
 

--- a/tlx/string/format_si_iec_units.cpp
+++ b/tlx/string/format_si_iec_units.cpp
@@ -10,14 +10,15 @@
 
 #include <tlx/string/format_si_iec_units.hpp>
 
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 
 namespace tlx {
 
 //! Format number as something like 1 TB
-std::string format_si_units(uint64_t number, int precision) {
-    // may not overflow, std::numeric_limits<uint64_t>::max() == 16 EiB
+std::string format_si_units(std::uint64_t number, int precision) {
+    // may not overflow, std::numeric_limits<std::uint64_t>::max() == 16 EiB
     double multiplier = 1000.0;
     static const char* SI_endings[] = {
         "", "k", "M", "G", "T", "P", "E"
@@ -35,8 +36,8 @@ std::string format_si_units(uint64_t number, int precision) {
 }
 
 //! Format number as something like 1 TiB
-std::string format_iec_units(uint64_t number, int precision) {
-    // may not overflow, std::numeric_limits<uint64_t>::max() == 16 EiB
+std::string format_iec_units(std::uint64_t number, int precision) {
+    // may not overflow, std::numeric_limits<std::uint64_t>::max() == 16 EiB
     double multiplier = 1024.0;
     static const char* IEC_endings[] = {
         "", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"

--- a/tlx/string/format_si_units.hpp
+++ b/tlx/string/format_si_units.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_FORMAT_SI_UNITS_HEADER
 #define TLX_STRING_FORMAT_SI_UNITS_HEADER
 
+#include <cstdint>
 #include <string>
 
 namespace tlx {
@@ -20,7 +21,7 @@ namespace tlx {
 
 //! Format a byte size using SI (K, M, G, T) suffixes (powers of ten). Returns
 //! "123 M" or similar.
-std::string format_si_units(uint64_t number, int precision = 3);
+std::string format_si_units(std::uint64_t number, int precision = 3);
 
 //! \}
 

--- a/tlx/string/hash_djb2.hpp
+++ b/tlx/string/hash_djb2.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_HASH_DJB2_HEADER
 #define TLX_STRING_HASH_DJB2_HEADER
 
+#include <cstdint>
 #include <string>
 
 namespace tlx {
@@ -23,8 +24,8 @@ namespace tlx {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const unsigned char* str) {
-    uint32_t hash = 5381;
+std::uint32_t hash_djb2(const unsigned char* str) {
+    std::uint32_t hash = 5381;
     unsigned char c;
     while ((c = *str++) != 0) {
         // hash * 33 + c
@@ -38,7 +39,7 @@ uint32_t hash_djb2(const unsigned char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const char* str) {
+std::uint32_t hash_djb2(const char* str) {
     return hash_djb2(reinterpret_cast<const unsigned char*>(str));
 }
 
@@ -47,8 +48,8 @@ uint32_t hash_djb2(const char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const unsigned char* str, size_t size) {
-    uint32_t hash = 5381;
+std::uint32_t hash_djb2(const unsigned char* str, size_t size) {
+    std::uint32_t hash = 5381;
     while (size-- > 0) {
         // hash * 33 + c
         hash = ((hash << 5) + hash) + static_cast<unsigned char>(*str++);
@@ -61,7 +62,7 @@ uint32_t hash_djb2(const unsigned char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const char* str, size_t size) {
+std::uint32_t hash_djb2(const char* str, size_t size) {
     return hash_djb2(reinterpret_cast<const unsigned char*>(str), size);
 }
 
@@ -70,7 +71,7 @@ uint32_t hash_djb2(const char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_djb2(const std::string& str) {
+std::uint32_t hash_djb2(const std::string& str) {
     return hash_djb2(str.data(), str.size());
 }
 

--- a/tlx/string/hash_sdbm.hpp
+++ b/tlx/string/hash_sdbm.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_HASH_SDBM_HEADER
 #define TLX_STRING_HASH_SDBM_HEADER
 
+#include <cstdint>
 #include <string>
 
 namespace tlx {
@@ -23,8 +24,8 @@ namespace tlx {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const unsigned char* str) {
-    uint32_t hash = 0;
+std::uint32_t hash_sdbm(const unsigned char* str) {
+    std::uint32_t hash = 0;
     unsigned char c;
     while ((c = *str++) != 0) {
         hash = c + (hash << 6) + (hash << 16) - hash;
@@ -37,7 +38,7 @@ uint32_t hash_sdbm(const unsigned char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const char* str) {
+std::uint32_t hash_sdbm(const char* str) {
     return hash_sdbm(reinterpret_cast<const unsigned char*>(str));
 }
 
@@ -46,8 +47,8 @@ uint32_t hash_sdbm(const char* str) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const unsigned char* str, size_t size) {
-    uint32_t hash = 0;
+std::uint32_t hash_sdbm(const unsigned char* str, size_t size) {
+    std::uint32_t hash = 0;
     while (size-- > 0) {
         hash = static_cast<unsigned char>(*str++)
                + (hash << 6) + (hash << 16) - hash;
@@ -60,7 +61,7 @@ uint32_t hash_sdbm(const unsigned char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const char* str, size_t size) {
+std::uint32_t hash_sdbm(const char* str, size_t size) {
     return hash_sdbm(reinterpret_cast<const unsigned char*>(str), size);
 }
 
@@ -69,7 +70,7 @@ uint32_t hash_sdbm(const char* str, size_t size) {
  * http://www.cse.yorku.ca/~oz/hash.html
  */
 static inline
-uint32_t hash_sdbm(const std::string& str) {
+std::uint32_t hash_sdbm(const std::string& str) {
     return hash_sdbm(str.data(), str.size());
 }
 

--- a/tlx/string/hexdump.cpp
+++ b/tlx/string/hexdump.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/hexdump.hpp>
 
+#include <cstdint>
 #include <sstream>
 #include <stdexcept>
 
@@ -47,7 +48,7 @@ std::string hexdump(const std::vector<char>& data) {
     return hexdump(data.data(), data.size());
 }
 
-std::string hexdump(const std::vector<uint8_t>& data) {
+std::string hexdump(const std::vector<std::uint8_t>& data) {
     return hexdump(data.data(), data.size());
 }
 
@@ -55,7 +56,7 @@ std::string hexdump_sourcecode(
     const std::string& str, const std::string& var_name) {
 
     std::ostringstream header;
-    header << "const uint8_t " << var_name << "[" << str.size() << "] = {\n";
+    header << "const std::uint8_t " << var_name << "[" << str.size() << "] = {\n";
 
     static const int perline = 16;
 
@@ -121,7 +122,7 @@ std::string hexdump_lc(const std::vector<char>& data) {
     return hexdump_lc(data.data(), data.size());
 }
 
-std::string hexdump_lc(const std::vector<uint8_t>& data) {
+std::string hexdump_lc(const std::vector<std::uint8_t>& data) {
     return hexdump_lc(data.data(), data.size());
 }
 

--- a/tlx/string/hexdump.hpp
+++ b/tlx/string/hexdump.hpp
@@ -67,11 +67,11 @@ std::string hexdump(const std::vector<char>& data);
  * \param data  binary data to output in hex
  * \return      string of hexadecimal pairs
  */
-std::string hexdump(const std::vector<uint8_t>& data);
+std::string hexdump(const std::vector<std::uint8_t>& data);
 
 /*!
  * Dump a (binary) string into a C source code snippet. The snippet defines an
- * array of const uint8_t* holding the data of the string.
+ * array of const std::uint8_t* holding the data of the string.
  *
  * \param str       string to output as C source array
  * \param var_name  name of the array variable in the outputted code snippet
@@ -125,7 +125,7 @@ std::string hexdump_lc(const std::vector<char>& data);
  * \param data  binary data to output in hex
  * \return      string of hexadecimal pairs
  */
-std::string hexdump_lc(const std::vector<uint8_t>& data);
+std::string hexdump_lc(const std::vector<std::uint8_t>& data);
 
 /******************************************************************************/
 // Parser for Hex Digit Sequence

--- a/tlx/string/parse_si_iec_units.cpp
+++ b/tlx/string/parse_si_iec_units.cpp
@@ -10,12 +10,13 @@
 
 #include <tlx/string/parse_si_iec_units.hpp>
 
+#include <cstdint>
 #include <cstdlib>
 
 namespace tlx {
 
 bool parse_si_iec_units(
-    const char* str, uint64_t* out_size, char default_unit) {
+    const char* str, std::uint64_t* out_size, char default_unit) {
 
     char* endptr;
     *out_size = strtoul(str, &endptr, 10);
@@ -86,7 +87,7 @@ bool parse_si_iec_units(
 }
 
 bool parse_si_iec_units(
-    const std::string& str, uint64_t* out_size, char default_unit) {
+    const std::string& str, std::uint64_t* out_size, char default_unit) {
     return parse_si_iec_units(str.c_str(), out_size, default_unit);
 }
 

--- a/tlx/string/parse_si_iec_units.hpp
+++ b/tlx/string/parse_si_iec_units.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_PARSE_SI_IEC_UNITS_HEADER
 #define TLX_STRING_PARSE_SI_IEC_UNITS_HEADER
 
+#include <cstdint>
 #include <string>
 
 namespace tlx {
@@ -25,7 +26,7 @@ namespace tlx {
  * (powers of ten) or in K/M/G/T/P (power of two).
  */
 bool parse_si_iec_units(
-    const char* str, uint64_t* out_size, char default_unit = 0);
+    const char* str, std::uint64_t* out_size, char default_unit = 0);
 
 /*!
  * Parse a string like "343KB" or "44 GiB" into the corresponding size in
@@ -34,7 +35,7 @@ bool parse_si_iec_units(
  * (powers of ten) or in K/M/G/T/P (power of two).
  */
 bool parse_si_iec_units(
-    const std::string& str, uint64_t* out_size, char default_unit = 0);
+    const std::string& str, std::uint64_t* out_size, char default_unit = 0);
 
 //! \}
 


### PR DESCRIPTION
* fix uintX_t usage by using std:: prefix and <cstdint> include
* CI: enable gcc 13 and macos-12/13 compilation