### PR TITLE
clang-tidy: apply readability-else-after-return

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks:
   - "-*"
   - "misc-include-cleaner"
+  - "readability-else-after-return"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/tlx/algorithm/multiway_merge.hpp
+++ b/tlx/algorithm/multiway_merge.hpp
@@ -803,8 +803,7 @@ RandomAccessIterator3 multiway_merge_bubble(
                         --nrp;
                         break;
                     }
-                    else
-                        pl[0] = *(TLX_POS(source[0]));
+                    pl[0] = *(TLX_POS(source[0]));
                 }
             }
             else
@@ -826,8 +825,7 @@ RandomAccessIterator3 multiway_merge_bubble(
                         --nrp;
                         break;
                     }
-                    else
-                        pl[0] = *(TLX_POS(source[0]));
+                    pl[0] = *(TLX_POS(source[0]));
                 }
             }
 
@@ -865,8 +863,7 @@ RandomAccessIterator3 multiway_merge_bubble(
                     --nrp;
                     break;
                 }
-                else
-                    pl[0] = *(TLX_POS(source[0]));
+                pl[0] = *(TLX_POS(source[0]));
             }
 
             // sink down

--- a/tlx/algorithm/parallel_multiway_merge.hpp
+++ b/tlx/algorithm/parallel_multiway_merge.hpp
@@ -241,11 +241,9 @@ RandomAccessIterator3 parallel_multiway_merge(
         return parallel_multiway_merge_base</* Stable */ false>(
             seqs_begin, seqs_end, target, size, comp, mwma, mwmsa, num_threads);
     }
-    else
-    {
-        return multiway_merge_base</* Stable */ false, /* Sentinels */ false>(
-            seqs_begin, seqs_end, target, size, comp, mwma);
-    }
+
+    return multiway_merge_base</* Stable */ false, /* Sentinels */ false>(
+        seqs_begin, seqs_end, target, size, comp, mwma);
 }
 
 /*!
@@ -294,11 +292,9 @@ RandomAccessIterator3 stable_parallel_multiway_merge(
         return parallel_multiway_merge_base</* Stable */ true>(
             seqs_begin, seqs_end, target, size, comp, mwma, mwmsa, num_threads);
     }
-    else
-    {
-        return multiway_merge_base</* Stable */ true, /* Sentinels */ false>(
-            seqs_begin, seqs_end, target, size, comp, mwma);
-    }
+
+    return multiway_merge_base</* Stable */ true, /* Sentinels */ false>(
+        seqs_begin, seqs_end, target, size, comp, mwma);
 }
 
 /*!
@@ -347,11 +343,9 @@ RandomAccessIterator3 parallel_multiway_merge_sentinels(
         return parallel_multiway_merge_base</* Stable */ false>(
             seqs_begin, seqs_end, target, size, comp, mwma, mwmsa, num_threads);
     }
-    else
-    {
-        return multiway_merge_base</* Stable */ false, /* Sentinels */ true>(
-            seqs_begin, seqs_end, target, size, comp, mwma);
-    }
+
+    return multiway_merge_base</* Stable */ false, /* Sentinels */ true>(
+        seqs_begin, seqs_end, target, size, comp, mwma);
 }
 
 /*!
@@ -400,11 +394,9 @@ RandomAccessIterator3 stable_parallel_multiway_merge_sentinels(
         return parallel_multiway_merge_base</* Stable */ true>(
             seqs_begin, seqs_end, target, size, comp, mwma, mwmsa, num_threads);
     }
-    else
-    {
-        return multiway_merge_base</* Stable */ true, /* Sentinels */ true>(
-            seqs_begin, seqs_end, target, size, comp, mwma);
-    }
+
+    return multiway_merge_base</* Stable */ true, /* Sentinels */ true>(
+        seqs_begin, seqs_end, target, size, comp, mwma);
 }
 
 //! \}

--- a/tlx/cmdline_parser.cpp
+++ b/tlx/cmdline_parser.cpp
@@ -163,10 +163,7 @@ public:
             dest_ = static_cast<int>(x);
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     void print_value(std::ostream& os) const final
@@ -210,10 +207,7 @@ public:
             dest_ = static_cast<unsigned int>(x);
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     void print_value(std::ostream& os) const final
@@ -256,10 +250,7 @@ public:
             dest_ = x;
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     void print_value(std::ostream& os) const final
@@ -300,10 +291,7 @@ public:
             --argc, ++argv;
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     void print_value(std::ostream& os) const final
@@ -345,10 +333,7 @@ public:
             --argc, ++argv;
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     void print_value(std::ostream& os) const final
@@ -392,10 +377,7 @@ public:
             --argc, ++argv;
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     void print_value(std::ostream& os) const final
@@ -436,10 +418,7 @@ public:
             --argc, ++argv;
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     void print_value(std::ostream& os) const final
@@ -1194,7 +1173,8 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                                 print_option_error(argc, argv, *oi, os);
                                 return false;
                             }
