### PR TITLE
[tidy] enable clang-tidy analysis and fix all includes using its include fixer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks:
+  - "-*"
+  - "misc-include-cleaner"
+
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+FormatStyle: file

--- a/.woodpecker/build-test.yaml
+++ b/.woodpecker/build-test.yaml
@@ -146,12 +146,12 @@ steps:
       - cmake ${CMAKE_FLAGS}
           -G Ninja
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-          -DCMAKE_C_COMPILER=${C_COMPILER}
           -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
           -DCMAKE_CXX_FLAGS=${CXX_FLAGS}
-          -DTLX_WARNINGS_ARE_ERRORS=ON
+          -DCMAKE_C_COMPILER=${C_COMPILER}
           -DTLX_BUILD_TESTS=ON
           -DTLX_TRY_COMPILE_HEADERS=ON
+          -DTLX_WARNINGS_ARE_ERRORS=ON
           ..
       - ninja
       - ninja test

--- a/.woodpecker/clang-tidy.yaml
+++ b/.woodpecker/clang-tidy.yaml
@@ -1,0 +1,32 @@
+when:
+  - event: pull_request
+  - event: manual
+
+matrix:
+  include:
+    - IMAGE:        ubuntu-24.04
+      BUILD_TYPE:   Release
+      C_COMPILER:   clang
+      CXX_COMPILER: clang++
+      CXX_FLAGS:
+
+steps:
+  - name: build
+    image: docker.io/bingmann/dev:${IMAGE}
+    commands:
+      - cmake --version
+      - mkdir build; cd build
+      - cmake
+          -G Ninja
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+          -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
+          -DCMAKE_CXX_FLAGS=${CXX_FLAGS}
+          -DCMAKE_C_COMPILER=${C_COMPILER}
+          -DTLX_BUILD_TESTS=ON
+          -DTLX_TRY_COMPILE_HEADERS=OFF
+          -DTLX_USE_CLANG_TIDY=ON
+          -DTLX_WARNINGS_ARE_ERRORS=ON
+          ..
+      - ninja
+      - cd ..
+      - bash -c 'clang-tidy -p build {tlx,tests}/*.[hc]pp {tlx,tests}/**/*.[hc]pp'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ option(TLX_MORE_TESTS
 option(TLX_WARNINGS_ARE_ERRORS
   "Compile with flags such that warnings are error." OFF)
 
+option(TLX_USE_CLANG_TIDY
+  "Compile with clang-tidy." OFF)
+
 ### building shared and/or static libraries
 
 # by default we currently only build a static library
@@ -272,6 +275,21 @@ endif()
 message(STATUS "TLX CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 ###############################################################################
+# enable clang-tidy analysis
+
+if(TLX_USE_CLANG_TIDY)
+
+  set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
+
+  # Generate a compile_commands.json to be used by external tools.
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
+    ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+
+endif()
+
+###############################################################################
 # enable gcov coverage analysis with gcc
 
 if(TLX_USE_GCOV)
@@ -393,7 +411,7 @@ if(TLX_TRY_COMPILE_HEADERS)
     set(source_name "${PROJECT_BINARY_DIR}/try_compile/${target_name}.cpp")
 
     file(WRITE ${source_name}
-      "#include <${header_file}>
+      "#include <${header_file}> // NOLINT(misc-include-cleaner)
        int main() { return 0; }")
 
     add_executable(${target_name} ${source_name})

--- a/tests/algorithm/multiway_merge_benchmark.cpp
+++ b/tests/algorithm/multiway_merge_benchmark.cpp
@@ -10,20 +10,21 @@
  ******************************************************************************/
 
 #include <tlx/algorithm/multiway_merge.hpp>
+#include <tlx/algorithm/multiway_merge_splitting.hpp>
 #include <tlx/algorithm/parallel_multiway_merge.hpp>
 #include <tlx/cmdline_parser.hpp>
 #include <tlx/die.hpp>
 #include <tlx/logger.hpp>
-#include <tlx/string/format_si_iec_units.hpp>
+#include <tlx/string/format_iec_units.hpp>
 #include <tlx/timestamp.hpp>
 #include <algorithm>
-#include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <iostream>
-#include <limits>
 #include <random>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 

--- a/tests/algorithm/multiway_merge_test.cpp
+++ b/tests/algorithm/multiway_merge_test.cpp
@@ -9,11 +9,18 @@
  ******************************************************************************/
 
 #include <tlx/algorithm/multiway_merge.hpp>
+#include <tlx/algorithm/multiway_merge_splitting.hpp>
 #include <tlx/algorithm/parallel_multiway_merge.hpp>
 #include <tlx/die.hpp>
 #include <tlx/logger.hpp>
+#include <cstddef>
+#include <functional>
 #include <iostream>
+#include <iterator>
+#include <limits>
 #include <random>
+#include <utility>
+#include <vector>
 
 struct Something
 {

--- a/tests/algorithm/random_bipartition_shuffle.cpp
+++ b/tests/algorithm/random_bipartition_shuffle.cpp
@@ -10,11 +10,8 @@
 
 #include <tlx/algorithm/random_bipartition_shuffle.hpp>
 #include <tlx/die.hpp>
-#include <algorithm>
-#include <array>
-#include <iostream>
-#include <iterator>
-#include <utility>
+#include <cstddef>
+#include <random>
 #include <vector>
 
 // This unit test performs a large number (10000) of random_shuffles, each time

--- a/tests/algorithm_test.cpp
+++ b/tests/algorithm_test.cpp
@@ -8,11 +8,16 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
-#include <tlx/algorithm.hpp>
+#include <tlx/algorithm/exclusive_scan.hpp>
+#include <tlx/algorithm/is_sorted_cmp.hpp>
+#include <tlx/algorithm/merge_combine.hpp>
 #include <tlx/die.hpp>
 #include <tlx/logger.hpp>
+#include <algorithm>
+#include <cstddef>
 #include <functional>
 #include <iterator>
+#include <utility>
 #include <vector>
 
 static void test_merge_combine()

--- a/tests/container/btree_speedtest.cpp
+++ b/tests/container/btree_speedtest.cpp
@@ -8,13 +8,14 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/btree.hpp>
 #include <tlx/container/btree_multimap.hpp>
 #include <tlx/container/btree_multiset.hpp>
 #include <tlx/container/splay_tree.hpp>
 #include <tlx/die.hpp>
 #include <tlx/timestamp.hpp>
-#include <chrono>
 #include <cstdlib>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -23,6 +24,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 // *** Settings
 

--- a/tests/container/btree_test.cpp
+++ b/tests/container/btree_test.cpp
@@ -8,16 +8,21 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/btree.hpp>
 #include <tlx/container/btree_map.hpp>
 #include <tlx/container/btree_multimap.hpp>
 #include <tlx/container/btree_multiset.hpp>
 #include <tlx/container/btree_set.hpp>
 #include <tlx/die.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
+#include <cstdlib>
+#include <functional>
 #include <set>
+#include <string>
+#include <utility>
 #include <vector>
 
 #if TLX_MORE_TESTS

--- a/tests/container/d_ary_heap_speedtest.cpp
+++ b/tests/container/d_ary_heap_speedtest.cpp
@@ -12,13 +12,14 @@
 #include <tlx/container/d_ary_heap.hpp>
 #include <tlx/die.hpp>
 #include <tlx/timestamp.hpp>
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <queue>
 #include <string>
+#include <vector>
 
 // *** Settings
 

--- a/tests/container/d_ary_heap_test.cpp
+++ b/tests/container/d_ary_heap_test.cpp
@@ -12,7 +12,10 @@
 #include <tlx/container/d_ary_heap.hpp>
 #include <tlx/die.hpp>
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <ostream>
 #include <random>
 #include <set>
 #include <vector>

--- a/tests/container/loser_tree_test.cpp
+++ b/tests/container/loser_tree_test.cpp
@@ -14,8 +14,11 @@
 #include <tlx/logger.hpp>
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <random>
+#include <utility>
 #include <vector>
 
 static long ctor_dtor_counter = 0;

--- a/tests/container/lru_cache_test.cpp
+++ b/tests/container/lru_cache_test.cpp
@@ -13,6 +13,8 @@
 
 #include <tlx/container/lru_cache.hpp>
 #include <tlx/die.hpp>
+#include <cstddef>
+#include <stdexcept>
 
 namespace tlx {
 

--- a/tests/container/radix_heap_test.cpp
+++ b/tests/container/radix_heap_test.cpp
@@ -12,13 +12,14 @@
 #include <tlx/die.hpp>
 #include <tlx/logger.hpp>
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <limits>
 #include <queue>
 #include <random>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 /******************************************************************************/

--- a/tests/container/ring_buffer_test.cpp
+++ b/tests/container/ring_buffer_test.cpp
@@ -10,6 +10,8 @@
 
 #include <tlx/container/ring_buffer.hpp>
 #include <tlx/die.hpp>
+#include <cstddef>
+#include <utility>
 
 static void test_fill_circular(size_t rb_size)
 {

--- a/tests/container/simple_vector_test.cpp
+++ b/tests/container/simple_vector_test.cpp
@@ -11,6 +11,8 @@
 #include <tlx/container/simple_vector.hpp>
 #include <tlx/die.hpp>
 #include <algorithm>
+#include <cstddef>
+#include <utility>
 
 struct MyInteger
 {

--- a/tests/container/splay_tree_test.cpp
+++ b/tests/container/splay_tree_test.cpp
@@ -11,8 +11,8 @@
 #include <tlx/container/splay_tree.hpp>
 #include <tlx/die.hpp>
 #include <algorithm>
+#include <cstddef>
 #include <deque>
-#include <iterator>
 #include <random>
 #include <set>
 #include <vector>

--- a/tests/container/string_view_test.cpp
+++ b/tests/container/string_view_test.cpp
@@ -11,6 +11,8 @@
 #include <tlx/container/string_view.hpp>
 #include <tlx/die.hpp>
 #include <tlx/string/split_view.hpp>
+#include <cstddef>
+#include <string>
 
 void construct_empty()
 {

--- a/tests/die_test.cpp
+++ b/tests/die_test.cpp
@@ -9,8 +9,8 @@
  ******************************************************************************/
 
 #include <tlx/die.hpp>
+#include <tlx/die/core.hpp>
 #include <cmath>
-#include <iomanip>
 
 int main()
 {

--- a/tests/digest_test.cpp
+++ b/tests/digest_test.cpp
@@ -14,6 +14,8 @@
 #include <tlx/digest/sha256.hpp>
 #include <tlx/digest/sha512.hpp>
 #include <tlx/string/hexdump.hpp>
+#include <utility>
+#include <vector>
 
 using namespace tlx;
 

--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -10,7 +10,19 @@
 
 #include <tlx/die.hpp>
 #include <tlx/logger.hpp>
-#include <tlx/logger/all.hpp>
+#include <tlx/logger/all.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/logger/core.hpp>
+#include <tlx/logger/wrap_unprintable.hpp>
+#include <array>
+#include <deque>
+#include <map>
+#include <ostream>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 template <typename Lambda>
 void check(const char* output, Lambda lambda)

--- a/tests/math/aggregate_test.cpp
+++ b/tests/math/aggregate_test.cpp
@@ -10,7 +10,7 @@
 
 #include <tlx/die.hpp>
 #include <tlx/math/aggregate.hpp>
-#include <iomanip>
+#include <cstddef>
 
 void test_integer()
 {

--- a/tests/math/polynomial_regression_test.cpp
+++ b/tests/math/polynomial_regression_test.cpp
@@ -11,8 +11,10 @@
 #include <tlx/die.hpp>
 #include <tlx/logger.hpp>
 #include <tlx/math/polynomial_regression.hpp>
-#include <iomanip>
+#include <cmath>
+#include <cstddef>
 #include <iostream>
+#include <vector>
 
 void test1()
 {

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -9,7 +9,19 @@
  ******************************************************************************/
 
 #include <tlx/die.hpp>
-#include <tlx/math.hpp>
+#include <tlx/math/bswap.hpp>
+#include <tlx/math/clz.hpp>
+#include <tlx/math/ctz.hpp>
+#include <tlx/math/ffs.hpp>
+#include <tlx/math/integer_log2.hpp>
+#include <tlx/math/is_power_of_two.hpp>
+#include <tlx/math/popcount.hpp>
+#include <tlx/math/power_to_the.hpp>
+#include <tlx/math/rol.hpp>
+#include <tlx/math/ror.hpp>
+#include <tlx/math/round_to_power_of_two.hpp>
+#include <tlx/math/round_up.hpp>
+#include <tlx/math/sgn.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/tests/meta/fold_test.cpp
+++ b/tests/meta/fold_test.cpp
@@ -15,7 +15,6 @@
 #include <tlx/meta/fold_right_tuple.hpp>
 #include <tlx/unused.hpp>
 #include <cmath>
-#include <cstddef>
 #include <iostream>
 #include <sstream>
 

--- a/tests/meta/function_chain_test.cpp
+++ b/tests/meta/function_chain_test.cpp
@@ -11,9 +11,7 @@
 
 #include <tlx/die.hpp>
 #include <tlx/meta/function_chain.hpp>
-#include <iostream>
 #include <string>
-#include <vector>
 
 static void test_chain_maker()
 {

--- a/tests/meta/function_stack_test.cpp
+++ b/tests/meta/function_stack_test.cpp
@@ -11,7 +11,7 @@
 
 #include <tlx/die.hpp>
 #include <tlx/meta/function_stack.hpp>
-#include <iostream>
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/tests/meta/has_member_test.cpp
+++ b/tests/meta/has_member_test.cpp
@@ -8,12 +8,10 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
-#include <tlx/die.hpp>
 #include <tlx/meta/has_member.hpp>
 #include <tlx/meta/has_method.hpp>
 #include <tlx/unused.hpp>
 #include <cmath>
-#include <cstddef>
 #include <string>
 
 /******************************************************************************/
@@ -32,6 +30,12 @@ public:
     void tfunc123(const Type& x)
     {
         tlx::unused(x);
+    }
+
+    static double func42(std::string s)
+    {
+        tlx::unused(s);
+        return 42.0;
     }
 };
 
@@ -59,7 +63,8 @@ static_assert(!has_member_tfunc456<ClassA, int>::value,
 // has_method test
 
 // the following code does not work with gcc 4.8
-#if __GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 8))
+#if __GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 8)) ||                 \
+    defined(__clang__)
 
 class ClassC
 {

--- a/tests/meta/log2_test.cpp
+++ b/tests/meta/log2_test.cpp
@@ -56,7 +56,7 @@ void test_log2_value(size_t p)
 static void test_log2()
 {
     /*[[[perl
-      print "test_log2_value<1ull << $_>($_);\n" for (0..63);
+      print "    test_log2_value<1ull << $_>($_);\n" for (0..63);
     ]]]*/
     test_log2_value<1ull << 0>(0);
     test_log2_value<1ull << 1>(1);

--- a/tests/meta/vmap_for_test.cpp
+++ b/tests/meta/vmap_for_test.cpp
@@ -18,6 +18,8 @@
 #include <cstddef>
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <tuple>
 
 /******************************************************************************/
 // vmap_foreach

--- a/tests/multi_timer_test.cpp
+++ b/tests/multi_timer_test.cpp
@@ -13,6 +13,7 @@
 
 #include <tlx/die.hpp>
 #include <tlx/multi_timer.hpp>
+#include <chrono>
 #include <thread>
 
 int main()

--- a/tests/semaphore_test.cpp
+++ b/tests/semaphore_test.cpp
@@ -8,8 +8,8 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
-#include <tlx/die.hpp>
 #include <tlx/semaphore.hpp>
+#include <cstddef>
 #include <thread>
 
 static void test_semaphore()

--- a/tests/siphash_test.cpp
+++ b/tests/siphash_test.cpp
@@ -13,6 +13,8 @@
 
 #include <tlx/die.hpp>
 #include <tlx/siphash.hpp>
+#include <cstddef>
+#include <cstdint>
 
 static const std::uint64_t test_vectors_data[64] = {
     0x726fdb47dd0e0e31ull, 0x74f839c593dc67fdull, 0x0d6c8009d9a94f5aull,

--- a/tests/sort_networks_test.cpp
+++ b/tests/sort_networks_test.cpp
@@ -9,10 +9,10 @@
  ******************************************************************************/
 
 #include <tlx/die.hpp>
-#include <tlx/logger.hpp>
 #include <tlx/sort/networks/best.hpp>
 #include <tlx/sort/networks/bose_nelson.hpp>
 #include <tlx/sort/networks/bose_nelson_parameter.hpp>
+#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <random>

--- a/tests/sort_parallel_mergesort_test.cpp
+++ b/tests/sort_parallel_mergesort_test.cpp
@@ -10,9 +10,10 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/algorithm/multiway_merge_splitting.hpp>
 #include <tlx/die.hpp>
-#include <tlx/logger.hpp>
 #include <tlx/sort/parallel_mergesort.hpp>
+#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <random>

--- a/tests/sort_strings_example.cpp
+++ b/tests/sort_strings_example.cpp
@@ -9,15 +9,18 @@
  ******************************************************************************/
 
 #include <tlx/cmdline_parser.hpp>
-#include <tlx/simple_vector.hpp>
+#include <tlx/container/simple_vector.hpp>
 #include <tlx/sort/strings.hpp>
 #include <tlx/sort/strings_parallel.hpp>
 #include <tlx/string/format_iec_units.hpp>
 #include <tlx/timestamp.hpp>
+#include <algorithm>
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <vector>
 
 int main(int argc, char* argv[])
 {

--- a/tests/sort_strings_parallel_test.cpp
+++ b/tests/sort_strings_parallel_test.cpp
@@ -10,8 +10,18 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/simple_vector.hpp>
+#include <tlx/logger.hpp>
 #include <tlx/sort/strings/parallel_sample_sort.hpp>
+#include <tlx/sort/strings/sample_sort_tools.hpp>
 #include <tlx/sort/strings_parallel.hpp>
+#include <tlx/timestamp.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <random>
+#include <string>
 #include "sort_strings_test.hpp"
 
 /******************************************************************************/
@@ -72,7 +82,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
                  .check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
     }
 
@@ -97,7 +107,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
                  .check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
     }
 
@@ -123,12 +133,12 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
         if (!check_lcp(ss, lcp.data()))
         {
             LOG1 << "LCP result is not correct!";
-            abort();
+            std::abort();
         }
     }
 

--- a/tests/sort_strings_test.cpp
+++ b/tests/sort_strings_test.cpp
@@ -11,11 +11,19 @@
  ******************************************************************************/
 
 #include "sort_strings_test.hpp"
+#include <tlx/container/simple_vector.hpp>
+#include <tlx/logger.hpp>
 #include <tlx/sort/strings.hpp>
 #include <tlx/sort/strings/insertion_sort.hpp>
 #include <tlx/sort/strings/multikey_quicksort.hpp>
 #include <tlx/sort/strings/radix_sort.hpp>
+#include <tlx/timestamp.hpp>
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <random>
+#include <string>
 
 void TestFrontend(const size_t num_strings, const size_t num_chars,
                   const std::string& letters)
@@ -51,7 +59,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
                  .check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
     }
 
@@ -76,7 +84,7 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
                  .check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
     }
 
@@ -102,12 +110,12 @@ void TestFrontend(const size_t num_strings, const size_t num_chars,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
         if (!check_lcp(ss, lcp.data()))
         {
             LOG1 << "LCP result is not correct!";
-            abort();
+            std::abort();
         }
     }
 

--- a/tests/sort_strings_test.hpp
+++ b/tests/sort_strings_test.hpp
@@ -13,13 +13,18 @@
 #ifndef TLX_TESTS_SORT_STRINGS_TEST_HEADER
 #define TLX_TESTS_SORT_STRINGS_TEST_HEADER
 
+#include <tlx/container/simple_vector.hpp>
 #include <tlx/logger.hpp>
-#include <tlx/simple_vector.hpp>
 #include <tlx/sort/strings/string_ptr.hpp>
+#include <tlx/sort/strings/string_set.hpp>
 #include <tlx/timestamp.hpp>
-#include <chrono>
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <memory>
 #include <random>
+#include <string>
+#include <vector>
 
 #if TLX_MORE_TESTS
 static const bool tlx_more_tests = true;
@@ -132,7 +137,7 @@ void TestUCharString(const char* name, const size_t num_strings,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
     }
     else
@@ -155,12 +160,12 @@ void TestUCharString(const char* name, const size_t num_strings,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
         if (!check_lcp(ss, lcp.data()))
         {
             LOG1 << "LCP result is not correct!";
-            abort();
+            std::abort();
         }
     }
 
@@ -214,7 +219,7 @@ void TestVectorStdString(const char* name, const size_t num_strings,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
     }
     else
@@ -237,12 +242,12 @@ void TestVectorStdString(const char* name, const size_t num_strings,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
         if (!check_lcp(ss, lcp.data()))
         {
             LOG1 << "LCP result is not correct!";
-            abort();
+            std::abort();
         }
     }
 }
@@ -289,7 +294,7 @@ void TestUPtrStdString(const char* name, const size_t num_strings,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
     }
     else
@@ -313,12 +318,12 @@ void TestUPtrStdString(const char* name, const size_t num_strings,
         if (!ss.check_order())
         {
             LOG1 << "Result is not sorted!";
-            abort();
+            std::abort();
         }
         if (!check_lcp(ss, lcp.data()))
         {
             LOG1 << "LCP result is not correct!";
-            abort();
+            std::abort();
         }
     }
 }
@@ -353,7 +358,7 @@ void TestStringSuffixString(const char* name, const size_t num_chars,
     if (!ss.check_order())
     {
         LOG1 << "Result is not sorted!";
-        abort();
+        std::abort();
     }
 }
 

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -8,15 +8,52 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/define/endian.hpp>
 #include <tlx/die.hpp>
 #include <tlx/port/setenv.hpp>
-#include <tlx/string.hpp>
 #include <tlx/string/appendline.hpp>
+#include <tlx/string/base64.hpp>
+#include <tlx/string/bitdump.hpp>
+#include <tlx/string/compare_icase.hpp>
+#include <tlx/string/contains_word.hpp>
+#include <tlx/string/ends_with.hpp>
+#include <tlx/string/equal_icase.hpp>
+#include <tlx/string/erase_all.hpp>
+#include <tlx/string/escape_html.hpp>
+#include <tlx/string/escape_uri.hpp>
+#include <tlx/string/expand_environment_variables.hpp>
+#include <tlx/string/extract_between.hpp>
+#include <tlx/string/format_iec_units.hpp>
+#include <tlx/string/format_si_units.hpp>
+#include <tlx/string/hash_djb2.hpp>
+#include <tlx/string/hash_sdbm.hpp>
+#include <tlx/string/hexdump.hpp>
+#include <tlx/string/join.hpp>
+#include <tlx/string/join_quoted.hpp>
+#include <tlx/string/less_icase.hpp>
+#include <tlx/string/levenshtein.hpp>
+#include <tlx/string/parse_si_iec_units.hpp>
+#include <tlx/string/parse_uri.hpp>
+#include <tlx/string/parse_uri_form_data.hpp>
+#include <tlx/string/replace.hpp>
+#include <tlx/string/split.hpp>
+#include <tlx/string/split_quoted.hpp>
+#include <tlx/string/split_words.hpp>
+#include <tlx/string/ssprintf.hpp>
 #include <tlx/string/ssprintf_generic.hpp>
+#include <tlx/string/starts_with.hpp>
+#include <tlx/string/to_lower.hpp>
+#include <tlx/string/to_upper.hpp>
+#include <tlx/string/trim.hpp>
+#include <tlx/string/word_wrap.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <random>
+#include <sstream>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 //! Returns an initialized unsigned char[] array inside an std::string
 #define ARRAY_AS_STRING(array)                                                 \

--- a/tests/thread_barrier_test.cpp
+++ b/tests/thread_barrier_test.cpp
@@ -13,10 +13,12 @@
 // this makes yield() available in older GCC versions
 #define _GLIBCXX_USE_SCHED_YIELD
 
+#include <tlx/container/simple_vector.hpp>
 #include <tlx/die.hpp>
-#include <tlx/simple_vector.hpp>
 #include <tlx/thread_barrier_mutex.hpp>
 #include <tlx/thread_barrier_spin.hpp>
+#include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <random>
 #include <thread>

--- a/tests/thread_pool_test.cpp
+++ b/tests/thread_pool_test.cpp
@@ -13,8 +13,11 @@
 
 #include <tlx/die.hpp>
 #include <tlx/thread_pool.hpp>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
 #include <numeric>
-#include <string>
+#include <thread>
 #include <vector>
 
 void test_loop_until_empty()

--- a/tlx/algorithm.hpp
+++ b/tlx/algorithm.hpp
@@ -15,18 +15,20 @@
 //! Algorithms for iterators and ranges
 
 /*[[[perl
-print "#include <$_>\n" foreach sort glob("tlx/algorithm/"."*.hpp");
+foreach (sort glob("tlx/algorithm/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n";
+}
 ]]]*/
-#include <tlx/algorithm/exclusive_scan.hpp>
-#include <tlx/algorithm/is_sorted_cmp.hpp>
-#include <tlx/algorithm/merge_advance.hpp>
-#include <tlx/algorithm/merge_combine.hpp>
-#include <tlx/algorithm/multisequence_partition.hpp>
-#include <tlx/algorithm/multisequence_selection.hpp>
-#include <tlx/algorithm/multiway_merge.hpp>
-#include <tlx/algorithm/multiway_merge_splitting.hpp>
-#include <tlx/algorithm/parallel_multiway_merge.hpp>
-#include <tlx/algorithm/random_bipartition_shuffle.hpp>
+#include <tlx/algorithm/exclusive_scan.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/is_sorted_cmp.hpp>  // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/merge_advance.hpp>  // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/merge_combine.hpp>  // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/multisequence_partition.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/multisequence_selection.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/multiway_merge.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/multiway_merge_splitting.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/parallel_multiway_merge.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/algorithm/random_bipartition_shuffle.hpp> // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_ALGORITHM_HEADER

--- a/tlx/algorithm/is_sorted_cmp.hpp
+++ b/tlx/algorithm/is_sorted_cmp.hpp
@@ -11,8 +11,6 @@
 #ifndef TLX_ALGORITHM_IS_SORTED_CMP_HEADER
 #define TLX_ALGORITHM_IS_SORTED_CMP_HEADER
 
-#include <functional>
-
 namespace tlx {
 
 //! \addtogroup tlx_algorithm

--- a/tlx/algorithm/merge_advance.hpp
+++ b/tlx/algorithm/merge_advance.hpp
@@ -19,6 +19,7 @@
 #define TLX_ALGORITHM_MERGE_ADVANCE_HEADER
 
 #include <algorithm>
+#include <iterator>
 
 namespace tlx {
 

--- a/tlx/algorithm/multisequence_partition.hpp
+++ b/tlx/algorithm/multisequence_partition.hpp
@@ -22,6 +22,9 @@
 #include <tlx/math/round_to_power_of_two.hpp>
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <functional>
+#include <iterator>
 #include <queue>
 #include <utility>
 #include <vector>

--- a/tlx/algorithm/multisequence_selection.hpp
+++ b/tlx/algorithm/multisequence_selection.hpp
@@ -22,6 +22,9 @@
 #include <tlx/math/round_to_power_of_two.hpp>
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <functional>
+#include <iterator>
 #include <queue>
 #include <utility>
 #include <vector>

--- a/tlx/algorithm/multiway_merge.hpp
+++ b/tlx/algorithm/multiway_merge.hpp
@@ -21,9 +21,12 @@
 #include <tlx/algorithm/merge_advance.hpp>
 #include <tlx/container/loser_tree.hpp>
 #include <tlx/container/simple_vector.hpp>
+#include <tlx/define/likely.hpp>
 #include <tlx/unused.hpp>
 #include <algorithm>
+#include <cassert>
 #include <functional>
+#include <iterator>
 #include <numeric>
 #include <utility>
 #include <vector>

--- a/tlx/algorithm/multiway_merge_splitting.hpp
+++ b/tlx/algorithm/multiway_merge_splitting.hpp
@@ -19,8 +19,10 @@
 #define TLX_ALGORITHM_MULTIWAY_MERGE_SPLITTING_HEADER
 
 #include <tlx/algorithm/multisequence_partition.hpp>
-#include <tlx/simple_vector.hpp>
+#include <tlx/container/simple_vector.hpp>
 #include <algorithm>
+#include <cstddef>
+#include <iterator>
 #include <vector>
 
 namespace tlx {

--- a/tlx/algorithm/parallel_multiway_merge.cpp
+++ b/tlx/algorithm/parallel_multiway_merge.cpp
@@ -16,6 +16,7 @@
  ******************************************************************************/
 
 #include <tlx/algorithm/parallel_multiway_merge.hpp>
+#include <cstddef>
 
 namespace tlx {
 

--- a/tlx/algorithm/parallel_multiway_merge.hpp
+++ b/tlx/algorithm/parallel_multiway_merge.hpp
@@ -19,7 +19,9 @@
 #define TLX_ALGORITHM_PARALLEL_MULTIWAY_MERGE_HEADER
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
+#include <iterator>
 #include <thread>
 #include <vector>
 
@@ -29,7 +31,7 @@
 
 #include <tlx/algorithm/multiway_merge.hpp>
 #include <tlx/algorithm/multiway_merge_splitting.hpp>
-#include <tlx/simple_vector.hpp>
+#include <tlx/container/simple_vector.hpp>
 
 namespace tlx {
 

--- a/tlx/algorithm/random_bipartition_shuffle.hpp
+++ b/tlx/algorithm/random_bipartition_shuffle.hpp
@@ -12,6 +12,7 @@
 #define TLX_ALGORITHM_RANDOM_BIPARTITION_SHUFFLE_HEADER
 
 #include <cassert>
+#include <cstddef>
 #include <iterator>
 #include <random>
 

--- a/tlx/backtrace.cpp
+++ b/tlx/backtrace.cpp
@@ -20,6 +20,7 @@
 
 #define TLX_HAVE_BACKTRACE_FUNC 1
 
+#include <alloca.h>
 #include <cxxabi.h>
 #include <execinfo.h>
 #include <signal.h>

--- a/tlx/cmdline_parser.hpp
+++ b/tlx/cmdline_parser.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_CMDLINE_PARSER_HEADER
 #define TLX_CMDLINE_PARSER_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <iosfwd>
 #include <string>

--- a/tlx/container.hpp
+++ b/tlx/container.hpp
@@ -15,22 +15,24 @@
 //! Containers and Data Structures
 
 /*[[[perl
-print "#include <$_>\n" foreach sort glob("tlx/container/"."*.hpp");
+foreach (sort glob("tlx/container/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n"
+}
 ]]]*/
-#include <tlx/container/btree.hpp>
-#include <tlx/container/btree_map.hpp>
-#include <tlx/container/btree_multimap.hpp>
-#include <tlx/container/btree_multiset.hpp>
-#include <tlx/container/btree_set.hpp>
-#include <tlx/container/d_ary_addressable_int_heap.hpp>
-#include <tlx/container/d_ary_heap.hpp>
-#include <tlx/container/loser_tree.hpp>
-#include <tlx/container/lru_cache.hpp>
-#include <tlx/container/radix_heap.hpp>
-#include <tlx/container/ring_buffer.hpp>
-#include <tlx/container/simple_vector.hpp>
-#include <tlx/container/splay_tree.hpp>
-#include <tlx/container/string_view.hpp>
+#include <tlx/container/btree.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/container/btree_map.hpp>      // NOLINT(misc-include-cleaner)
+#include <tlx/container/btree_multimap.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/container/btree_multiset.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/container/btree_set.hpp>      // NOLINT(misc-include-cleaner)
+#include <tlx/container/d_ary_addressable_int_heap.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/container/d_ary_heap.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/container/loser_tree.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/container/lru_cache.hpp>     // NOLINT(misc-include-cleaner)
+#include <tlx/container/radix_heap.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/container/ring_buffer.hpp>   // NOLINT(misc-include-cleaner)
+#include <tlx/container/simple_vector.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/container/splay_tree.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/container/string_view.hpp>   // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_CONTAINER_HEADER

--- a/tlx/container/btree.hpp
+++ b/tlx/container/btree.hpp
@@ -19,9 +19,8 @@
 #include <cassert>
 #include <cstddef>
 #include <functional>
-#include <istream>
+#include <iterator>
 #include <memory>
-#include <ostream>
 #include <utility>
 
 namespace tlx {

--- a/tlx/container/d_ary_heap.hpp
+++ b/tlx/container/d_ary_heap.hpp
@@ -15,7 +15,6 @@
 #include <cassert>
 #include <cstddef>
 #include <functional>
-#include <limits>
 #include <queue>
 #include <vector>
 

--- a/tlx/container/loser_tree.hpp
+++ b/tlx/container/loser_tree.hpp
@@ -25,8 +25,10 @@
 #include <tlx/unused.hpp>
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <type_traits>
 #include <utility>
 
 namespace tlx {

--- a/tlx/container/simple_vector.hpp
+++ b/tlx/container/simple_vector.hpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <new>
 #include <utility>
 
 namespace tlx {
@@ -264,7 +265,7 @@ private:
             return static_cast<ValueType*>(operator new(size *
                                                         sizeof(ValueType)));
         }
-        abort();
+        std::abort();
     }
 
     static void destroy_array(ValueType* array, size_t size)
@@ -286,7 +287,7 @@ private:
             operator delete(array);
             return;
         }
-        abort();
+        std::abort();
     }
 };
 

--- a/tlx/container/splay_tree.hpp
+++ b/tlx/container/splay_tree.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_CONTAINER_SPLAY_TREE_HEADER
 #define TLX_CONTAINER_SPLAY_TREE_HEADER
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 

--- a/tlx/container/string_view.hpp
+++ b/tlx/container/string_view.hpp
@@ -24,7 +24,9 @@
 
 #include <tlx/string/hash_djb2.hpp>
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
+#include <functional>
 #include <iterator>
 #include <ostream>
 #include <stdexcept>

--- a/tlx/counting_ptr.hpp
+++ b/tlx/counting_ptr.hpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <cstddef>
 #include <iosfwd>
 #include <type_traits>
 #include <utility>

--- a/tlx/define.hpp
+++ b/tlx/define.hpp
@@ -15,18 +15,20 @@
 //! Attribute macros and other defines
 
 /*[[[perl
-print "#include <$_>\n" foreach sort glob("tlx/define/"."*.hpp");
+foreach (sort glob("tlx/define/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n"
+}
 ]]]*/
-#include <tlx/define/attribute_always_inline.hpp>
-#include <tlx/define/attribute_fallthrough.hpp>
-#include <tlx/define/attribute_format_printf.hpp>
-#include <tlx/define/attribute_packed.hpp>
-#include <tlx/define/attribute_warn_unused_result.hpp>
-#include <tlx/define/constexpr.hpp>
-#include <tlx/define/deprecated.hpp>
-#include <tlx/define/endian.hpp>
-#include <tlx/define/likely.hpp>
-#include <tlx/define/visibility_hidden.hpp>
+#include <tlx/define/attribute_always_inline.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/define/attribute_fallthrough.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/define/attribute_format_printf.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/define/attribute_packed.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/define/attribute_warn_unused_result.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/define/constexpr.hpp>         // NOLINT(misc-include-cleaner)
+#include <tlx/define/deprecated.hpp>        // NOLINT(misc-include-cleaner)
+#include <tlx/define/endian.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/define/likely.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/define/visibility_hidden.hpp> // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_DEFINE_HEADER

--- a/tlx/die/core.cpp
+++ b/tlx/die/core.cpp
@@ -10,8 +10,12 @@
 
 #include <tlx/die/core.hpp>
 #include <atomic>
+#include <cstddef>
+#include <exception>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/die/core.hpp
+++ b/tlx/die/core.hpp
@@ -12,8 +12,8 @@
 #define TLX_DIE_CORE_HEADER
 
 #include <cstring>
-#include <iomanip>
-#include <sstream>
+#include <iomanip> // NOLINT(misc-include-cleaner)
+#include <sstream> // NOLINT(misc-include-cleaner)
 #include <stdexcept>
 #include <string>
 

--- a/tlx/digest.hpp
+++ b/tlx/digest.hpp
@@ -15,12 +15,14 @@
 //! Message Digests: MD-5, SHA-256, and SHA-512.
 
 /*[[[perl
-print "#include <$_>\n" foreach sort glob("tlx/digest/"."*.hpp");
+foreach (sort glob("tlx/digest/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n"
+}
 ]]]*/
-#include <tlx/digest/md5.hpp>
-#include <tlx/digest/sha1.hpp>
-#include <tlx/digest/sha256.hpp>
-#include <tlx/digest/sha512.hpp>
+#include <tlx/digest/md5.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/digest/sha1.hpp>   // NOLINT(misc-include-cleaner)
+#include <tlx/digest/sha256.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/digest/sha512.hpp> // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_DIGEST_HEADER

--- a/tlx/digest/md5.cpp
+++ b/tlx/digest/md5.cpp
@@ -14,7 +14,9 @@
 #include <tlx/digest/md5.hpp>
 #include <tlx/math/rol.hpp>
 #include <tlx/string/hexdump.hpp>
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/digest/md5.hpp
+++ b/tlx/digest/md5.hpp
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_MD5_HEADER
 #define TLX_DIGEST_MD5_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/tlx/digest/sha1.cpp
+++ b/tlx/digest/sha1.cpp
@@ -14,7 +14,9 @@
 #include <tlx/digest/sha1.hpp>
 #include <tlx/math/rol.hpp>
 #include <tlx/string/hexdump.hpp>
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/digest/sha1.hpp
+++ b/tlx/digest/sha1.hpp
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_SHA1_HEADER
 #define TLX_DIGEST_SHA1_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/tlx/digest/sha256.cpp
+++ b/tlx/digest/sha256.cpp
@@ -15,7 +15,9 @@
 #include <tlx/math/ror.hpp>
 #include <tlx/string/hexdump.hpp>
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/digest/sha256.hpp
+++ b/tlx/digest/sha256.hpp
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_SHA256_HEADER
 #define TLX_DIGEST_SHA256_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/tlx/digest/sha512.cpp
+++ b/tlx/digest/sha512.cpp
@@ -15,6 +15,7 @@
 #include <tlx/math/ror.hpp>
 #include <tlx/string/hexdump.hpp>
 #include <cstdint>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/digest/sha512.hpp
+++ b/tlx/digest/sha512.hpp
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_SHA512_HEADER
 #define TLX_DIGEST_SHA512_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/tlx/logger/all.hpp
+++ b/tlx/logger/all.hpp
@@ -14,18 +14,18 @@
 /*[[[perl
 foreach (sort glob("tlx/logger/"."*.hpp")) {
   next if $_ eq "tlx/logger/all.hpp";
-  print "#include <$_>\n";
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n";
 }
 ]]]*/
-#include <tlx/logger/array.hpp>
-#include <tlx/logger/core.hpp>
-#include <tlx/logger/deque.hpp>
-#include <tlx/logger/map.hpp>
-#include <tlx/logger/set.hpp>
-#include <tlx/logger/tuple.hpp>
-#include <tlx/logger/unordered_map.hpp>
-#include <tlx/logger/unordered_set.hpp>
-#include <tlx/logger/wrap_unprintable.hpp>
+#include <tlx/logger/array.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/logger/core.hpp>             // NOLINT(misc-include-cleaner)
+#include <tlx/logger/deque.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/logger/map.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/logger/set.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/logger/tuple.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/logger/unordered_map.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/logger/unordered_set.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/logger/wrap_unprintable.hpp> // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_LOGGER_ALL_HEADER

--- a/tlx/logger/array.hpp
+++ b/tlx/logger/array.hpp
@@ -13,6 +13,8 @@
 
 #include <tlx/logger/core.hpp>
 #include <array>
+#include <cstddef>
+#include <ostream>
 
 namespace tlx {
 

--- a/tlx/logger/core.hpp
+++ b/tlx/logger/core.hpp
@@ -13,6 +13,7 @@
 #ifndef TLX_LOGGER_CORE_HEADER
 #define TLX_LOGGER_CORE_HEADER
 
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/tlx/logger/deque.hpp
+++ b/tlx/logger/deque.hpp
@@ -13,6 +13,7 @@
 
 #include <tlx/logger/core.hpp>
 #include <deque>
+#include <ostream>
 
 namespace tlx {
 

--- a/tlx/logger/map.hpp
+++ b/tlx/logger/map.hpp
@@ -13,6 +13,7 @@
 
 #include <tlx/logger/core.hpp>
 #include <map>
+#include <ostream>
 
 namespace tlx {
 

--- a/tlx/logger/set.hpp
+++ b/tlx/logger/set.hpp
@@ -12,6 +12,7 @@
 #define TLX_LOGGER_SET_HEADER
 
 #include <tlx/logger/core.hpp>
+#include <ostream>
 #include <set>
 
 namespace tlx {

--- a/tlx/logger/tuple.hpp
+++ b/tlx/logger/tuple.hpp
@@ -13,7 +13,9 @@
 
 #include <tlx/logger/core.hpp>
 #include <tlx/meta/call_foreach_tuple_with_index.hpp>
+#include <ostream>
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/logger/unordered_map.hpp
+++ b/tlx/logger/unordered_map.hpp
@@ -12,6 +12,7 @@
 #define TLX_LOGGER_UNORDERED_MAP_HEADER
 
 #include <tlx/logger/core.hpp>
+#include <ostream>
 #include <unordered_map>
 
 namespace tlx {

--- a/tlx/logger/unordered_set.hpp
+++ b/tlx/logger/unordered_set.hpp
@@ -12,6 +12,7 @@
 #define TLX_LOGGER_UNORDERED_SET_HEADER
 
 #include <tlx/logger/core.hpp>
+#include <ostream>
 #include <unordered_set>
 
 namespace tlx {

--- a/tlx/math.hpp
+++ b/tlx/math.hpp
@@ -15,28 +15,30 @@
 //! Simple math functions
 
 /*[[[perl
-print "#include <$_>\n" foreach sort glob("tlx/math/"."*.hpp");
+foreach (sort glob("tlx/math/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n"
+}
 ]]]*/
-#include <tlx/math/abs_diff.hpp>
-#include <tlx/math/aggregate.hpp>
-#include <tlx/math/aggregate_min_max.hpp>
-#include <tlx/math/bswap.hpp>
-#include <tlx/math/bswap_be.hpp>
-#include <tlx/math/bswap_le.hpp>
-#include <tlx/math/clz.hpp>
-#include <tlx/math/ctz.hpp>
-#include <tlx/math/div_ceil.hpp>
-#include <tlx/math/ffs.hpp>
-#include <tlx/math/integer_log2.hpp>
-#include <tlx/math/is_power_of_two.hpp>
-#include <tlx/math/polynomial_regression.hpp>
-#include <tlx/math/popcount.hpp>
-#include <tlx/math/power_to_the.hpp>
-#include <tlx/math/rol.hpp>
-#include <tlx/math/ror.hpp>
-#include <tlx/math/round_to_power_of_two.hpp>
-#include <tlx/math/round_up.hpp>
-#include <tlx/math/sgn.hpp>
+#include <tlx/math/abs_diff.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/math/aggregate.hpp>             // NOLINT(misc-include-cleaner)
+#include <tlx/math/aggregate_min_max.hpp>     // NOLINT(misc-include-cleaner)
+#include <tlx/math/bswap.hpp>                 // NOLINT(misc-include-cleaner)
+#include <tlx/math/bswap_be.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/math/bswap_le.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/math/clz.hpp>                   // NOLINT(misc-include-cleaner)
+#include <tlx/math/ctz.hpp>                   // NOLINT(misc-include-cleaner)
+#include <tlx/math/div_ceil.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/math/ffs.hpp>                   // NOLINT(misc-include-cleaner)
+#include <tlx/math/integer_log2.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/math/is_power_of_two.hpp>       // NOLINT(misc-include-cleaner)
+#include <tlx/math/polynomial_regression.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/math/popcount.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/math/power_to_the.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/math/rol.hpp>                   // NOLINT(misc-include-cleaner)
+#include <tlx/math/ror.hpp>                   // NOLINT(misc-include-cleaner)
+#include <tlx/math/round_to_power_of_two.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/math/round_up.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/math/sgn.hpp>                   // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_MATH_HEADER

--- a/tlx/math/aggregate.hpp
+++ b/tlx/math/aggregate.hpp
@@ -11,9 +11,9 @@
 #ifndef TLX_MATH_AGGREGATE_HEADER
 #define TLX_MATH_AGGREGATE_HEADER
 
-#include <tlx/define/likely.hpp>
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 
 namespace tlx {

--- a/tlx/math/bswap_le.hpp
+++ b/tlx/math/bswap_le.hpp
@@ -15,7 +15,7 @@
 #define TLX_MATH_BSWAP_LE_HEADER
 
 #include <tlx/define/endian.hpp>
-#include <tlx/math/bswap.hpp>
+#include <tlx/math/bswap.hpp> // NOLINT(misc-include-cleaner)
 #include <cstdint>
 
 namespace tlx {

--- a/tlx/meta.hpp
+++ b/tlx/meta.hpp
@@ -15,37 +15,39 @@
 //! Tools for easier meta-template programming
 
 /*[[[perl
-print "#include <$_>\n" foreach sort glob("tlx/meta/"."*.hpp");
+foreach (sort glob("tlx/meta/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n"
+}
 ]]]*/
-#include <tlx/meta/apply_tuple.hpp>
-#include <tlx/meta/call_for_range.hpp>
-#include <tlx/meta/call_foreach.hpp>
-#include <tlx/meta/call_foreach_tuple.hpp>
-#include <tlx/meta/call_foreach_tuple_with_index.hpp>
-#include <tlx/meta/call_foreach_with_index.hpp>
-#include <tlx/meta/enable_if.hpp>
-#include <tlx/meta/fold_left.hpp>
-#include <tlx/meta/fold_left_tuple.hpp>
-#include <tlx/meta/fold_right.hpp>
-#include <tlx/meta/fold_right_tuple.hpp>
-#include <tlx/meta/function_chain.hpp>
-#include <tlx/meta/function_stack.hpp>
-#include <tlx/meta/has_member.hpp>
-#include <tlx/meta/has_method.hpp>
-#include <tlx/meta/index_sequence.hpp>
-#include <tlx/meta/is_std_array.hpp>
-#include <tlx/meta/is_std_pair.hpp>
-#include <tlx/meta/is_std_tuple.hpp>
-#include <tlx/meta/is_std_vector.hpp>
-#include <tlx/meta/log2.hpp>
-#include <tlx/meta/no_operation.hpp>
-#include <tlx/meta/static_index.hpp>
-#include <tlx/meta/vexpand.hpp>
-#include <tlx/meta/vmap_for_range.hpp>
-#include <tlx/meta/vmap_foreach.hpp>
-#include <tlx/meta/vmap_foreach_tuple.hpp>
-#include <tlx/meta/vmap_foreach_tuple_with_index.hpp>
-#include <tlx/meta/vmap_foreach_with_index.hpp>
+#include <tlx/meta/apply_tuple.hpp>        // NOLINT(misc-include-cleaner)
+#include <tlx/meta/call_for_range.hpp>     // NOLINT(misc-include-cleaner)
+#include <tlx/meta/call_foreach.hpp>       // NOLINT(misc-include-cleaner)
+#include <tlx/meta/call_foreach_tuple.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/meta/call_foreach_tuple_with_index.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/meta/call_foreach_with_index.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/meta/enable_if.hpp>               // NOLINT(misc-include-cleaner)
+#include <tlx/meta/fold_left.hpp>               // NOLINT(misc-include-cleaner)
+#include <tlx/meta/fold_left_tuple.hpp>         // NOLINT(misc-include-cleaner)
+#include <tlx/meta/fold_right.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/meta/fold_right_tuple.hpp>        // NOLINT(misc-include-cleaner)
+#include <tlx/meta/function_chain.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/meta/function_stack.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/meta/has_member.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/meta/has_method.hpp>              // NOLINT(misc-include-cleaner)
+#include <tlx/meta/index_sequence.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/meta/is_std_array.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/meta/is_std_pair.hpp>             // NOLINT(misc-include-cleaner)
+#include <tlx/meta/is_std_tuple.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/meta/is_std_vector.hpp>           // NOLINT(misc-include-cleaner)
+#include <tlx/meta/log2.hpp>                    // NOLINT(misc-include-cleaner)
+#include <tlx/meta/no_operation.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/meta/static_index.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/meta/vexpand.hpp>                 // NOLINT(misc-include-cleaner)
+#include <tlx/meta/vmap_for_range.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/meta/vmap_foreach.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/meta/vmap_foreach_tuple.hpp>      // NOLINT(misc-include-cleaner)
+#include <tlx/meta/vmap_foreach_tuple_with_index.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/meta/vmap_foreach_with_index.hpp> // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_META_HEADER

--- a/tlx/meta/apply_tuple.hpp
+++ b/tlx/meta/apply_tuple.hpp
@@ -12,7 +12,9 @@
 #define TLX_META_APPLY_TUPLE_HEADER
 
 #include <tlx/meta/index_sequence.hpp>
+#include <cstddef>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 namespace tlx {

--- a/tlx/meta/call_for_range.hpp
+++ b/tlx/meta/call_for_range.hpp
@@ -12,6 +12,7 @@
 #define TLX_META_CALL_FOR_RANGE_HEADER
 
 #include <tlx/meta/static_index.hpp>
+#include <cstddef>
 #include <utility>
 
 namespace tlx {

--- a/tlx/meta/call_foreach_tuple.hpp
+++ b/tlx/meta/call_foreach_tuple.hpp
@@ -13,7 +13,9 @@
 
 #include <tlx/meta/call_foreach.hpp>
 #include <tlx/meta/index_sequence.hpp>
+#include <cstddef>
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/call_foreach_tuple_with_index.hpp
+++ b/tlx/meta/call_foreach_tuple_with_index.hpp
@@ -13,7 +13,9 @@
 
 #include <tlx/meta/call_foreach_with_index.hpp>
 #include <tlx/meta/index_sequence.hpp>
+#include <cstddef>
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/call_foreach_with_index.hpp
+++ b/tlx/meta/call_foreach_with_index.hpp
@@ -12,6 +12,7 @@
 #define TLX_META_CALL_FOREACH_WITH_INDEX_HEADER
 
 #include <tlx/meta/static_index.hpp>
+#include <cstddef>
 #include <utility>
 
 namespace tlx {

--- a/tlx/meta/fold_left.hpp
+++ b/tlx/meta/fold_left.hpp
@@ -11,8 +11,7 @@
 #ifndef TLX_META_FOLD_LEFT_HEADER
 #define TLX_META_FOLD_LEFT_HEADER
 
-#include <tlx/meta/index_sequence.hpp>
-#include <tuple>
+#include <utility>
 
 namespace tlx {
 

--- a/tlx/meta/fold_left_tuple.hpp
+++ b/tlx/meta/fold_left_tuple.hpp
@@ -13,7 +13,9 @@
 
 #include <tlx/meta/fold_left.hpp>
 #include <tlx/meta/index_sequence.hpp>
+#include <cstddef>
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/fold_right.hpp
+++ b/tlx/meta/fold_right.hpp
@@ -11,8 +11,7 @@
 #ifndef TLX_META_FOLD_RIGHT_HEADER
 #define TLX_META_FOLD_RIGHT_HEADER
 
-#include <tlx/meta/index_sequence.hpp>
-#include <tuple>
+#include <utility>
 
 namespace tlx {
 

--- a/tlx/meta/fold_right_tuple.hpp
+++ b/tlx/meta/fold_right_tuple.hpp
@@ -13,7 +13,9 @@
 
 #include <tlx/meta/fold_right.hpp>
 #include <tlx/meta/index_sequence.hpp>
+#include <cstddef>
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/function_chain.hpp
+++ b/tlx/meta/function_chain.hpp
@@ -18,6 +18,7 @@
 #define TLX_META_FUNCTION_CHAIN_HEADER
 
 #include <tlx/meta/index_sequence.hpp>
+#include <cstddef>
 #include <tuple>
 
 namespace tlx {

--- a/tlx/meta/function_stack.hpp
+++ b/tlx/meta/function_stack.hpp
@@ -21,6 +21,7 @@
 #define TLX_META_FUNCTION_STACK_HEADER
 
 #include <tlx/meta/index_sequence.hpp>
+#include <cstddef>
 #include <tuple>
 
 namespace tlx {

--- a/tlx/meta/is_std_array.hpp
+++ b/tlx/meta/is_std_array.hpp
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <cstddef>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/is_std_pair.hpp
+++ b/tlx/meta/is_std_pair.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_META_IS_STD_PAIR_HEADER
 #define TLX_META_IS_STD_PAIR_HEADER
 
+#include <type_traits>
 #include <utility>
 
 namespace tlx {

--- a/tlx/meta/is_std_tuple.hpp
+++ b/tlx/meta/is_std_tuple.hpp
@@ -12,6 +12,7 @@
 #define TLX_META_IS_STD_TUPLE_HEADER
 
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/is_std_vector.hpp
+++ b/tlx/meta/is_std_vector.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_META_IS_STD_VECTOR_HEADER
 #define TLX_META_IS_STD_VECTOR_HEADER
 
+#include <type_traits>
 #include <vector>
 
 namespace tlx {

--- a/tlx/meta/vmap_for_range.hpp
+++ b/tlx/meta/vmap_for_range.hpp
@@ -12,6 +12,7 @@
 #define TLX_META_VMAP_FOR_RANGE_HEADER
 
 #include <tlx/meta/static_index.hpp>
+#include <cstddef>
 #include <tuple>
 #include <utility>
 

--- a/tlx/meta/vmap_foreach_tuple.hpp
+++ b/tlx/meta/vmap_foreach_tuple.hpp
@@ -13,7 +13,9 @@
 
 #include <tlx/meta/index_sequence.hpp>
 #include <tlx/meta/vmap_foreach.hpp>
+#include <cstddef>
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/vmap_foreach_tuple_with_index.hpp
+++ b/tlx/meta/vmap_foreach_tuple_with_index.hpp
@@ -13,7 +13,9 @@
 
 #include <tlx/meta/index_sequence.hpp>
 #include <tlx/meta/vmap_foreach_with_index.hpp>
+#include <cstddef>
 #include <tuple>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/meta/vmap_foreach_with_index.hpp
+++ b/tlx/meta/vmap_foreach_with_index.hpp
@@ -12,6 +12,7 @@
 #define TLX_META_VMAP_FOREACH_WITH_INDEX_HEADER
 
 #include <tlx/meta/static_index.hpp>
+#include <cstddef>
 #include <tuple>
 #include <utility>
 

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -12,6 +12,10 @@
 #include <tlx/logger/core.hpp>
 #include <tlx/multi_timer.hpp>
 #include <tlx/string/hash_djb2.hpp>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <mutex>
 
@@ -54,7 +58,7 @@ MultiTimer::Entry& MultiTimer::find_or_create(const char* name)
     std::uint32_t hash = hash_djb2(name);
     for (size_t i = 0; i < timers_.size(); ++i)
     {
-        if (timers_[i].hash == hash && strcmp(timers_[i].name, name) == 0)
+        if (timers_[i].hash == hash && std::strcmp(timers_[i].name, name) == 0)
             return timers_[i];
     }
     Entry new_entry;

--- a/tlx/port.hpp
+++ b/tlx/port.hpp
@@ -15,9 +15,11 @@
 //! Tools to enable easier writing of portable code.
 
 /*[[[perl
-print "#include <$_>\n" foreach sort glob("tlx/port/"."*.hpp");
+foreach (sort glob("tlx/port/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n";
+}
 ]]]*/
-#include <tlx/port/setenv.hpp>
+#include <tlx/port/setenv.hpp> // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_PORT_HEADER

--- a/tlx/port/setenv.cpp
+++ b/tlx/port/setenv.cpp
@@ -9,7 +9,7 @@
  ******************************************************************************/
 
 #include <tlx/port/setenv.hpp>
-#include <cstdlib>
+#include <stdlib.h>
 
 namespace tlx {
 

--- a/tlx/semaphore.hpp
+++ b/tlx/semaphore.hpp
@@ -18,6 +18,7 @@
 #define TLX_SEMAPHORE_HEADER
 
 #include <condition_variable>
+#include <cstddef>
 #include <mutex>
 
 namespace tlx {

--- a/tlx/simple_vector.hpp
+++ b/tlx/simple_vector.hpp
@@ -13,7 +13,7 @@
 #ifndef TLX_SIMPLE_VECTOR_HEADER
 #define TLX_SIMPLE_VECTOR_HEADER
 
-#include <tlx/container/simple_vector.hpp>
+#include <tlx/container/simple_vector.hpp> // NOLINT(misc-include-cleaner)
 
 #endif // !TLX_SIMPLE_VECTOR_HEADER
 

--- a/tlx/siphash.hpp
+++ b/tlx/siphash.hpp
@@ -33,6 +33,7 @@
 
 #if defined(__SSE2__)
 #include <emmintrin.h>
+#include <xmmintrin.h>
 #endif
 
 namespace tlx {

--- a/tlx/sort.hpp
+++ b/tlx/sort.hpp
@@ -15,11 +15,13 @@
 //! Specialized Sorting Algorithms
 
 /*[[[perl
-print "#include <$_>\n" foreach sort grep(!/_impl/, glob("tlx/sort/"."*.hpp"));
+foreach (sort grep(!/_impl/, glob("tlx/sort/"."*.hpp"))) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n";
+}
 ]]]*/
-#include <tlx/sort/parallel_mergesort.hpp>
-#include <tlx/sort/strings.hpp>
-#include <tlx/sort/strings_parallel.hpp>
+#include <tlx/sort/parallel_mergesort.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/sort/strings.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/sort/strings_parallel.hpp>   // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_SORT_HEADER

--- a/tlx/sort/parallel_mergesort.hpp
+++ b/tlx/sort/parallel_mergesort.hpp
@@ -18,19 +18,20 @@
 #ifndef TLX_SORT_PARALLEL_MERGESORT_HEADER
 #define TLX_SORT_PARALLEL_MERGESORT_HEADER
 
+#include <tlx/algorithm/multiway_merge_splitting.hpp>
+#include <tlx/algorithm/parallel_multiway_merge.hpp>
+#include <tlx/container/simple_vector.hpp>
+#include <tlx/thread_barrier_mutex.hpp>
 #include <algorithm>
+#include <cstddef>
 #include <functional>
+#include <iterator>
 #include <thread>
 #include <utility>
 
 #if defined(_OPENMP)
 #include <omp.h>
 #endif
-
-#include <tlx/algorithm/multisequence_selection.hpp>
-#include <tlx/algorithm/parallel_multiway_merge.hpp>
-#include <tlx/simple_vector.hpp>
-#include <tlx/thread_barrier_mutex.hpp>
 
 namespace tlx {
 

--- a/tlx/sort/strings.hpp
+++ b/tlx/sort/strings.hpp
@@ -13,9 +13,10 @@
 #ifndef TLX_SORT_STRINGS_HEADER
 #define TLX_SORT_STRINGS_HEADER
 
-#include <tlx/sort/strings/insertion_sort.hpp>
-#include <tlx/sort/strings/multikey_quicksort.hpp>
 #include <tlx/sort/strings/radix_sort.hpp>
+#include <tlx/sort/strings/string_ptr.hpp>
+#include <tlx/sort/strings/string_set.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/tlx/sort/strings_parallel.hpp
+++ b/tlx/sort/strings_parallel.hpp
@@ -14,6 +14,9 @@
 #define TLX_SORT_STRINGS_PARALLEL_HEADER
 
 #include <tlx/sort/strings/parallel_sample_sort.hpp>
+#include <tlx/sort/strings/string_ptr.hpp>
+#include <tlx/sort/strings/string_set.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/tlx/stack_allocator.hpp
+++ b/tlx/stack_allocator.hpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>
+#include <type_traits>
 
 namespace tlx {
 

--- a/tlx/string.hpp
+++ b/tlx/string.hpp
@@ -17,49 +17,50 @@
 /*[[[perl
 my %exclude = ("tlx/string/appendline.hpp" => 1,
                "tlx/string/ssprintf_generic.hpp" => 1);
-print "#include <$_>\n"
-    foreach grep {!$exclude{$_}} sort glob("tlx/string/"."*.hpp");
+foreach (grep {!$exclude{$_}} sort glob("tlx/string/"."*.hpp")) {
+  print "#include <$_> // NOLINT(misc-include-cleaner)\n"
+}
 ]]]*/
-#include <tlx/string/base64.hpp>
-#include <tlx/string/bitdump.hpp>
-#include <tlx/string/compare_icase.hpp>
-#include <tlx/string/contains.hpp>
-#include <tlx/string/contains_word.hpp>
-#include <tlx/string/ends_with.hpp>
-#include <tlx/string/equal_icase.hpp>
-#include <tlx/string/erase_all.hpp>
-#include <tlx/string/escape_html.hpp>
-#include <tlx/string/escape_uri.hpp>
-#include <tlx/string/expand_environment_variables.hpp>
-#include <tlx/string/extract_between.hpp>
-#include <tlx/string/format_iec_units.hpp>
-#include <tlx/string/format_si_iec_units.hpp>
-#include <tlx/string/format_si_units.hpp>
-#include <tlx/string/hash_djb2.hpp>
-#include <tlx/string/hash_sdbm.hpp>
-#include <tlx/string/hexdump.hpp>
-#include <tlx/string/index_of.hpp>
-#include <tlx/string/join.hpp>
-#include <tlx/string/join_generic.hpp>
-#include <tlx/string/join_quoted.hpp>
-#include <tlx/string/less_icase.hpp>
-#include <tlx/string/levenshtein.hpp>
-#include <tlx/string/pad.hpp>
-#include <tlx/string/parse_si_iec_units.hpp>
-#include <tlx/string/parse_uri.hpp>
-#include <tlx/string/parse_uri_form_data.hpp>
-#include <tlx/string/replace.hpp>
-#include <tlx/string/split.hpp>
-#include <tlx/string/split_quoted.hpp>
-#include <tlx/string/split_view.hpp>
-#include <tlx/string/split_words.hpp>
-#include <tlx/string/ssprintf.hpp>
-#include <tlx/string/starts_with.hpp>
-#include <tlx/string/to_lower.hpp>
-#include <tlx/string/to_upper.hpp>
-#include <tlx/string/trim.hpp>
-#include <tlx/string/union_words.hpp>
-#include <tlx/string/word_wrap.hpp>
+#include <tlx/string/base64.hpp>        // NOLINT(misc-include-cleaner)
+#include <tlx/string/bitdump.hpp>       // NOLINT(misc-include-cleaner)
+#include <tlx/string/compare_icase.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/string/contains.hpp>      // NOLINT(misc-include-cleaner)
+#include <tlx/string/contains_word.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/string/ends_with.hpp>     // NOLINT(misc-include-cleaner)
+#include <tlx/string/equal_icase.hpp>   // NOLINT(misc-include-cleaner)
+#include <tlx/string/erase_all.hpp>     // NOLINT(misc-include-cleaner)
+#include <tlx/string/escape_html.hpp>   // NOLINT(misc-include-cleaner)
+#include <tlx/string/escape_uri.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/string/expand_environment_variables.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/string/extract_between.hpp>     // NOLINT(misc-include-cleaner)
+#include <tlx/string/format_iec_units.hpp>    // NOLINT(misc-include-cleaner)
+#include <tlx/string/format_si_iec_units.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/string/format_si_units.hpp>     // NOLINT(misc-include-cleaner)
+#include <tlx/string/hash_djb2.hpp>           // NOLINT(misc-include-cleaner)
+#include <tlx/string/hash_sdbm.hpp>           // NOLINT(misc-include-cleaner)
+#include <tlx/string/hexdump.hpp>             // NOLINT(misc-include-cleaner)
+#include <tlx/string/index_of.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/string/join.hpp>                // NOLINT(misc-include-cleaner)
+#include <tlx/string/join_generic.hpp>        // NOLINT(misc-include-cleaner)
+#include <tlx/string/join_quoted.hpp>         // NOLINT(misc-include-cleaner)
+#include <tlx/string/less_icase.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/string/levenshtein.hpp>         // NOLINT(misc-include-cleaner)
+#include <tlx/string/pad.hpp>                 // NOLINT(misc-include-cleaner)
+#include <tlx/string/parse_si_iec_units.hpp>  // NOLINT(misc-include-cleaner)
+#include <tlx/string/parse_uri.hpp>           // NOLINT(misc-include-cleaner)
+#include <tlx/string/parse_uri_form_data.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/string/replace.hpp>             // NOLINT(misc-include-cleaner)
+#include <tlx/string/split.hpp>               // NOLINT(misc-include-cleaner)
+#include <tlx/string/split_quoted.hpp>        // NOLINT(misc-include-cleaner)
+#include <tlx/string/split_view.hpp>          // NOLINT(misc-include-cleaner)
+#include <tlx/string/split_words.hpp>         // NOLINT(misc-include-cleaner)
+#include <tlx/string/ssprintf.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/string/starts_with.hpp>         // NOLINT(misc-include-cleaner)
+#include <tlx/string/to_lower.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/string/to_upper.hpp>            // NOLINT(misc-include-cleaner)
+#include <tlx/string/trim.hpp>                // NOLINT(misc-include-cleaner)
+#include <tlx/string/union_words.hpp>         // NOLINT(misc-include-cleaner)
+#include <tlx/string/word_wrap.hpp>           // NOLINT(misc-include-cleaner)
 // [[[end]]]
 
 #endif // !TLX_STRING_HEADER

--- a/tlx/string/appendline.cpp
+++ b/tlx/string/appendline.cpp
@@ -10,6 +10,10 @@
 
 #include <tlx/string/appendline.hpp>
 #include <algorithm>
+#include <cstddef>
+#include <ios>
+#include <istream>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/base64.cpp
+++ b/tlx/string/base64.cpp
@@ -9,8 +9,10 @@
  ******************************************************************************/
 
 #include <tlx/string/base64.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/base64.hpp
+++ b/tlx/string/base64.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_BASE64_HEADER
 #define TLX_STRING_BASE64_HEADER
 
+#include <cstddef>
 #include <string>
 
 namespace tlx {

--- a/tlx/string/bitdump.cpp
+++ b/tlx/string/bitdump.cpp
@@ -9,6 +9,8 @@
  ******************************************************************************/
 
 #include <tlx/string/bitdump.hpp>
+#include <cstddef>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/bitdump.hpp
+++ b/tlx/string/bitdump.hpp
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_BITDUMP_HEADER
 #define TLX_STRING_BITDUMP_HEADER
 
-#include <cstdint>
+#include <cstddef>
 #include <string>
 
 namespace tlx {

--- a/tlx/string/compare_icase.cpp
+++ b/tlx/string/compare_icase.cpp
@@ -10,7 +10,7 @@
 
 #include <tlx/string/compare_icase.hpp>
 #include <tlx/string/to_lower.hpp>
-#include <algorithm>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/contains.cpp
+++ b/tlx/string/contains.cpp
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 #include <tlx/string/contains.hpp>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/contains_word.cpp
+++ b/tlx/string/contains_word.cpp
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 #include <tlx/string/contains_word.hpp>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/ends_with.cpp
+++ b/tlx/string/ends_with.cpp
@@ -12,6 +12,7 @@
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
 #include <cstring>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/equal_icase.cpp
+++ b/tlx/string/equal_icase.cpp
@@ -11,6 +11,7 @@
 #include <tlx/string/equal_icase.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/erase_all.cpp
+++ b/tlx/string/erase_all.cpp
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 #include <tlx/string/erase_all.hpp>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/escape_html.cpp
+++ b/tlx/string/escape_html.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/escape_html.hpp>
 #include <cstring>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/escape_uri.cpp
+++ b/tlx/string/escape_uri.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/escape_uri.hpp>
 #include <cstring>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/expand_environment_variables.cpp
+++ b/tlx/string/expand_environment_variables.cpp
@@ -12,6 +12,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/extract_between.cpp
+++ b/tlx/string/extract_between.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/extract_between.hpp>
 #include <cstring>
+#include <string>
 
 namespace tlx {
 
@@ -36,13 +37,13 @@ static inline std::string extract_between_template(const std::string& str,
 std::string extract_between(const std::string& str, const char* sep1,
                             const char* sep2)
 {
-    return extract_between_template(str, sep1, strlen(sep1), sep2);
+    return extract_between_template(str, sep1, std::strlen(sep1), sep2);
 }
 
 std::string extract_between(const std::string& str, const char* sep1,
                             const std::string& sep2)
 {
-    return extract_between_template(str, sep1, strlen(sep1), sep2);
+    return extract_between_template(str, sep1, std::strlen(sep1), sep2);
 }
 
 std::string extract_between(const std::string& str, const std::string& sep1,

--- a/tlx/string/format_si_iec_units.cpp
+++ b/tlx/string/format_si_iec_units.cpp
@@ -8,10 +8,13 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
-#include <tlx/string/format_si_iec_units.hpp>
+#include <tlx/string/format_iec_units.hpp>
+#include <tlx/string/format_si_units.hpp>
 #include <cstdint>
 #include <iomanip>
+#include <ios>
 #include <sstream>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/format_si_iec_units.hpp
+++ b/tlx/string/format_si_iec_units.hpp
@@ -11,8 +11,8 @@
 #ifndef TLX_STRING_FORMAT_SI_IEC_UNITS_HEADER
 #define TLX_STRING_FORMAT_SI_IEC_UNITS_HEADER
 
-#include <tlx/string/format_iec_units.hpp>
-#include <tlx/string/format_si_units.hpp>
+#include <tlx/string/format_iec_units.hpp> // NOLINT(misc-include-cleaner)
+#include <tlx/string/format_si_units.hpp>  // NOLINT(misc-include-cleaner)
 
 #endif // !TLX_STRING_FORMAT_SI_IEC_UNITS_HEADER
 

--- a/tlx/string/hash_djb2.hpp
+++ b/tlx/string/hash_djb2.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_HASH_DJB2_HEADER
 #define TLX_STRING_HASH_DJB2_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/tlx/string/hash_sdbm.hpp
+++ b/tlx/string/hash_sdbm.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_HASH_SDBM_HEADER
 #define TLX_STRING_HASH_SDBM_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/tlx/string/hexdump.cpp
+++ b/tlx/string/hexdump.cpp
@@ -9,9 +9,12 @@
  ******************************************************************************/
 
 #include <tlx/string/hexdump.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace tlx {
 

--- a/tlx/string/hexdump.hpp
+++ b/tlx/string/hexdump.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_HEXDUMP_HEADER
 #define TLX_STRING_HEXDUMP_HEADER
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/tlx/string/index_of.cpp
+++ b/tlx/string/index_of.cpp
@@ -10,7 +10,10 @@
 
 #include <tlx/string/equal_icase.hpp>
 #include <tlx/string/index_of.hpp>
+#include <cstddef>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace tlx {
 

--- a/tlx/string/index_of.hpp
+++ b/tlx/string/index_of.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_INDEX_OF_HEADER
 #define TLX_STRING_INDEX_OF_HEADER
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/tlx/string/join.cpp
+++ b/tlx/string/join.cpp
@@ -10,6 +10,8 @@
 
 #include <tlx/string/join.hpp>
 #include <tlx/string/join_generic.hpp>
+#include <string>
+#include <vector>
 
 namespace tlx {
 

--- a/tlx/string/join_quoted.cpp
+++ b/tlx/string/join_quoted.cpp
@@ -9,6 +9,9 @@
  ******************************************************************************/
 
 #include <tlx/string/join_quoted.hpp>
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace tlx {
 

--- a/tlx/string/less_icase.cpp
+++ b/tlx/string/less_icase.cpp
@@ -11,6 +11,7 @@
 #include <tlx/string/less_icase.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/levenshtein.hpp
+++ b/tlx/string/levenshtein.hpp
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_LEVENSHTEIN_HEADER
 #define TLX_STRING_LEVENSHTEIN_HEADER
 
-#include <tlx/simple_vector.hpp>
+#include <tlx/container/simple_vector.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
 #include <cstring>

--- a/tlx/string/pad.cpp
+++ b/tlx/string/pad.cpp
@@ -9,6 +9,8 @@
  ******************************************************************************/
 
 #include <tlx/string/pad.hpp>
+#include <cstddef>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/pad.hpp
+++ b/tlx/string/pad.hpp
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_PAD_HEADER
 #define TLX_STRING_PAD_HEADER
 
+#include <cstddef>
 #include <string>
 
 namespace tlx {

--- a/tlx/string/parse_si_iec_units.cpp
+++ b/tlx/string/parse_si_iec_units.cpp
@@ -11,6 +11,7 @@
 #include <tlx/string/parse_si_iec_units.hpp>
 #include <cstdint>
 #include <cstdlib>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/parse_uri.hpp
+++ b/tlx/string/parse_uri.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_PARSE_URI_HEADER
 
 #include <tlx/container/string_view.hpp>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/parse_uri_form_data.hpp
+++ b/tlx/string/parse_uri_form_data.hpp
@@ -13,6 +13,7 @@
 
 #include <cstring>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace tlx {

--- a/tlx/string/replace.cpp
+++ b/tlx/string/replace.cpp
@@ -9,8 +9,8 @@
  ******************************************************************************/
 
 #include <tlx/string/replace.hpp>
-#include <algorithm>
 #include <cstring>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/split.cpp
+++ b/tlx/string/split.cpp
@@ -9,7 +9,10 @@
  ******************************************************************************/
 
 #include <tlx/string/split.hpp>
+#include <algorithm>
 #include <cstring>
+#include <string>
+#include <vector>
 
 namespace tlx {
 

--- a/tlx/string/split_quoted.cpp
+++ b/tlx/string/split_quoted.cpp
@@ -10,6 +10,9 @@
 
 #include <tlx/string/split_quoted.hpp>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace tlx {
 

--- a/tlx/string/split_view.hpp
+++ b/tlx/string/split_view.hpp
@@ -14,6 +14,7 @@
 #define TLX_STRING_SPLIT_VIEW_HEADER
 
 #include <tlx/container/string_view.hpp>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/split_words.cpp
+++ b/tlx/string/split_words.cpp
@@ -9,6 +9,8 @@
  ******************************************************************************/
 
 #include <tlx/string/split_words.hpp>
+#include <string>
+#include <vector>
 
 namespace tlx {
 

--- a/tlx/string/ssprintf.cpp
+++ b/tlx/string/ssprintf.cpp
@@ -11,6 +11,7 @@
 #include <tlx/string/ssprintf.hpp>
 #include <cstdarg>
 #include <cstdio>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/ssprintf.hpp
+++ b/tlx/string/ssprintf.hpp
@@ -12,6 +12,7 @@
 #define TLX_STRING_SSPRINTF_HEADER
 
 #include <tlx/define/attribute_format_printf.hpp>
+#include <cstddef>
 #include <string>
 
 namespace tlx {

--- a/tlx/string/starts_with.cpp
+++ b/tlx/string/starts_with.cpp
@@ -11,6 +11,7 @@
 #include <tlx/string/starts_with.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/to_lower.cpp
+++ b/tlx/string/to_lower.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/to_upper.cpp
+++ b/tlx/string/to_upper.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/to_upper.hpp>
 #include <algorithm>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/trim.cpp
+++ b/tlx/string/trim.cpp
@@ -11,6 +11,7 @@
 #include <tlx/string/trim.hpp>
 #include <algorithm>
 #include <cstring>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/union_words.cpp
+++ b/tlx/string/union_words.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/contains_word.hpp>
 #include <tlx/string/union_words.hpp>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/string/word_wrap.cpp
+++ b/tlx/string/word_wrap.cpp
@@ -10,6 +10,7 @@
 
 #include <tlx/string/word_wrap.hpp>
 #include <cctype>
+#include <string>
 
 namespace tlx {
 

--- a/tlx/thread_barrier_mutex.hpp
+++ b/tlx/thread_barrier_mutex.hpp
@@ -13,6 +13,7 @@
 
 #include <tlx/meta/no_operation.hpp>
 #include <condition_variable>
+#include <cstddef>
 #include <mutex>
 
 namespace tlx {

--- a/tlx/thread_barrier_spin.hpp
+++ b/tlx/thread_barrier_spin.hpp
@@ -13,6 +13,7 @@
 
 #include <tlx/meta/no_operation.hpp>
 #include <atomic>
+#include <cstddef>
 #include <thread>
 
 namespace tlx {

--- a/tlx/thread_pool.cpp
+++ b/tlx/thread_pool.cpp
@@ -9,7 +9,13 @@
  ******************************************************************************/
 
 #include <tlx/thread_pool.hpp>
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <exception>
 #include <iostream>
+#include <mutex>
+#include <utility>
 
 namespace tlx {
 

--- a/tlx/thread_pool.hpp
+++ b/tlx/thread_pool.hpp
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <cassert>
 #include <condition_variable>
+#include <cstddef>
 #include <deque>
 #include <mutex>
 #include <thread>


### PR DESCRIPTION
This PR starts the process of integrating clang-tidy checks into tlx.
All includes are fixed using clang-tidy's include fixer and a Woodpecker CI job is added.