### PR TITLE
clang-tidy: more checks: `performance-*`, `portability-*`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,11 @@
 Checks:
   - "-*"
   - "misc-include-cleaner"
+  - "openmp-*"
+  - "performance-*"
+  - "-performance-enum-size"
+  - "portability-*"
+  - "-portability-simd-intrinsics"
   - "readability-else-after-return"
 
 WarningsAsErrors: '*'

--- a/tests/algorithm/multiway_merge_benchmark.cpp
+++ b/tests/algorithm/multiway_merge_benchmark.cpp
@@ -338,7 +338,7 @@ void test_multiway_merge(size_t seq_count, const size_t seq_size)
                   << " time/item[ns]="
                   << (ts2 - ts1) / static_cast<double>(g_inner_repeat) /
                          total_size * 1e9 //
-                  << std::endl;
+                  << '\n';
     }
 
     die_unless(std::is_sorted(out.cbegin(), out.cend(), cmp));

--- a/tests/cmdline_parser_example.cpp
+++ b/tests/cmdline_parser_example.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
     if (!cp.process(argc, argv))
         return -1; // some error occurred and help was always written to user.
 
-    std::cout << "Command line parsed okay." << std::endl;
+    std::cout << "Command line parsed okay.\n";
 
     // output for debugging
     cp.print_result();

--- a/tests/container/loser_tree_test.cpp
+++ b/tests/container/loser_tree_test.cpp
@@ -345,7 +345,7 @@ void benchmark_losertree(const char* benchmark, size_t num_vectors,
               << " benchmark=" << benchmark << " num_vectors=" << num_vectors
               << " vector_size=" << vector_size
               << " init_time=" << time_delta(tp1, tp2)
-              << " merge_time=" << time_delta(tp2, tp3) << std::endl;
+              << " merge_time=" << time_delta(tp2, tp3) << '\n';
 }
 
 int main(int argc, char* argv[])

--- a/tests/container/radix_heap_test.cpp
+++ b/tests/container/radix_heap_test.cpp
@@ -71,7 +71,7 @@ public:
         die("find_lsb on empty field");
     }
 
-    void swap(naive_bitarray& o)
+    void swap(naive_bitarray& o) noexcept
     {
         std::swap(bits_, o.bits_);
     }

--- a/tests/counting_ptr_test.cpp
+++ b/tests/counting_ptr_test.cpp
@@ -57,6 +57,7 @@ int main()
             die_unless(i1->unique());
 
             // make pointer sharing same object
+            // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
             IntegerPtr i2 = i1;
 
             die_unequal(42, i2->i);

--- a/tests/deprecated_test.cpp
+++ b/tests/deprecated_test.cpp
@@ -28,7 +28,7 @@ int main()
     also_do_not_use();
 
     std::cout << "This test takes place during compilation.\n"
-              << "Nothing to see here, move on!" << std::endl;
+              << "Nothing to see here, move on!\n";
     return 0;
 }
 

--- a/tests/math/polynomial_regression_test.cpp
+++ b/tests/math/polynomial_regression_test.cpp
@@ -102,12 +102,12 @@ void dump(PolynomialRegression& pr, double xmin, double xmax)
          << pr.r_square();
 
     for (double x = xmin; x <= xmax; x += 0.1)
-        std::cout << x << '\t' << pr.evaluate(x) << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
+        std::cout << x << '\t' << pr.evaluate(x) << '\n';
+    std::cout << '\n';
+    std::cout << '\n';
 
     for (size_t i = 0; i < pr.size(); ++i)
-        std::cout << pr.point(i).x << '\t' << pr.point(i).y << std::endl;
+        std::cout << pr.point(i).x << '\t' << pr.point(i).y << '\n';
 }
 
 void test6()

--- a/tests/meta/has_member_test.cpp
+++ b/tests/meta/has_member_test.cpp
@@ -32,7 +32,7 @@ public:
         tlx::unused(x);
     }
 
-    static double func42(std::string s)
+    static double func42(const std::string& s)
     {
         tlx::unused(s);
         return 42.0;
@@ -74,7 +74,7 @@ public:
         tlx::unused(i);
     }
 