-                            else if (verbose_process_)
+
+                            if (verbose_process_)
                             {
                                 os << "Option " << (*oi)->option_text()
                                    << " set to ";
@@ -1240,7 +1220,8 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                                     print_option_error(argc, argv, *oi, os);
                                     return false;
                                 }
-                                else if (verbose_process_)
+
+                                if (verbose_process_)
                                 {
                                     os << "Option " << (*oi)->option_text()
                                        << " set to ";
@@ -1276,7 +1257,8 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                     print_param_error(argc, argv, *argi, os);
                     return false;
                 }
-                else if (verbose_process_)
+
+                if (verbose_process_)
                 {
                     os << "Parameter " << (*argi)->param_text() << " set to ";
                     (*argi)->print_value(os);

--- a/tlx/container/loser_tree.hpp
+++ b/tlx/container/loser_tree.hpp
@@ -165,12 +165,10 @@ public:
             losers_[root] = losers_[right];
             return left;
         }
-        else
-        {
-            // right one is less
-            losers_[root] = losers_[left];
-            return right;
-        }
+
+        // right one is less
+        losers_[root] = losers_[left];
+        return right;
     }
 
     void init()
@@ -425,12 +423,10 @@ public:
             losers_[root] = losers_[right];
             return left;
         }
-        else
-        {
-            // right one is less
-            losers_[root] = losers_[left];
-            return right;
-        }
+
+        // right one is less
+        losers_[root] = losers_[left];
+        return right;
     }
 
     void init()
@@ -649,12 +645,10 @@ public:
             losers_[root] = losers_[right];
             return left;
         }
-        else
-        {
-            // right one is less
-            losers_[root] = losers_[left];
-            return right;
-        }
+
+        // right one is less
+        losers_[root] = losers_[left];
+        return right;
     }
 
     void init()
@@ -846,12 +840,10 @@ public:
             losers_[root] = losers_[right];
             return left;
         }
-        else
-        {
-            // right one is less
-            losers_[root] = losers_[left];
-            return right;
-        }
+
+        // right one is less
+        losers_[root] = losers_[left];
+        return right;
     }
 
     void init()

--- a/tlx/container/splay_tree.hpp
+++ b/tlx/container/splay_tree.hpp
@@ -215,11 +215,9 @@ Tree* splay_erase(const Key& k, Tree*& t, const Compare& cmp)
         }
         return r;
     }
-    else
-    {
-        // it wasn't there
-        return nullptr;
-    }
+
+    // it wasn't there
+    return nullptr;
 }
 
 //! traverse the tree in preorder (left, node, right)

--- a/tlx/sort/strings/insertion_sort.hpp
+++ b/tlx/sort/strings/insertion_sort.hpp
@@ -117,7 +117,8 @@ insertion_sort(const StringPtr& strptr, size_t depth, size_t /* memory */)
                 ss[begin + i - 1] = std::move(cur_str);
                 break;
             }
-            else if (cur_lcp == new_lcp)
+
+            if (cur_lcp == new_lcp)
             {
                 // CASE 2: compare more characters
 
@@ -177,7 +178,8 @@ insertion_sort(const StringPtr& strptr, size_t depth, size_t /* memory */)
                 ss[begin + i - 1] = std::move(cur_str);
                 break;
             }
-            else if (cur_lcp == new_lcp)
+
+            if (cur_lcp == new_lcp)
             {
                 // CASE 2: compare more characters
 

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -130,8 +130,7 @@ public:
         size_t threshold = this->smallsort_threshold;
         if (this->enable_rest_size)
             return std::max(threshold, rest_size / num_threads);
-        else
-            return std::max(threshold, total_size / num_threads);
+        return std::max(threshold, total_size / num_threads);
     }
 
     //! decrement number of unordered strings
@@ -700,14 +699,12 @@ public:
                 return k;
             return i;
         }
-        else
-        {
-            if (A[j] > A[k])
-                return j;
-            if (A[i] < A[k])
-                return i;
-            return k;
-        }
+
+        if (A[j] > A[k])
+            return j;
+        if (A[i] < A[k])
+            return i;
+        return k;
     }
 
     //! Insertion sort the strings only based on the cached characters.
@@ -860,7 +857,7 @@ public:
                         min_gt = std::min(min_gt, cache[llt]);
                         break;
                     }
-                    else if (r == 0)
+                    if (r == 0)
                     {
                         std::swap(strset.at(leq), strset.at(llt));
                         std::swap(cache[leq], cache[llt]);
@@ -880,7 +877,7 @@ public:
                         max_lt = std::max(max_lt, cache[rgt]);
                         break;
                     }
