### PR TITLE
Update cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,14 @@
 # All rights reserved. Published under the Boost Software License, Version 1.0
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9)
 
-if(NOT TARGET tlx)
+if(TARGET tlx)
+  return()
+endif()
 
 # custom cmake scripts
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/misc/cmake)
-
-# project
-project(tlx)
 
 # default to Debug building for single-config generators
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -43,6 +42,11 @@ endif()
 set(TLX_VERSION "0.6.1")
 set(TLX_SOVERSION "0.6")
 #[[end]]
+
+# project
+project(tlx
+  DESCRIPTION "A Collection of Sophisticated C++ Data Structures, Algorithms, and Miscellaneous Helpers"
+  VERSION ${TLX_VERSION})
 
 ################################################################################
 ### Options and Switches
@@ -464,9 +468,5 @@ if(TLX_INSTALL_PKGCONFIG_DIR)
   install(FILES ${PROJECT_BINARY_DIR}/${TLX_LIBNAME}.pc
     DESTINATION ${TLX_INSTALL_PKGCONFIG_DIR})
 endif()
-
-################################################################################
-
-endif(NOT TARGET tlx)
 
 ################################################################################


### PR DESCRIPTION
Compiling a project using tlx shows the following prominent warning message:

```
CMake Deprecation Warning at extlib/tlx/CMakeLists.txt:11 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Warning (dev) at extlib/tlx/CMakeLists.txt:19 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
This warning is for project developers.  Use -Wno-dev to suppress it.
```

I think cmake 3.9 should be old enough that it is available on basically every machine. Ubuntu ships cmake 3.28