-    static double func456(std::string s)
+    static double func456(const std::string& s)
     {
         tlx::unused(s);
         return 42.0;
@@ -90,7 +90,7 @@ public:
 class ClassD
 {
 public:
-    void func123(std::string)
+    void func123(const std::string&)
     {
     }
 };
@@ -109,7 +109,7 @@ static_assert(has_method_func123<ClassC, std::string(int)>::value == false,
 
 TLX_MAKE_HAS_STATIC_METHOD(func456);
 
-static_assert(has_method_func456<ClassC, double(std::string)>::value,
+static_assert(has_method_func456<ClassC, double(const std::string&)>::value,
               "has_method_func123 test failed.");
 static_assert(has_method_func456<ClassC, double(int)>::value == false,
               "has_method_func123 test failed.");

--- a/tests/sort_strings_example.cpp
+++ b/tests/sort_strings_example.cpp
@@ -40,18 +40,18 @@ int main(int argc, char* argv[])
     if (!cp.process(argc, argv))
         return -1;
 
-    std::cerr << "Opening " << file << std::endl;
+    std::cerr << "Opening " << file << '\n';
     std::ifstream in(file.c_str());
     if (!in.good())
     {
-        std::cerr << "Error opening file: " << strerror(errno) << std::endl;
+        std::cerr << "Error opening file: " << strerror(errno) << '\n';
         return -1;
     }
 
     if (!in.seekg(0, std::ios::end).good())
     {
         std::cerr << "Error seeking to end of file: " << strerror(errno)
-                  << std::endl;
+                  << '\n';
         return -1;
     }
     size_t size = in.tellg();
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
     // read file and make string pointer array
     double ts1_read = tlx::timestamp();
 
-    std::cerr << "Reading " << size << " bytes" << std::endl;
+    std::cerr << "Reading " << size << " bytes\n";
     in.seekg(0, std::ios::beg);
 
     // first string pointer
@@ -100,10 +100,9 @@ int main(int argc, char* argv[])
     double ts2_read = tlx::timestamp();
 
     std::cerr << "Reading took " << ts2_read - ts1_read << " seconds at "
-              << tlx::format_iec_units(size / (ts2_read - ts1_read)) << "B/s"
-              << std::endl;
+              << tlx::format_iec_units(size / (ts2_read - ts1_read)) << "B/s\n";
 
-    std::cerr << "Found " << strings.size() << " strings to sort." << std::endl;
+    std::cerr << "Found " << strings.size() << " strings to sort.\n";
 
     // sort
     double ts1_sort = tlx::timestamp();
@@ -115,8 +114,7 @@ int main(int argc, char* argv[])
     }
     double ts2_sort = tlx::timestamp();
 
-    std::cerr << "Sorting took " << ts2_sort - ts1_sort << " seconds."
-              << std::endl;
+    std::cerr << "Sorting took " << ts2_sort - ts1_sort << " seconds.\n";
 
     // output sorted strings
     double ts1_write = tlx::timestamp();
@@ -127,8 +125,8 @@ int main(int argc, char* argv[])
     double ts2_write = tlx::timestamp();
 
     std::cerr << "Writing took " << ts2_write - ts1_write << " seconds at "
-              << tlx::format_iec_units(size / (ts2_write - ts1_write)) << "/s"
-              << std::endl;
+              << tlx::format_iec_units(size / (ts2_write - ts1_write))
+              << "/s\n";
 
     return 0;
 }

--- a/tlx/cmdline_parser.cpp
+++ b/tlx/cmdline_parser.cpp
@@ -550,7 +550,7 @@ void CmdlineParser::output_wrap(std::ostream& os, const std::string& text,
             to = lspace + 1;
 
         // output line
-        os << std::string(indent, ' ') << text.substr(t, to - t) << std::endl;
+        os << std::string(indent, ' ') << text.substr(t, to - t) << '\n';
 
         current = 0;
         indent = indent_rest;
@@ -1044,24 +1044,24 @@ void CmdlineParser::print_usage(std::ostream& os)
            << (arg->repeated_ ? " ..." : "") << (arg->required_ ? '>' : ']');
     }
 
-    os << std::endl;
+    os << '\n';
 
     if (!description_.empty())
     {
-        os << std::endl;
+        os << '\n';
         output_wrap(os, description_, line_wrap_);
     }
     if (!author_.empty())
     {
-        os << "Author: " << author_ << std::endl;
+        os << "Author: " << author_ << '\n';
     }
 
     if (!description_.empty() || !author_.empty())
-        os << std::endl;
+        os << '\n';
 
     if (!param_list_.empty())
     {
-        os << "Parameters:" << std::endl;
+        os << "Parameters:\n";
 
         for (ArgumentList::const_iterator it = param_list_.begin();
              it != param_list_.end(); ++it)
@@ -1077,7 +1077,7 @@ void CmdlineParser::print_usage(std::ostream& os)
 
     if (!option_list_.empty())
     {
-        os << "Options:" << std::endl;
+        os << "Options:\n";
 
         for (ArgumentList::const_iterator it = option_list_.begin();
              it != option_list_.end(); ++it)
@@ -1107,8 +1107,8 @@ void CmdlineParser::print_option_error(int argc, const char* const* argv,
         os << '"' << argv[0] << '"';
 
     os << " for " << arg->type_name() << " option " << arg->option_text()
-       << (argc == 0 ? " is missing!" : " is invalid!") << std::endl
-       << std::endl;
+       << (argc == 0 ? " is missing!" : " is invalid!") << '\n'
+       << '\n';
 
     print_usage(os);
 }
@@ -1121,8 +1121,8 @@ void CmdlineParser::print_param_error(int argc, const char* const* argv,
         os << '"' << argv[0] << '"';
 
     os << " for " << arg->type_name() << " parameter " << arg->param_text()
-       << (argc == 0 ? " is missing!" : " is invalid!") << std::endl
-       << std::endl;
+       << (argc == 0 ? " is missing!" : " is invalid!") << '\n'
+       << '\n';
 
     print_usage(os);
 }
@@ -1179,16 +1179,14 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                                 os << "Option " << (*oi)->option_text()
                                    << " set to ";
                                 (*oi)->print_value(os);
-                                os << '.' << std::endl;
+                                os << '.' << '\n';
                             }
                             break;
                         }
                     }
                     if (oi == option_list_.end())
                     {
-                        os << "Error: unknown option \"" << arg << "\"."
-                           << std::endl
-                           << std::endl;
+                        os << "Error: unknown option \"" << arg << "\".\n\n";
                         print_usage(os);
                         return false;
                     }