-                    else if (r == 0)
+                    if (r == 0)
                     {
                         std::swap(strset.at(req), strset.at(rgt));
                         std::swap(cache[req], cache[rgt]);

--- a/tlx/sort/strings/sample_sort_tools.hpp
+++ b/tlx/sort/strings/sample_sort_tools.hpp
@@ -207,26 +207,24 @@ public:
 
             return recurse(midhi, hi, 2 * treeidx + 1, mykey);
         }
-        else
-        {
-            key_type xorSplit = rec_prevkey ^ mykey;
 
-            TLX_LOGC(debug_splitter)                        //
-                << "    lcp: " << hexdump_type(rec_prevkey) //
-                << " XOR " << hexdump_type(mykey)           //
-                << " = " << hexdump_type(xorSplit)          //
-                << " - " << clz(xorSplit)                   //
-                << " bits = " << clz(xorSplit) / 8          //
-                << " chars lcp";
+        key_type xorSplit = rec_prevkey ^ mykey;
 
-            *splitter_++ = mykey;
+        TLX_LOGC(debug_splitter)                        //
+            << "    lcp: " << hexdump_type(rec_prevkey) //
+            << " XOR " << hexdump_type(mykey)           //
+            << " = " << hexdump_type(xorSplit)          //
+            << " - " << clz(xorSplit)                   //
+            << " bits = " << clz(xorSplit) / 8          //
+            << " chars lcp";
 
-            *lcp_iter_++ = (clz(xorSplit) / 8) |
-                           // marker for done splitters
-                           ((mykey & 0xFF) ? 0 : 0x80);
+        *splitter_++ = mykey;
 
-            return mykey;
-        }
+        *lcp_iter_++ = (clz(xorSplit) / 8) |
+                       // marker for done splitters
+                       ((mykey & 0xFF) ? 0 : 0x80);
+
+        return mykey;
     }
 
 private:
@@ -313,24 +311,22 @@ public:
 
             return recurse(midhi, hi, 2 * treeidx + 1, mykey);
         }
-        else
-        {
-            key_type xorSplit = rec_prevkey ^ mykey;
 
-            TLX_LOGC(debug_splitter)                        //
-                << "    lcp: " << hexdump_type(rec_prevkey) //
-                << " XOR " << hexdump_type(mykey)           //
-                << " = " << hexdump_type(xorSplit)          //
-                << " - " << clz(xorSplit)                   //
-                << " bits = " << clz(xorSplit) / 8          //
-                << " chars lcp";
+        key_type xorSplit = rec_prevkey ^ mykey;
 
-            *lcp_iter_++ = (clz(xorSplit) / 8) |
-                           // marker for done splitters
-                           ((mykey & 0xFF) ? 0 : 0x80);
+        TLX_LOGC(debug_splitter)                        //
+            << "    lcp: " << hexdump_type(rec_prevkey) //
+            << " XOR " << hexdump_type(mykey)           //
+            << " = " << hexdump_type(xorSplit)          //
+            << " - " << clz(xorSplit)                   //
+            << " bits = " << clz(xorSplit) / 8          //
+            << " chars lcp";
 
-            return mykey;
-        }
+        *lcp_iter_++ = (clz(xorSplit) / 8) |
+                       // marker for done splitters
+                       ((mykey & 0xFF) ? 0 : 0x80);
+
+        return mykey;
     }
 
 private:

--- a/tlx/sort/strings/string_ptr.hpp
+++ b/tlx/sort/strings/string_ptr.hpp
@@ -258,14 +258,10 @@ public:
     StringShadowPtr copy_back() const
     {
         if (!flipped_)
-        {
             return *this;
-        }
-        else
-        {
-            std::move(active_.begin(), active_.end(), shadow_.begin());
-            return StringShadowPtr(shadow_, active_, !flipped_);
-        }
+
+        std::move(active_.begin(), active_.end(), shadow_.begin());
+        return StringShadowPtr(shadow_, active_, !flipped_);
     }
 
     //! if we want to save the LCPs
@@ -364,14 +360,10 @@ public:
     StringShadowLcpPtr copy_back() const
     {
         if (!flipped_)
-        {
             return *this;
-        }
-        else
-        {
-            std::move(active_.begin(), active_.end(), shadow_.begin());
-            return StringShadowLcpPtr(shadow_, active_, lcp_, !flipped_);
-        }
+
+        std::move(active_.begin(), active_.end(), shadow_.begin());
+        return StringShadowLcpPtr(shadow_, active_, lcp_, !flipped_);
     }
 
     //! if we want to save the LCPs

