### PR TITLE
clang-tidy: enable more readability checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks:
   - "readability-simplify-boolean-expr"
   - "readability-container-size-empty"
   - "readability-implicit-bool-conversion"
+  - "readability-redundant-inline-specifier"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks:
   - "readability-else-after-return"
   - "readability-inconsistent-declaration-parameter-name"
   - "readability-simplify-boolean-expr"
+  - "readability-container-size-empty"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,8 @@ Checks:
   - "portability-*"
   - "-portability-simd-intrinsics"
   - "readability-else-after-return"
+  - "readability-inconsistent-declaration-parameter-name"
+  - "readability-simplify-boolean-expr"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks:
   - "readability-inconsistent-declaration-parameter-name"
   - "readability-simplify-boolean-expr"
   - "readability-container-size-empty"
+  - "readability-implicit-bool-conversion"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/tests/algorithm/multiway_merge_benchmark.cpp
+++ b/tests/algorithm/multiway_merge_benchmark.cpp
@@ -434,7 +434,8 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
 
     // run individually for debugging
-    if (0)
+    auto placeholder = false;
+    if (placeholder)
     {
         test_repeat<std::uint64_t, PARA_GNU_MWM_EXACT>(2, 2 * 1024 * 1024);
         test_repeat<std::uint64_t, PARA_MWM_EXACT_LT>(2, 2 * 1024 * 1024);

--- a/tests/container/btree_test.cpp
+++ b/tests/container/btree_test.cpp
@@ -1419,7 +1419,7 @@ void test_erase_iterator1()
         }
     }
 
-    die_unless(map.size() == 0);
+    die_unless(map.empty());
 }
 
 void test_iterators()

--- a/tests/container/btree_test.cpp
+++ b/tests/container/btree_test.cpp
@@ -1445,7 +1445,7 @@ struct TestData
     }
 
     // also used as implicit conversion constructor
-    inline TestData(unsigned int _a) : a(_a), b(0)
+    TestData(unsigned int _a) : a(_a), b(0)
     {
     }
 };
@@ -1454,7 +1454,7 @@ struct TestCompare
 {
     unsigned int somevalue;
 
-    inline TestCompare(unsigned int sv) : somevalue(sv)
+    TestCompare(unsigned int sv) : somevalue(sv)
     {
     }
 

--- a/tests/container/splay_tree_test.cpp
+++ b/tests/container/splay_tree_test.cpp
@@ -111,7 +111,7 @@ void test2_random()
             tree.insert(v);
             check.insert(std::lower_bound(check.begin(), check.end(), v), v);
         }