@@ -1199,7 +1197,7 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                 // short option
                 if (arg[1] == 0)
                 {
-                    os << "Invalid option \"" << arg << "\"." << std::endl;
+                    os << "Invalid option \"" << arg << "\".\n";
                 }
                 else
                 {
@@ -1226,7 +1224,7 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                                     os << "Option " << (*oi)->option_text()
                                        << " set to ";
                                     (*oi)->print_value(os);
-                                    os << '.' << std::endl;
+                                    os << '.' << '\n';
                                 }
                                 break;
                             }
@@ -1240,7 +1238,7 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                                 os << "-" << arg[offset] << "\" at position "
                                    << offset << " in option sequence \"";
                             }
-                            os << arg << "\"." << std::endl << std::endl;
+                            os << arg << "\".\n\n";
                             print_usage(os);
                             return false;
                         }
@@ -1262,7 +1260,7 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
                 {
                     os << "Parameter " << (*argi)->param_text() << " set to ";
                     (*argi)->print_value(os);
-                    os << '.' << std::endl;
+                    os << '.' << '\n';
                 }
                 (*argi)->found_ = true;
                 if (!(*argi)->repeated_)
@@ -1271,8 +1269,7 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
             else
             {
                 os << "Error: unexpected extra argument "
-                   << "\"" << argv[0] << "\"." << std::endl
-                   << std::endl;
+                   << "\"" << argv[0] << "\".\n\n";
                 --argc, ++argv;
                 print_usage(os);
                 return false;
@@ -1288,14 +1285,14 @@ bool CmdlineParser::process(int argc, const char* const* argv, std::ostream& os)
         if ((*it)->required_ && !(*it)->found_)
         {
             os << "Error: argument for parameter " << (*it)->longkey_
-               << " is required!" << std::endl;
+               << " is required!\n";
             good = false;
         }
     }
 
     if (!good)
     {
-        os << std::endl;
+        os << '\n';
         print_usage(os);
     }
 
@@ -1315,7 +1312,7 @@ void CmdlineParser::print_result(std::ostream& os)
 
     if (!param_list_.empty())
     {
-        os << "Parameters:" << std::endl;
+        os << "Parameters:\n";
 
         for (ArgumentList::const_iterator it = param_list_.begin();
              it != param_list_.end(); ++it)
@@ -1333,13 +1330,13 @@ void CmdlineParser::print_result(std::ostream& os)
 
             arg->print_value(os);
 
-            os << std::endl;
+            os << '\n';
         }
     }
 
     if (!option_list_.empty())
     {
-        os << "Options:" << std::endl;
+        os << "Options:\n";
 
         for (ArgumentList::const_iterator it = option_list_.begin();
              it != option_list_.end(); ++it)
@@ -1357,7 +1354,7 @@ void CmdlineParser::print_result(std::ostream& os)
 
             arg->print_value(os);
 
-            os << std::endl;
+            os << '\n';
         }
     }
 