--- a/tlx/string/compare_icase.cpp
+++ b/tlx/string/compare_icase.cpp
@@ -25,16 +25,14 @@ int compare_icase(const char* a, const char* b)
             continue;
         if (ca < cb)
             return -1;
-        else
-            return +1;
+        return +1;
     }
 
     if (*a == 0 && *b != 0)
         return +1;
-    else if (*a != 0 && *b == 0)
+    if (*a != 0 && *b == 0)
         return -1;
-    else
-        return 0;
+    return 0;
 }
 
 int compare_icase(const char* a, const std::string& b)
@@ -50,16 +48,14 @@ int compare_icase(const char* a, const std::string& b)
             continue;
         if (ca < cb)
             return -1;
-        else
-            return +1;
+        return +1;
     }
 
     if (*a == 0 && bi != b.end())
         return +1;
-    else if (*a != 0 && bi == b.end())
+    if (*a != 0 && bi == b.end())
         return -1;
-    else
-        return 0;
+    return 0;
 }
 
 int compare_icase(const std::string& a, const char* b)
@@ -75,16 +71,14 @@ int compare_icase(const std::string& a, const char* b)
             continue;
         if (ca < cb)
             return -1;
-        else
-            return +1;
+        return +1;
     }
 
     if (ai == a.end() && *b != 0)
         return +1;
-    else if (ai != a.end() && *b == 0)
+    if (ai != a.end() && *b == 0)
         return -1;
-    else
-        return 0;
+    return 0;
 }
 
 int compare_icase(const std::string& a, const std::string& b)
@@ -101,16 +95,14 @@ int compare_icase(const std::string& a, const std::string& b)
             continue;
         if (ca < cb)
             return -1;
-        else
-            return +1;
+        return +1;
     }
 
     if (ai == a.end() && bi != b.end())
         return +1;
-    else if (ai != a.end() && bi == b.end())
+    if (ai != a.end() && bi == b.end())
         return -1;
-    else
-        return 0;
+    return 0;
 }
 
 } // namespace tlx

--- a/tlx/string/contains_word.cpp
+++ b/tlx/string/contains_word.cpp
@@ -44,8 +44,7 @@ bool contains_word(const std::string& str, const char* word)
             {
                 if (it == str.end() || is_white(*it))
                     return true;
-                else
-                    break;
+                break;
             }
             if (it == str.end())
                 return false;
@@ -88,8 +87,7 @@ bool contains_word(const std::string& str, const std::string& word)
             {
                 if (it == str.end() || is_white(*it))
                     return true;
-                else
-                    break;
+                break;
             }
             if (it == str.end())
                 return false;

--- a/tlx/string/split_quoted.cpp
+++ b/tlx/string/split_quoted.cpp
@@ -39,11 +39,10 @@ std::vector<std::string> split_quoted(const std::string& str, char sep,
             while (true)
             {
                 if (it == str.end())
-                {
                     throw std::runtime_error(
                         "unmatched end quote in split_quoted().");
-                }
-                else if (*it == quote)
+
+                if (*it == quote)
                 {
                     ++it;
                     if (it == str.end())
@@ -52,30 +51,27 @@ std::vector<std::string> split_quoted(const std::string& str, char sep,
                         out.emplace_back(std::move(entry));
                         return out;
                     }
-                    else if (*it == sep)
+                    if (*it == sep)
                     {
                         // quote + sep -> end of this entry
                         out.emplace_back(std::move(entry));
                         ++it;
                         break;
                     }
-                    else
-                    {
-                        throw std::runtime_error(
-                            std::string("extra quote enclosed in entry,"
-                                        " followed by ") +
-                            *it);
-                    }
+
+                    throw std::runtime_error(
+                        std::string(
+                            "extra quote enclosed in entry, followed by ") +
+                        *it);
                 }
-                else if (*it == escape)
+                if (*it == escape)
                 {
                     ++it;
                     if (it == str.end())
-                    {
                         throw std::runtime_error(
                             "escape as last character in string");
-                    }
-                    else if (*it == quote)
+
+                    if (*it == quote)
                     {
                         // escape + quote -> quote
                         entry += *it++;
@@ -126,18 +122,17 @@ std::vector<std::string> split_quoted(const std::string& str, char sep,
                     out.emplace_back(std::move(entry));
                     return out;
                 }
-                else if (*it == sep)
+
+                if (*it == sep)
                 {
                     // sep -> end of this entry
                     out.emplace_back(std::move(entry));
                     ++it;
                     break;
                 }
-                else
-                {
-                    // normal character
-                    entry += *it++;
-                }
+
+                // normal character
+                entry += *it++;
             }
         }
     }


### PR DESCRIPTION
This PR activates the "readability-else-after-return" checker for clang-tidy and fixes all instances.
It reduces indentation by avoiding else after `return`s or `break`s.