-        else if (check.size())
+        else if (!check.empty())
         {
             size_t idx = rng() % check.size();
             auto it = check.begin() + idx;

--- a/tests/meta/has_member_test.cpp
+++ b/tests/meta/has_member_test.cpp
@@ -99,30 +99,29 @@ TLX_MAKE_HAS_METHOD(func123);
 
 static_assert(has_method_func123<ClassC, void(int)>::value,
               "has_method_func123 test failed.");
-static_assert(has_method_func123<ClassC, void(std::string)>::value == false,
+static_assert(!has_method_func123<ClassC, void(std::string)>::value,
               "has_method_func123 test failed.");
 
-static_assert(has_method_func123<ClassD, void(int)>::value == false,
+static_assert(!has_method_func123<ClassD, void(int)>::value,
               "has_method_func123 test failed.");
-static_assert(has_method_func123<ClassC, std::string(int)>::value == false,
+static_assert(!has_method_func123<ClassC, std::string(int)>::value,
               "has_method_func123 test failed.");
 
 TLX_MAKE_HAS_STATIC_METHOD(func456);
 
 static_assert(has_method_func456<ClassC, double(const std::string&)>::value,
               "has_method_func123 test failed.");
-static_assert(has_method_func456<ClassC, double(int)>::value == false,
+static_assert(!has_method_func456<ClassC, double(int)>::value,
               "has_method_func123 test failed.");
 
 TLX_MAKE_HAS_TEMPLATE_METHOD(tfunc123);
 
-static_assert(has_method_tfunc123<ClassC, void(std::string, double)>::value ==
-                  false,
+static_assert(!has_method_tfunc123<ClassC, void(std::string, double)>::value,
               "has_method_tfunc123 test failed.");
-static_assert(has_method_tfunc123<ClassC, void(int, double)>::value == false,
+static_assert(!has_method_tfunc123<ClassC, void(int, double)>::value,
               "has_method_tfunc123 test failed.");
 
-static_assert(has_method_tfunc123<ClassD, void(int, double)>::value == false,
+static_assert(!has_method_tfunc123<ClassD, void(int, double)>::value,
               "has_method_tfunc123 test failed.");
 
 #endif

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -277,8 +277,8 @@ static void test_escape_uri()
 
 static void test_expand_environment_variables()
 {
-    tlx::setenv("TEST_1", "def", /* overwrite */ true);
-    tlx::setenv("VAR_2", "uvw", /* overwrite */ true);
+    tlx::setenv("TEST_1", "def", /* overwrite */ 1);
+    tlx::setenv("VAR_2", "uvw", /* overwrite */ 1);
 
     die_unequal(tlx::expand_environment_variables("abc$TEST_1 ---${VAR_2}xyz"),
                 "abcdef ---uvwxyz");

--- a/tlx/algorithm/multisequence_partition.hpp
+++ b/tlx/algorithm/multisequence_partition.hpp
@@ -48,8 +48,7 @@ public:
     {
     }
 
-    inline bool operator()(const std::pair<T1, T2>& p1,
-                           const std::pair<T1, T2>& p2)
+    bool operator()(const std::pair<T1, T2>& p1, const std::pair<T1, T2>& p2)
     {
         if (comp_(p1.first, p2.first))
             return true;
@@ -74,8 +73,7 @@ public:
     {
     }
 
-    inline bool operator()(const std::pair<T1, T2>& p1,
-                           const std::pair<T1, T2>& p2)
+    bool operator()(const std::pair<T1, T2>& p1, const std::pair<T1, T2>& p2)
     {
         if (comp_(p2.first, p1.first))
             return true;

--- a/tlx/algorithm/multisequence_selection.hpp
+++ b/tlx/algorithm/multisequence_selection.hpp
@@ -48,8 +48,7 @@ public:
     {
     }
 
-    inline bool operator()(const std::pair<T1, T2>& p1,
-                           const std::pair<T1, T2>& p2)
+    bool operator()(const std::pair<T1, T2>& p1, const std::pair<T1, T2>& p2)
     {
         if (comp_(p1.first, p2.first))
             return true;
@@ -74,8 +73,7 @@ public:
     {
     }
 
-    inline bool operator()(const std::pair<T1, T2>& p1,
-                           const std::pair<T1, T2>& p2)
+    bool operator()(const std::pair<T1, T2>& p1, const std::pair<T1, T2>& p2)
     {
         if (comp_(p2.first, p1.first))
             return true;

--- a/tlx/backtrace.cpp
+++ b/tlx/backtrace.cpp
@@ -116,21 +116,21 @@ void print_cxx_backtrace(FILE* out, unsigned int max_frames)
 
         // find parentheses and +address offset surrounding the mangled name:
         // ./module(function+0x15c) [0x8048a6d]
-        for (char* p = symbollist[i]; *p; ++p)
+        for (char* p = symbollist[i]; *p != 0; ++p)
         {
             if (*p == '(')
                 begin_name = p;
             else if (*p == '+')
                 begin_offset = p;
-            else if (*p == ')' && begin_offset)
+            else if (*p == ')' && begin_offset != nullptr)
             {
                 end_offset = p;
                 break;
             }
         }
 
-        if (begin_name && begin_offset && end_offset &&
-            begin_name < begin_offset)
+        if (begin_name != nullptr && begin_offset != nullptr &&
+            end_offset != nullptr && begin_name < begin_offset)
         {
             *begin_name++ = '\0';
             *begin_offset++ = '\0';

--- a/tlx/container/d_ary_addressable_int_heap.hpp
+++ b/tlx/container/d_ary_addressable_int_heap.hpp
@@ -358,7 +358,7 @@ private:
         {
             // Iterate from the last internal node up to the root.
             size_t last_internal = (heap_.size() - 2) / arity;
-            for (size_t i = last_internal + 1; i; --i)
+            for (size_t i = last_internal + 1; i != 0; --i)
             {
                 // Index of the current internal node.
                 size_t cur = i - 1;

--- a/tlx/container/d_ary_heap.hpp
+++ b/tlx/container/d_ary_heap.hpp
@@ -263,7 +263,7 @@ private:
         {
             // Iterate from the last internal node up to the root.
             size_t last_internal = (heap_.size() - 2) / arity;
-            for (size_t i = last_internal + 1; i; --i)
+            for (size_t i = last_internal + 1; i != 0; --i)
             {
                 // Index of the current internal node.
                 size_t cur = i - 1;

--- a/tlx/container/radix_heap.hpp
+++ b/tlx/container/radix_heap.hpp
@@ -99,7 +99,7 @@ class BitArrayRecursive<Size, false>
     static_assert(width > leaf_width,
                   "Size has to be larger than 2**leaf_width");
     static constexpr size_t root_width =
-        (width % leaf_width) ? (width % leaf_width) : leaf_width;
+        (width % leaf_width) != 0 ? (width % leaf_width) : leaf_width;
     static constexpr size_t child_width = width - root_width;
     using child_type = BitArrayRecursive<1llu << child_width, child_width <= 6>;
 

--- a/tlx/container/string_view.hpp
+++ b/tlx/container/string_view.hpp
@@ -80,8 +80,9 @@ public:
     StringView(std::string&&) = delete;
 
     //! assign a whole C-style string
-    StringView(const char* str) noexcept : ptr_(str),
-                                           size_(str ? std::strlen(str) : 0)
+    StringView(const char* str) noexcept
+        : ptr_(str),
+          size_(str != nullptr ? std::strlen(str) : 0)
     {
     }
 

--- a/tlx/die/core.hpp
+++ b/tlx/die/core.hpp
@@ -67,7 +67,7 @@ bool set_die_with_exception(bool b);
 #define tlx_die_unless(X)                                                      \
     do                                                                         \
     {                                                                          \
-        if (!(X))                                                              \
+        if (!(X)) /* NOLINT(readability-simplify-boolean-expr) */              \
         {                                                                      \
             ::tlx::die_with_message("DIE: Assertion \"" #X "\" failed!",       \
                                     __FILE__, __LINE__);                       \
@@ -91,7 +91,7 @@ bool set_die_with_exception(bool b);
 #define tlx_die_verbose_unless(X, msg)                                         \
     do                                                                         \
     {                                                                          \
-        if (!(X))                                                              \
+        if (!(X)) /* NOLINT(readability-simplify-boolean-expr) */              \
         {                                                                      \
             tlx_die_with_sstream("DIE: Assertion \"" #X "\" failed!\n"         \
                                  << msg << '\n');                              \

--- a/tlx/logger/core.cpp
+++ b/tlx/logger/core.cpp
@@ -87,7 +87,7 @@ LoggerPrefixHook* set_logger_prefix_hook(LoggerPrefixHook* hook)
 Logger::Logger()
 {
     LoggerPrefixHook* prefix_hook = s_logger_prefix_hook.load();
-    if (prefix_hook)
+    if (prefix_hook != nullptr)
         prefix_hook->add_log_prefix(oss_);
 }
 
@@ -100,7 +100,7 @@ Logger::~Logger()
 SpacingLogger::SpacingLogger()
 {
     LoggerPrefixHook* prefix_hook = s_logger_prefix_hook.load();
-    if (prefix_hook)
+    if (prefix_hook != nullptr)
         prefix_hook->add_log_prefix(oss_);
 }
 

--- a/tlx/math/clz.hpp
+++ b/tlx/math/clz.hpp
@@ -46,76 +46,76 @@ inline unsigned clz(Integral x);
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<unsigned>(unsigned i)
+inline unsigned clz<unsigned>(unsigned x)
 {
-    if (i == 0)
-        return 8 * sizeof(i);
-    return static_cast<unsigned>(__builtin_clz(i));
+    if (x == 0)
+        return 8 * sizeof(x);
+    return static_cast<unsigned>(__builtin_clz(x));
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<int>(int i)
+inline unsigned clz<int>(int x)
 {
-    return clz(static_cast<unsigned>(i));
+    return clz(static_cast<unsigned>(x));
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<unsigned long>(unsigned long i)
+inline unsigned clz<unsigned long>(unsigned long x)
 {
-    if (i == 0)
-        return 8 * sizeof(i);
-    return static_cast<unsigned>(__builtin_clzl(i));
+    if (x == 0)
+        return 8 * sizeof(x);
+    return static_cast<unsigned>(__builtin_clzl(x));
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<long>(long i)
+inline unsigned clz<long>(long x)
 {
-    return clz(static_cast<unsigned long>(i));
+    return clz(static_cast<unsigned long>(x));
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<unsigned long long>(unsigned long long i)
+inline unsigned clz<unsigned long long>(unsigned long long x)
 {
-    if (i == 0)
-        return 8 * sizeof(i);
-    return static_cast<unsigned>(__builtin_clzll(i));
+    if (x == 0)
+        return 8 * sizeof(x);
+    return static_cast<unsigned>(__builtin_clzll(x));
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<long long>(long long i)
+inline unsigned clz<long long>(long long x)
 {
-    return clz(static_cast<unsigned long long>(i));
+    return clz(static_cast<unsigned long long>(x));
 }
 
 #elif defined(_MSC_VER)
 
 //! clz (count leading zeros)
 template <typename Integral>
-inline unsigned clz<unsigned>(Integral i)
+inline unsigned clz<unsigned>(Integral x)
 {
     unsigned long leading_zeros = 0;
-    if (sizeof(i) > 4)
+    if (sizeof(x) > 4)
     {
 #if defined(_WIN64)
-        if (_BitScanReverse64(&leading_zeros, i))
+        if (_BitScanReverse64(&leading_zeros, x))
             return 63 - leading_zeros;
         else
-            return 8 * sizeof(i);
+            return 8 * sizeof(x);
 #else
-        return clz_template(i);
+        return clz_template(x);
 #endif
     }
     else
     {
-        if (_BitScanReverse(&leading_zeros, static_cast<unsigned>(i)))
+        if (_BitScanReverse(&leading_zeros, static_cast<unsigned>(x)))
             return 31 - leading_zeros;
         else
-            return 8 * sizeof(i);
+            return 8 * sizeof(x);
     }
 }
 
@@ -123,44 +123,44 @@ inline unsigned clz<unsigned>(Integral i)
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<int>(int i)
+inline unsigned clz<int>(int x)
 {
-    return clz_template(i);
+    return clz_template(x);
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<unsigned>(unsigned i)
+inline unsigned clz<unsigned>(unsigned x)
 {
-    return clz_template(i);
+    return clz_template(x);
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<long>(long i)
+inline unsigned clz<long>(long x)
 {
-    return clz_template(i);
+    return clz_template(x);
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<unsigned long>(unsigned long i)
+inline unsigned clz<unsigned long>(unsigned long x)
 {
-    return clz_template(i);
+    return clz_template(x);
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<long long>(long long i)
+inline unsigned clz<long long>(long long x)
 {
-    return clz_template(i);
+    return clz_template(x);
 }
 
 //! clz (count leading zeros)
 template <>
-inline unsigned clz<unsigned long long>(unsigned long long i)
+inline unsigned clz<unsigned long long>(unsigned long long x)
 {
-    return clz_template(i);
+    return clz_template(x);
 }
 
 #endif

--- a/tlx/math/ctz.hpp
+++ b/tlx/math/ctz.hpp
@@ -46,76 +46,76 @@ inline unsigned ctz(Integral x);
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<unsigned>(unsigned i)
+inline unsigned ctz<unsigned>(unsigned x)
 {
-    if (i == 0)
-        return 8 * sizeof(i);
-    return static_cast<unsigned>(__builtin_ctz(i));
+    if (x == 0)
+        return 8 * sizeof(x);
+    return static_cast<unsigned>(__builtin_ctz(x));
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<int>(int i)
+inline unsigned ctz<int>(int x)
 {
-    return ctz(static_cast<unsigned>(i));
+    return ctz(static_cast<unsigned>(x));
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<unsigned long>(unsigned long i)
+inline unsigned ctz<unsigned long>(unsigned long x)
 {
-    if (i == 0)
-        return 8 * sizeof(i);
-    return static_cast<unsigned>(__builtin_ctzl(i));
+    if (x == 0)
+        return 8 * sizeof(x);
+    return static_cast<unsigned>(__builtin_ctzl(x));
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<long>(long i)
+inline unsigned ctz<long>(long x)
 {
-    return ctz(static_cast<unsigned long>(i));
+    return ctz(static_cast<unsigned long>(x));
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<unsigned long long>(unsigned long long i)
+inline unsigned ctz<unsigned long long>(unsigned long long x)
 {
-    if (i == 0)
-        return 8 * sizeof(i);
-    return static_cast<unsigned>(__builtin_ctzll(i));
+    if (x == 0)
+        return 8 * sizeof(x);
+    return static_cast<unsigned>(__builtin_ctzll(x));
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<long long>(long long i)
+inline unsigned ctz<long long>(long long x)
 {
-    return ctz(static_cast<unsigned long long>(i));
+    return ctz(static_cast<unsigned long long>(x));
 }
 
 #elif defined(_MSC_VER)
 
 //! ctz (count trailing zeros)
 template <typename Integral>
-inline unsigned ctz<unsigned>(Integral i)
+inline unsigned ctz<unsigned>(Integral x)
 {
     unsigned long trailing_zeros = 0;
-    if (sizeof(i) > 4)
+    if (sizeof(x) > 4)
     {
 #if defined(_WIN64)
-        if (_BitScanForward64(&trailing_zeros, i))
+        if (_BitScanForward64(&trailing_zeros, x))
             return trailing_zeros;
         else
-            return 8 * sizeof(i);
+            return 8 * sizeof(x);
 #else
-        return ctz_template(i);
+        return ctz_template(x);
 #endif
     }
     else
     {
-        if (_BitScanForward(&trailing_zeros, static_cast<unsigned>(i)))
+        if (_BitScanForward(&trailing_zeros, static_cast<unsigned>(x)))
             return trailing_zeros;
         else
-            return 8 * sizeof(i);
+            return 8 * sizeof(x);
     }
 }
 
@@ -123,44 +123,44 @@ inline unsigned ctz<unsigned>(Integral i)
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<int>(int i)
+inline unsigned ctz<int>(int x)
 {
-    return ctz_template(i);
+    return ctz_template(x);
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<unsigned>(unsigned i)
+inline unsigned ctz<unsigned>(unsigned x)
 {
-    return ctz_template(i);
+    return ctz_template(x);
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<long>(long i)
+inline unsigned ctz<long>(long x)
 {
-    return ctz_template(i);
+    return ctz_template(x);
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<unsigned long>(unsigned long i)
+inline unsigned ctz<unsigned long>(unsigned long x)
 {
-    return ctz_template(i);
+    return ctz_template(x);
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<long long>(long long i)
+inline unsigned ctz<long long>(long long x)
 {
-    return ctz_template(i);
+    return ctz_template(x);
 }
 
 //! ctz (count trailing zeros)
 template <>
-inline unsigned ctz<unsigned long long>(unsigned long long i)
+inline unsigned ctz<unsigned long long>(unsigned long long x)
 {
-    return ctz_template(i);
+    return ctz_template(x);
 }
 
 #endif

--- a/tlx/math/div_ceil.hpp
+++ b/tlx/math/div_ceil.hpp
@@ -21,8 +21,8 @@ namespace tlx {
 
 //! calculate n div k with rounding up, for n and k positive!
 template <typename IntegralN, typename IntegralK>
-static inline constexpr auto div_ceil(const IntegralN& n, const IntegralK& k)
-    -> decltype(n + k)
+static constexpr auto div_ceil(const IntegralN& n,
+                               const IntegralK& k) -> decltype(n + k)
 {
     return (n + k - 1) / k;
 }

--- a/tlx/math/power_to_the.hpp
+++ b/tlx/math/power_to_the.hpp
@@ -26,7 +26,7 @@ namespace tlx {
 
 //! returns x raised to the power of D using log(D) explicit multiplications.
 template <unsigned D, typename T>
-static inline constexpr T power_to_the(T x)
+static constexpr T power_to_the(T x)
 {
     // Compiler optimize two calls to the same recursion into one
     // Tested with GCC 4+, Clang 3+, MSVC 15+

--- a/tlx/math/round_up.hpp
+++ b/tlx/math/round_up.hpp
@@ -21,8 +21,8 @@ namespace tlx {
 
 //! round n up to the next multiple of k, for n and k positive!
 template <typename IntegralN, typename IntegralK>
-static inline constexpr auto round_up(const IntegralN& n, const IntegralK& k)
-    -> decltype(n + k)
+static constexpr auto round_up(const IntegralN& n,
+                               const IntegralK& k) -> decltype(n + k)
 {
     return ((n + k - 1) / k) * k;
 }

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -115,9 +115,9 @@ const char* MultiTimer::running() const
     return running_;
 }
 
-double MultiTimer::get(const char* name)
+double MultiTimer::get(const char* timer)
 {
-    return find_or_create(name).duration.count();
+    return find_or_create(timer).duration.count();
 }
 
 double MultiTimer::total() const

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -73,7 +73,8 @@ void MultiTimer::start(const char* timer)
 {
     tlx_die_unless(timer);
     std::uint32_t hash = hash_djb2(timer);
-    if (running_ && hash == running_hash_ && strcmp(running_, timer) == 0)
+    if (running_ != nullptr && hash == running_hash_ &&
+        strcmp(running_, timer) == 0)
     {
         static bool warning_shown = false;
         if (!warning_shown)
@@ -93,7 +94,7 @@ void MultiTimer::start(const char* timer)
 void MultiTimer::stop()
 {
     auto new_time_point = std::chrono::high_resolution_clock::now();
-    if (running_)
+    if (running_ != nullptr)
     {
         Entry& e = find_or_create(running_);
         e.duration += new_time_point - time_point_;
@@ -145,7 +146,7 @@ void MultiTimer::print(const char* info) const
 MultiTimer& MultiTimer::add(const MultiTimer& b)
 {
     std::unique_lock<std::mutex> lock(s_timer_add_mutex);
-    if (b.running_)
+    if (b.running_ != nullptr)
         TLX_LOG1 << "MultiTimer: trying to add running timer";
 
     for (const Entry& t : b.timers_)

--- a/tlx/sort/networks/cswap.hpp
+++ b/tlx/sort/networks/cswap.hpp
@@ -37,7 +37,7 @@ public:
     }
 
     template <typename Type>
-    inline void operator()(Type& left, Type& right)
+    void operator()(Type& left, Type& right)
     {
         if (cmp_(right, left))
             std::swap(left, right);

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -1175,7 +1175,7 @@ public:
             ss_stack_[--ss_front_].calculate_lcp(ctx_);
         }
 
-        if (pstep_)
+        if (pstep_ != nullptr)
             pstep_->substep_notify_done();
         delete this;
     }
@@ -1501,7 +1501,7 @@ public:
             bkt_[0].destroy();
         }
 
-        if (pstep_)
+        if (pstep_ != nullptr)
             pstep_->substep_notify_done();
         delete this;
     }

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -465,7 +465,7 @@ public:
         typedef SeqSampleSortStep Step;
 
         assert(ss_front_ == 0);
-        assert(ss_stack_.size() == 0);
+        assert(ss_stack_.empty());
 
         std::uint16_t* bktcache =
             reinterpret_cast<std::uint16_t*>(bktcache_.data());
@@ -997,7 +997,7 @@ public:
         key_type* cache = reinterpret_cast<key_type*>(bktcache_.data());
 
         assert(ms_front_ == 0);
-        assert(ms_stack_.size() == 0);
+        assert(ms_stack_.empty());
 
         // std::deque is much slower than std::vector, so we use an artificial
         // pop_front variable.

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -122,7 +122,7 @@ public:
 
     //! enqueue a new job in the thread pool
     template <typename StringPtr>
-    void enqueue(PS5SortStep* sstep, const StringPtr& strptr, size_t depth);
+    void enqueue(PS5SortStep* pstep, const StringPtr& strptr, size_t depth);
 
     //! return sequential sorting threshold
     size_t sequential_threshold()

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -679,13 +679,13 @@ public:
     /*------------------------------------------------------------------------*/
     //! Stack of Recursive MKQS Steps
 
-    static inline int cmp(const key_type& a, const key_type& b)
+    static int cmp(const key_type& a, const key_type& b)
     {
         return (a > b) ? 1 : (a < b) ? -1 : 0;
     }
 
     template <typename Type>
-    static inline size_t med3(Type* A, size_t i, size_t j, size_t k)
+    static size_t med3(Type* A, size_t i, size_t j, size_t k)
     {
         if (A[i] == A[j])
             return i;
@@ -708,8 +708,8 @@ public:
     }
 
     //! Insertion sort the strings only based on the cached characters.
-    static inline void insertion_sort_cache_block(const StringPtr& strptr,
-                                                  key_type* cache)
+    static void insertion_sort_cache_block(const StringPtr& strptr,
+                                           key_type* cache)
     {
         const StringSet& strings = strptr.active();
         size_t n = strptr.size();
@@ -732,8 +732,8 @@ public:
 
     //! Insertion sort, but use cached characters if possible.
     template <bool CacheDirty>
-    static inline void insertion_sort_cache(const StringPtr& _strptr,
-                                            key_type* cache, size_t depth)
+    static void insertion_sort_cache(const StringPtr& _strptr, key_type* cache,
+                                     size_t depth)
     {
         StringPtr strptr = _strptr.copy_back();
 

--- a/tlx/sort/strings/radix_sort.hpp
+++ b/tlx/sort/strings/radix_sort.hpp
@@ -119,7 +119,7 @@ static inline void radixsort_CE0_loop(const StringShadowPtr& strptr,
     std::stack<RadixStep, std::vector<RadixStep> > radixstack;
     radixstack.emplace(strptr, depth);
 
-    while (radixstack.size())
+    while (!radixstack.empty())
     {
         while (radixstack.top().idx < 255)
         {

--- a/tlx/sort/strings/radix_sort.hpp
+++ b/tlx/sort/strings/radix_sort.hpp
@@ -402,7 +402,8 @@ struct RadixStep_CE3
             size_t second = get_next_non_empty_bkt_index(first + 1);
             while (second < RADIX)
             {
-                size_t partial_equal = (first >> 8) == (second >> 8);
+                size_t partial_equal =
+                    static_cast<size_t>((first >> 8) == (second >> 8));
                 strptr.set_lcp(bkt, depth + partial_equal);
                 bkt += bkt_size[second];
                 first = second;
@@ -772,7 +773,8 @@ struct RadixStep_CI3
             size_t second = get_next_non_empty_bkt_index(first + 1);
             while (second < RADIX)
             {
-                size_t partial_equal = (first >> 8) == (second >> 8);
+                size_t partial_equal =
+                    static_cast<size_t>((first >> 8) == (second >> 8));
                 strptr.set_lcp(bkt, depth + partial_equal);
                 bkt += bkt_size[second];
                 first = second;

--- a/tlx/sort/strings/sample_sort_tools.hpp
+++ b/tlx/sort/strings/sample_sort_tools.hpp
@@ -55,7 +55,7 @@ struct PerfectTreeCalculations
     static const size_t treebits = TreeBits;
     static const size_t num_nodes = (1 << treebits) - 1;
 
-    static inline unsigned int level_to_preorder(unsigned int id)
+    static unsigned int level_to_preorder(unsigned int id)
     {
         assert(id > 0);
         TLX_LOG << "index: " << id << " = " << to_binary(id);
@@ -71,7 +71,7 @@ struct PerfectTreeCalculations
         return bkt;
     }
 
-    static inline unsigned int pre_to_levelorder(unsigned int id)
+    static unsigned int pre_to_levelorder(unsigned int id)
     {
         assert(id > 0);
         TLX_LOG << "index: " << id << " = " << to_binary(id);
@@ -87,7 +87,7 @@ struct PerfectTreeCalculations
         return bkt;
     }
 
-    static inline void self_verify()
+    static void self_verify()
     {
         for (size_t i = 1; i <= num_nodes; ++i)
         {

--- a/tlx/string/expand_environment_variables.cpp
+++ b/tlx/string/expand_environment_variables.cpp
@@ -53,11 +53,11 @@ std::string& expand_environment_variables(std::string* sp)
             p = dp + vlen + 1;
         }
         else if (dp + 1 < s.size() &&
-                 (std::isalpha(s[dp + 1]) || s[dp + 1] == '_'))
+                 (std::isalpha(s[dp + 1]) != 0 || s[dp + 1] == '_'))
         {
             // match "$[a-zA-Z][a-zA-Z0-9]*"
             std::string::size_type de = dp + 1;
-            while (de < s.size() && (std::isalnum(s[de]) || s[de] == '_'))
+            while (de < s.size() && (std::isalnum(s[de]) != 0 || s[de] == '_'))
                 ++de;
 
             // cut out variable name

--- a/tlx/string/join_quoted.cpp
+++ b/tlx/string/join_quoted.cpp
@@ -15,23 +15,23 @@
 
 namespace tlx {
 
-std::string join_quoted(const std::vector<std::string>& vec, char sep,
+std::string join_quoted(const std::vector<std::string>& strs, char sep,
                         char quote, char escape)
 {
     std::string out;
-    if (vec.empty())
+    if (strs.empty())
         return out;
 
-    for (size_t i = 0; i < vec.size(); ++i)
+    for (size_t i = 0; i < strs.size(); ++i)
     {
         if (i != 0)
             out += sep;
 
-        if (vec[i].find(sep) != std::string::npos)
+        if (strs[i].find(sep) != std::string::npos)
         {
             out += quote;
-            for (std::string::const_iterator it = vec[i].begin();
-                 it != vec[i].end(); ++it)
+            for (std::string::const_iterator it = strs[i].begin();
+                 it != strs[i].end(); ++it)
             {
                 if (*it == quote || *it == escape)
                 {
@@ -58,16 +58,16 @@ std::string join_quoted(const std::vector<std::string>& vec, char sep,
         }
         else
         {
-            out += vec[i];
+            out += strs[i];
         }
     }
 
     return out;
 }
 
-std::string join_quoted(const std::vector<std::string>& vec)
+std::string join_quoted(const std::vector<std::string>& strs)
 {
-    return join_quoted(vec, ' ', '"', '\\');
+    return join_quoted(strs, ' ', '"', '\\');
 }
 
 } // namespace tlx

--- a/tlx/string/join_quoted.hpp
+++ b/tlx/string/join_quoted.hpp
@@ -26,7 +26,7 @@ namespace tlx {
  * the separator, quote the field. In the quoted string, escape all quotes,
  * escapes, \\n, \\r, \\t sequences. This is the opposite of split_quoted().
  */
-std::string join_quoted(const std::vector<std::string>& str, char sep,
+std::string join_quoted(const std::vector<std::string>& strs, char sep,
                         char quote, char escape);
 
 /*!
@@ -34,7 +34,7 @@ std::string join_quoted(const std::vector<std::string>& str, char sep,
  * contains a space, quote the field. In the quoted string, escape all quotes,
  * escapes, \\n, \\r, \\t sequences. This is the opposite of split_quoted().
  */
-std::string join_quoted(const std::vector<std::string>& str);
+std::string join_quoted(const std::vector<std::string>& strs);
 
 //! \}
 //! \}

--- a/tlx/string/less_icase.hpp
+++ b/tlx/string/less_icase.hpp
@@ -39,7 +39,7 @@ bool less_icase(const std::string& a, const std::string& b);
 //! Case-insensitive less order relation functional class for std::map, etc.
 struct less_icase_asc
 {
-    inline bool operator()(const std::string& a, const std::string& b) const
+    bool operator()(const std::string& a, const std::string& b) const
     {
         return less_icase(a, b);
     }
@@ -49,7 +49,7 @@ struct less_icase_asc
 //! std::map, etc.
 struct less_icase_desc
 {
-    inline bool operator()(const std::string& a, const std::string& b) const
+    bool operator()(const std::string& a, const std::string& b) const
     {
         return !less_icase(a, b);
     }

--- a/tlx/string/levenshtein.hpp
+++ b/tlx/string/levenshtein.hpp
@@ -33,7 +33,7 @@ struct LevenshteinStandardParameters
     static const unsigned int cost_insert_delete = 1;
     static const unsigned int cost_replace = 1;
 
-    static inline bool char_equal(const char& a, const char& b)
+    static bool char_equal(const char& a, const char& b)
     {
         return (a == b);
     }
@@ -48,7 +48,7 @@ struct LevenshteinStandardICaseParameters
     static const unsigned int cost_insert_delete = 1;
     static const unsigned int cost_replace = 1;
 
-    static inline bool char_equal(const char& a, const char& b)
+    static bool char_equal(const char& a, const char& b)
     {
         return to_lower(a) == to_lower(b);
     }

--- a/tlx/string/parse_uri.hpp
+++ b/tlx/string/parse_uri.hpp
@@ -32,7 +32,7 @@ static inline void parse_uri(const char* uri, tlx::string_view* path,
 
     // find path part
     const char* begin = c;
-    while (!(*c == '?' || *c == '#' || *c == 0))
+    while (*c != '?' && *c != '#' && *c != 0)
     {
         ++c;
     }
@@ -43,7 +43,7 @@ static inline void parse_uri(const char* uri, tlx::string_view* path,
     if (*c == '?')
     {
         begin = ++c;
-        while (!(*c == '#' || *c == 0))
+        while (*c != '#' && *c != 0)
         {
             ++c;
         }

--- a/tlx/string/parse_uri_form_data.hpp
+++ b/tlx/string/parse_uri_form_data.hpp
@@ -35,7 +35,7 @@ static inline std::string parse_uri_form_data_decode(const char* str,
         out.reserve(end - str);
     char a, b;
 
-    while (*str && str != end)
+    while (*str != 0 && str != end)
     {
         if (*str == '%' && (a = str[1]) != 0 && (b = str[2]) != 0)
         {


### PR DESCRIPTION
This PR enables more clang-tidy checks:
- `readability-inconsistent-declaration-parameter-name`
- `readability-simplify-boolean-expr`
- `readability-container-size-empty`
- `readability-implicit-bool-conversion`
- `readability-redundant-inline-specifier`