--- a/tlx/container/btree.hpp
+++ b/tlx/container/btree.hpp
@@ -1285,7 +1285,7 @@ public:
     }
 
     //! Fast swapping of two identical B+ tree objects.
-    void swap(BTree& from)
+    void swap(BTree& from) noexcept
     {
         std::swap(root_, from.root_);
         std::swap(head_leaf_, from.head_leaf_);

--- a/tlx/container/btree_map.hpp
+++ b/tlx/container/btree_map.hpp
@@ -209,7 +209,7 @@ public:
     }
 
     //! Fast swapping of two identical B+ tree objects.
-    void swap(btree_map& from)
+    void swap(btree_map& from) noexcept
     {
         std::swap(tree_, from.tree_);
     }

--- a/tlx/container/btree_multimap.hpp
+++ b/tlx/container/btree_multimap.hpp
@@ -211,7 +211,7 @@ public:
     }
 
     //! Fast swapping of two identical B+ tree objects.
-    void swap(btree_multimap& from)
+    void swap(btree_multimap& from) noexcept
     {
         std::swap(tree_, from.tree_);
     }

--- a/tlx/container/btree_multiset.hpp
+++ b/tlx/container/btree_multiset.hpp
@@ -208,7 +208,7 @@ public:
     }
 
     //! Fast swapping of two identical B+ tree objects.
-    void swap(btree_multiset& from)
+    void swap(btree_multiset& from) noexcept
     {
         std::swap(tree_, from.tree_);
     }

--- a/tlx/container/btree_set.hpp
+++ b/tlx/container/btree_set.hpp
@@ -207,7 +207,7 @@ public:
     }
 
     //! Fast swapping of two identical B+ tree objects.
-    void swap(btree_set& from)
+    void swap(btree_set& from) noexcept
     {
         std::swap(tree_, from.tree_);
     }

--- a/tlx/die/core.cpp
+++ b/tlx/die/core.cpp
@@ -35,6 +35,7 @@ void die_with_message(const std::string& msg)
     if (s_die_with_exception)
         throw DieException(msg);
 
+    // NOLINTNEXTLINE(performance-avoid-endl)
     std::cerr << msg << std::endl;
     std::terminate();
 }

--- a/tlx/die/core.hpp
+++ b/tlx/die/core.hpp
@@ -146,8 +146,8 @@ inline bool die_equal_compare(double a, double b)
 #define tlx_die_unequal(X, Y)                                                  \
     do                                                                         \
     {                                                                          \
-        auto x__ = (X);                                                        \
-        auto y__ = (Y);                                                        \
+        auto x__ = (X); /* NOLINT */                                           \
+        auto y__ = (Y); /* NOLINT */                                           \
         if (!::tlx::die_equal_compare(x__, y__))                               \
         {                                                                      \
             tlx_die_with_sstream("DIE-UNEQUAL: " #X " != " #Y " : "            \
@@ -170,8 +170,8 @@ inline bool die_equal_compare(double a, double b)
 #define tlx_die_verbose_unequal(X, Y, msg)                                     \
     do                                                                         \
     {                                                                          \
-        auto x__ = (X);                                                        \
-        auto y__ = (Y);                                                        \
+        auto x__ = (X); /* NOLINT */                                           \
+        auto y__ = (Y); /* NOLINT */                                           \
         if (!::tlx::die_equal_compare(x__, y__))                               \
         {                                                                      \
             tlx_die_with_sstream("DIE-UNEQUAL: " #X " != " #Y " : "            \
@@ -204,8 +204,8 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps)
 #define tlx_die_unequal_eps(X, Y, eps)                                         \
     do                                                                         \
     {                                                                          \
-        auto x__ = (X);                                                        \
-        auto y__ = (Y);                                                        \
+        auto x__ = (X); /* NOLINT */                                           \
+        auto y__ = (Y); /* NOLINT */                                           \
         if (!::tlx::die_equal_eps_compare(x__, y__, eps))                      \
         {                                                                      \
             tlx_die("DIE-UNEQUAL-EPS: " #X " != " #Y " : "                     \
@@ -220,8 +220,8 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps)
 #define tlx_die_verbose_unequal_eps(X, Y, eps, msg)                            \
     do                                                                         \
     {                                                                          \
-        auto x__ = (X);                                                        \
-        auto y__ = (Y);                                                        \
+        auto x__ = (X); /* NOLINT */                                           \
+        auto y__ = (Y); /* NOLINT */                                           \
         if (!::tlx::die_equal_eps_compare(x__, y__, eps))                      \
         {                                                                      \
             tlx_die("DIE-UNEQUAL-EPS: " #X " != " #Y " : "                     \
@@ -249,8 +249,8 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps)
 #define tlx_die_equal(X, Y)                                                    \
     do                                                                         \
     {                                                                          \
-        auto x__ = (X);                                                        \
-        auto y__ = (Y);                                                        \
+        auto x__ = (X); /* NOLINT */                                           \
+        auto y__ = (Y); /* NOLINT */                                           \
         if (::tlx::die_equal_compare(x__, y__))                                \
         {                                                                      \
             tlx_die_with_sstream("DIE-EQUAL: " #X " == " #Y " : "              \
@@ -273,8 +273,8 @@ inline bool die_equal_eps_compare(TypeA x, TypeB y, double eps)
 #define tlx_die_verbose_equal(X, Y, msg)                                       \
     do                                                                         \
     {                                                                          \
-        auto x__ = (X);                                                        \
-        auto y__ = (Y);                                                        \
+        auto x__ = (X); /* NOLINT */                                           \
+        auto y__ = (Y); /* NOLINT */                                           \
         if (::tlx::die_equal_compare(x__, y__))                                \
         {                                                                      \
             tlx_die_with_sstream("DIE-EQUAL: " #X " == " #Y " : "              \

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -48,8 +48,8 @@ MultiTimer::MultiTimer()
 
 MultiTimer::MultiTimer(const MultiTimer&) = default;
 MultiTimer& MultiTimer::operator=(const MultiTimer&) = default;
-MultiTimer::MultiTimer(MultiTimer&&) = default;
-MultiTimer& MultiTimer::operator=(MultiTimer&&) = default;
+MultiTimer::MultiTimer(MultiTimer&&) noexcept = default;
+MultiTimer& MultiTimer::operator=(MultiTimer&&) noexcept = default;
 
 MultiTimer::~MultiTimer() = default;
 
@@ -134,7 +134,7 @@ void MultiTimer::print(const char* info, std::ostream& os) const
     {
         os << ' ' << timer.name << '=' << timer.duration.count();
     }
-    os << " total=" << total_duration_.count() << std::endl;
+    os << " total=" << total_duration_.count() << '\n';
 }
 
 void MultiTimer::print(const char* info) const

--- a/tlx/multi_timer.hpp
+++ b/tlx/multi_timer.hpp
@@ -45,9 +45,9 @@ public:
     //! default assignment operator
     MultiTimer& operator=(const MultiTimer&);
     //! move-constructor: default
-    MultiTimer(MultiTimer&&);
+    MultiTimer(MultiTimer&&) noexcept;
     //! move-assignment operator: default
-    MultiTimer& operator=(MultiTimer&&);
+    MultiTimer& operator=(MultiTimer&&) noexcept;
 
     //! destructor
     ~MultiTimer();

--- a/tlx/semaphore.hpp
+++ b/tlx/semaphore.hpp
@@ -38,12 +38,12 @@ public:
     Semaphore& operator=(const Semaphore&) = delete;
 
     //! move-constructor: just move the value
-    Semaphore(Semaphore&& s) : value_(s.value_)
+    Semaphore(Semaphore&& s) noexcept : value_(s.value_)
     {
     }
 
     //! move-assignment: just move the value
-    Semaphore& operator=(Semaphore&& s)
+    Semaphore& operator=(Semaphore&& s) noexcept
     {
         value_ = s.value_;
         return *this;

--- a/tlx/thread_pool.cpp
+++ b/tlx/thread_pool.cpp
@@ -140,6 +140,7 @@ void ThreadPool::worker(size_t p)
                 }
                 catch (std::exception& e)
                 {
+                    // NOLINTNEXTLINE(performance-avoid-endl)
                     std::cerr << "EXCEPTION: " << e.what() << std::endl;
                 }
                 // destroy job by closing scope


### PR DESCRIPTION
This PR enables and fixes more clang-tidy checks:
- `openmp-*`
- `performance-*`
- `portability-*`