### PR TITLE
clang-tidy: enable some `cppcoreguidelines-*` checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks:
   - "-readability-qualified-auto"
   - "-readability-redundant-access-specifiers"
   - "-readability-static-accessed-through-instance"
+  - "cppcoreguidelines-virtual-class-destructor"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks:
   - "cppcoreguidelines-prefer-member-initializer"
   - "cppcoreguidelines-use-default-member-init"
   - "cppcoreguidelines-virtual-class-destructor"
+  - "cppcoreguidelines-non-private-member-variables-in-classes"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks:
   - "-readability-qualified-auto"
   - "-readability-redundant-access-specifiers"
   - "-readability-static-accessed-through-instance"
+  - "cppcoreguidelines-use-default-member-init"
   - "cppcoreguidelines-virtual-class-destructor"
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks:
   - "-readability-qualified-auto"
   - "-readability-redundant-access-specifiers"
   - "-readability-static-accessed-through-instance"
+  - "cppcoreguidelines-prefer-member-initializer"
   - "cppcoreguidelines-use-default-member-init"
   - "cppcoreguidelines-virtual-class-destructor"
 

--- a/tests/algorithm/multiway_merge_benchmark.cpp
+++ b/tests/algorithm/multiway_merge_benchmark.cpp
@@ -91,7 +91,7 @@ enum benchmark_type
  */
 class scoped_print_timer
 {
-protected:
+private:
     //! message
     std::string message_;
 

--- a/tests/container/loser_tree_test.cpp
+++ b/tests/container/loser_tree_test.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <iostream>
 #include <random>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/tests/container/radix_heap_test.cpp
+++ b/tests/container/radix_heap_test.cpp
@@ -76,7 +76,7 @@ public:
         std::swap(bits_, o.bits_);
     }
 
-protected:
+private:
     std::vector<bool> bits_;
 };
 

--- a/tlx/algorithm/multisequence_partition.hpp
+++ b/tlx/algorithm/multisequence_partition.hpp
@@ -40,7 +40,7 @@ namespace multisequence_partition_detail {
 template <typename T1, typename T2, typename Comparator>
 class lexicographic
 {
-protected:
+private:
     Comparator& comp_;
 
 public:
@@ -65,7 +65,7 @@ public:
 template <typename T1, typename T2, typename Comparator>
 class lexicographic_rev
 {
-protected:
+private:
     Comparator& comp_;
 
 public:

--- a/tlx/algorithm/multisequence_selection.hpp
+++ b/tlx/algorithm/multisequence_selection.hpp
@@ -40,7 +40,7 @@ namespace multisequence_selection_detail {
 template <typename T1, typename T2, typename Comparator>
 class lexicographic
 {
-protected:
+private:
     Comparator& comp_;
 
 public:
@@ -65,7 +65,7 @@ public:
 template <typename T1, typename T2, typename Comparator>
 class lexicographic_rev
 {
-protected:
+private:
     Comparator& comp_;
 
 public:

--- a/tlx/algorithm/multiway_merge.hpp
+++ b/tlx/algorithm/multiway_merge.hpp
@@ -63,7 +63,7 @@ public:
     using value_type =
         typename std::iterator_traits<RandomAccessIterator>::value_type;
 
-protected:
+private:
     //! Current iterator position.
     RandomAccessIterator current;
     //! End iterator of the sequence.
@@ -155,7 +155,7 @@ public:
     using value_type =
         typename std::iterator_traits<RandomAccessIterator>::value_type;
 
-protected:
+private:
     //! Current iterator position.
     RandomAccessIterator current;
     //! Comparator.

--- a/tlx/cmdline_parser.cpp
+++ b/tlx/cmdline_parser.cpp
@@ -97,7 +97,7 @@ public:
 //! specialization of argument for boolean flags (can only be set to true).
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentBool final : public Argument
 {
-protected:
+private:
     //! reference to boolean to set to true
     bool& dest_;
 
@@ -132,7 +132,7 @@ public:
 //! specialization of argument for integer options or parameters
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentInt final : public Argument
 {
-protected:
+private:
     int& dest_;
 
 public:
@@ -176,7 +176,7 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentUnsigned final
     : public Argument
 {
-protected:
+private:
     unsigned int& dest_;
 
 public:
@@ -219,7 +219,7 @@ public:
 //! specialization of argument for size_t options or parameters
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentSizeT final : public Argument
 {
-protected:
+private:
     size_t& dest_;
 
 public:
@@ -262,7 +262,7 @@ public:
 //! specialization of argument for float options or parameters
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentFloat final : public Argument
 {
-protected:
+private:
     float& dest_;
 
 public:
@@ -304,7 +304,7 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentDouble final
     : public Argument
 {
-protected:
+private:
     double& dest_;
 
 public:
@@ -347,7 +347,7 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentBytes32 final
     : public Argument
 {
-protected:
+private:
     std::uint32_t& dest_;
 
 public:
@@ -391,7 +391,7 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentBytes64 final
     : public Argument
 {
-protected:
+private:
     std::uint64_t& dest_;
 
 public:
@@ -431,7 +431,7 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentString final
     : public Argument
 {
-protected:
+private:
     std::string& dest_;
 
 public:
@@ -468,7 +468,7 @@ public:
 class TLX_VISIBILITY_HIDDEN CmdlineParser::ArgumentStringlist final
     : public Argument
 {
-protected:
+private:
     std::vector<std::string>& dest_;
 
 public:

--- a/tlx/container/btree.hpp
+++ b/tlx/container/btree.hpp
@@ -1299,7 +1299,7 @@ public:
     //! Function class to compare value_type objects. Required by the STL
     class value_compare
     {
-    protected:
+    private:
         //! Key comparison function from the template parameter
         key_compare key_comp;
 

--- a/tlx/container/btree.hpp
+++ b/tlx/container/btree.hpp
@@ -1164,24 +1164,19 @@ public:
     struct tree_stats
     {
         //! Number of items in the B+ tree
-        size_type size;
+        size_type size = 0;
 
         //! Number of leaves in the B+ tree
-        size_type leaves;
+        size_type leaves = 0;
 
         //! Number of inner nodes in the B+ tree
-        size_type inner_nodes;
+        size_type inner_nodes = 0;
 
         //! Base B+ tree parameter: The number of key/data slots in each leaf
         static const unsigned short leaf_slots = Self::leaf_slotmax;
 
         //! Base B+ tree parameter: The number of key slots in each inner node.
         static const unsigned short inner_slots = Self::inner_slotmax;
-
-        //! Zero initialized
-        tree_stats() : size(0), leaves(0), inner_nodes(0)
-        {
-        }
 
         //! Return the total number of nodes
         size_type nodes() const

--- a/tlx/container/d_ary_addressable_int_heap.hpp
+++ b/tlx/container/d_ary_addressable_int_heap.hpp
@@ -51,7 +51,7 @@ public:
 
     static constexpr size_t arity = Arity;
 
-protected:
+private:
     //! Cells in the heap.
     std::vector<key_type> heap_;
 

--- a/tlx/container/d_ary_heap.hpp
+++ b/tlx/container/d_ary_heap.hpp
@@ -43,7 +43,7 @@ public:
 
     static constexpr size_t arity = Arity;
 
-protected:
+private:
     //! Cells in the heap.
     std::vector<key_type> heap_;
 

--- a/tlx/container/loser_tree.hpp
+++ b/tlx/container/loser_tree.hpp
@@ -84,16 +84,12 @@ protected:
     //! the comparator object
     Comparator cmp_;
     //! still have to construct keys
-    bool first_insert_;
+    bool first_insert_ = true;
 
 public:
     explicit LoserTreeCopyBase(const Source& k,
                                const Comparator& cmp = Comparator())
-        : ik_(k),
-          k_(round_up_to_power_of_two(ik_)),
-          losers_(2 * k_),
-          cmp_(cmp),
-          first_insert_(true)
+        : ik_(k), k_(round_up_to_power_of_two(ik_)), losers_(2 * k_), cmp_(cmp)
     {
         for (Source i = ik_ - 1; i < k_; ++i)
         {

--- a/tlx/container/loser_tree.hpp
+++ b/tlx/container/loser_tree.hpp
@@ -74,6 +74,8 @@ protected:
         ValueType key;
     };
 
+    // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
+
     //! number of nodes
     const Source ik_;
     //! log_2(ik) next greater power of 2
@@ -83,6 +85,9 @@ protected:
     SimpleVector<Loser> losers_;
     //! the comparator object
     Comparator cmp_;
+
+    // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
+private:
     //! still have to construct keys
     bool first_insert_ = true;
 
@@ -346,6 +351,8 @@ protected:
         const ValueType* keyp;
     };
 
+    // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
+
     //! number of nodes
     const Source ik_;
     //! log_2(ik) next greater power of 2
@@ -355,6 +362,7 @@ protected:
     //! the comparator object
     Comparator cmp_;
 
+    // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 public:
     explicit LoserTreePointerBase(Source k,
                                   const Comparator& cmp = Comparator())
@@ -587,6 +595,8 @@ protected:
         ValueType key;
     };
 
+    // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
+
     //! number of nodes
     Source ik_;
     //! log_2(ik) next greater power of 2
@@ -596,6 +606,7 @@ protected:
     //! the comparator object
     Comparator cmp_;
 
+    // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 public:
     LoserTreeCopyUnguardedBase(Source k, const ValueType& sentinel,
                                const Comparator& cmp = Comparator())
@@ -778,6 +789,8 @@ protected:
         const ValueType* keyp;
     };
 
+    // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
+
     //! number of nodes
     Source ik_;
     //! log_2(ik) next greater power of 2
@@ -787,6 +800,7 @@ protected:
     //! the comparator object
     Comparator cmp_;
 
+    // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 public:
     LoserTreePointerUnguardedBase(const Source& k, const ValueType& sentinel,
                                   const Comparator& cmp = Comparator())

--- a/tlx/container/radix_heap.hpp
+++ b/tlx/container/radix_heap.hpp
@@ -598,7 +598,7 @@ public:
         initialize_();
     }
 
-protected:
+private:
     KeyExtract key_extract_;
     size_t size_{0};
     ranked_key_type insertion_limit_{0};

--- a/tlx/container/ring_buffer.hpp
+++ b/tlx/container/ring_buffer.hpp
@@ -394,7 +394,7 @@ public:
 
     //! \}
 
-protected:
+private:
     //! target max_size of circular buffer prescribed by the user. Never equal
     //! to the data_.size(), which is rounded up to a power of two.
     size_t max_size_;

--- a/tlx/container/simple_vector.hpp
+++ b/tlx/container/simple_vector.hpp
@@ -54,7 +54,7 @@ public:
     using value_type = ValueType;
     using size_type = size_t;
 
-protected:
+private:
     //! size of allocated memory
     size_type size_;
 

--- a/tlx/delegate.hpp
+++ b/tlx/delegate.hpp
@@ -185,7 +185,8 @@ public:
               typename = typename std::enable_if<!std::is_same<
                   Delegate, typename std::decay<T>::type>::value>::type>
     Delegate(T&& f)
-        : store_(
+        : caller_(functor_caller<typename std::decay<T>::type>),
+          store_(
               // allocate memory for T in shared_ptr with appropriate deleter
               typename std::allocator_traits<Allocator>::template rebind_alloc<
                   typename std::decay<T>::type>{}
@@ -203,8 +204,6 @@ public:
             Functor(std::forward<T>(f)));
 
         object_ptr_ = store_.get();
-
-        caller_ = functor_caller<Functor>;
     }
 
     //! constructor from any functor object T, which may be a lambda with

--- a/tlx/digest/md5.cpp
+++ b/tlx/digest/md5.cpp
@@ -189,8 +189,6 @@ static void md5_compress(std::uint32_t state[4], const std::uint8_t* buf)
 
 MD5::MD5()
 {
-    curlen_ = 0;
-    length_ = 0;
     state_[0] = 0x67452301UL;
     state_[1] = 0xefcdab89UL;
     state_[2] = 0x98badcfeUL;

--- a/tlx/digest/md5.hpp
+++ b/tlx/digest/md5.hpp
@@ -55,9 +55,9 @@ public:
     std::string digest_hex_uc();
 
 private:
-    std::uint64_t length_;
+    std::uint64_t length_ = 0;
     std::uint32_t state_[4];
-    std::uint32_t curlen_;
+    std::uint32_t curlen_ = 0;
     std::uint8_t buf_[64];
 };
 

--- a/tlx/digest/sha1.cpp
+++ b/tlx/digest/sha1.cpp
@@ -139,8 +139,6 @@ static void sha1_compress(std::uint32_t state[4], const std::uint8_t* buf)
 
 SHA1::SHA1()
 {
-    curlen_ = 0;
-    length_ = 0;
     state_[0] = 0x67452301UL;
     state_[1] = 0xefcdab89UL;
     state_[2] = 0x98badcfeUL;

--- a/tlx/digest/sha1.hpp
+++ b/tlx/digest/sha1.hpp
@@ -55,9 +55,9 @@ public:
     std::string digest_hex_uc();
 
 private:
-    std::uint64_t length_;
+    std::uint64_t length_ = 0;
     std::uint32_t state_[5];
-    std::uint32_t curlen_;
+    std::uint32_t curlen_ = 0;
     std::uint8_t buf_[64];
 };
 

--- a/tlx/digest/sha256.cpp
+++ b/tlx/digest/sha256.cpp
@@ -149,8 +149,6 @@ void sha256_compress(std::uint32_t state[8], const std::uint8_t* buf)
 
 SHA256::SHA256()
 {
-    curlen_ = 0;
-    length_ = 0;
     state_[0] = 0x6A09E667UL;
     state_[1] = 0xBB67AE85UL;
     state_[2] = 0x3C6EF372UL;

--- a/tlx/digest/sha256.hpp
+++ b/tlx/digest/sha256.hpp
@@ -55,9 +55,9 @@ public:
     std::string digest_hex_uc();
 
 private:
-    std::uint64_t length_;
+    std::uint64_t length_ = 0;
     std::uint32_t state_[8];
-    std::uint32_t curlen_;
+    std::uint32_t curlen_ = 0;
     std::uint8_t buf_[64];
 };
 

--- a/tlx/digest/sha512.cpp
+++ b/tlx/digest/sha512.cpp
@@ -162,8 +162,6 @@ static void sha512_compress(std::uint64_t state[8], const std::uint8_t* buf)
 
 SHA512::SHA512()
 {
-    curlen_ = 0;
-    length_ = 0;
     state_[0] = 0x6a09e667f3bcc908ULL;
     state_[1] = 0xbb67ae8584caa73bULL;
     state_[2] = 0x3c6ef372fe94f82bULL;

--- a/tlx/digest/sha512.hpp
+++ b/tlx/digest/sha512.hpp
@@ -55,9 +55,9 @@ public:
     std::string digest_hex_uc();
 
 private:
-    std::uint64_t length_;
+    std::uint64_t length_ = 0;
     std::uint64_t state_[8];
-    std::uint32_t curlen_;
+    std::uint32_t curlen_ = 0;
     std::uint8_t buf_[128];
 };
 

--- a/tlx/logger/core.cpp
+++ b/tlx/logger/core.cpp
@@ -126,6 +126,7 @@ LoggerOutputHook::~LoggerOutputHook()
 
 LoggerCollectOutput::LoggerCollectOutput(bool echo) : echo_(echo)
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
     next_ = set_logger_output_hook(this);
 }
 

--- a/tlx/logger/core.hpp
+++ b/tlx/logger/core.hpp
@@ -223,7 +223,7 @@ public:
     //! method the receive log lines
     void append_log_line(const std::string& line) final;
 
-protected:
+private:
     //! previous logger, will be restored by destructor
     LoggerOutputHook* next_;
 

--- a/tlx/math/polynomial_regression.hpp
+++ b/tlx/math/polynomial_regression.hpp
@@ -35,7 +35,7 @@ class PolynomialRegression
 public:
     //! start new polynomial regression calculation
     PolynomialRegression(size_t order)
-        : order_(order), size_(0), X_(2 * order + 1, 0), Y_(order + 1, 0)
+        : order_(order), X_(2 * order + 1, 0), Y_(order + 1, 0)
     {
     }
 
@@ -152,7 +152,7 @@ protected:
     std::vector<Point> points_;
 
     //! number of points added
-    size_t size_;
+    size_t size_ = 0;
 
     //! X_ = vector that stores values of sigma(x_i^2n)
     std::vector<Type> X_;

--- a/tlx/math/polynomial_regression.hpp
+++ b/tlx/math/polynomial_regression.hpp
@@ -144,7 +144,7 @@ public:
         return coefficients_;
     }
 
-protected:
+private:
     //! polynomial order
     size_t order_;
 

--- a/tlx/meta/no_operation.hpp
+++ b/tlx/meta/no_operation.hpp
@@ -32,7 +32,7 @@ public:
         return return_value_;
     }
 
-protected:
+private:
     ReturnType return_value_;
 };
 

--- a/tlx/multi_timer.cpp
+++ b/tlx/multi_timer.cpp
@@ -40,9 +40,7 @@ struct MultiTimer::Entry
 // MultiTimer
 
 MultiTimer::MultiTimer()
-    : total_duration_(std::chrono::duration<double>::zero()),
-      running_(nullptr),
-      running_hash_(0)
+    : total_duration_(std::chrono::duration<double>::zero())
 {
 }
 

--- a/tlx/multi_timer.hpp
+++ b/tlx/multi_timer.hpp
@@ -114,7 +114,7 @@ public:
     //! change back timer to previous timer.
     ~ScopedMultiTimerSwitch();
 
-protected:
+private:
     //! reference to MultiTimer
     MultiTimer& timer_;
 
@@ -133,7 +133,7 @@ public:
     //! change back timer to previous timer.
     ~ScopedMultiTimer();
 
-protected:
+private:
     //! reference to base timer
     MultiTimer& base_;
 

--- a/tlx/multi_timer.hpp
+++ b/tlx/multi_timer.hpp
@@ -93,9 +93,9 @@ private:
     std::chrono::duration<double> total_duration_;
 
     //! currently running timer name
-    const char* running_;
+    const char* running_ = nullptr;
     //! hash of running_
-    std::uint32_t running_hash_;
+    std::uint32_t running_hash_ = 0;
     //! start of currently running timer name
     std::chrono::time_point<std::chrono::high_resolution_clock> time_point_;
 

--- a/tlx/sort/networks/cswap.hpp
+++ b/tlx/sort/networks/cswap.hpp
@@ -43,7 +43,7 @@ public:
             std::swap(left, right);
     }
 
-protected:
+private:
     Comparator cmp_;
 };
 

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -182,7 +182,7 @@ protected:
     {
     }
 
-    virtual ~PS5SortStep()
+    ~PS5SortStep()
     {
         assert(substep_working_ == 0);
     }
@@ -324,7 +324,7 @@ public:
             << " flip=" << strptr_.flipped();
     }
 
-    ~PS5SmallsortJob()
+    virtual ~PS5SmallsortJob()
     {
         mtimer_.stop();
         ctx_.mtimer.add(mtimer_);

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -1231,6 +1231,7 @@ public:
         : ctx_(ctx), pstep_(pstep), strptr_(strptr), depth_(depth)
     {
         // calculate number of parts
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         parts_ = strptr_.size() / ctx.sequential_threshold() * 2;
         if (parts_ == 0)
             parts_ = 1;

--- a/tlx/sort/strings/parallel_sample_sort.hpp
+++ b/tlx/sort/strings/parallel_sample_sort.hpp
@@ -367,7 +367,7 @@ public:
     {
     public:
         StringPtr strptr_;
-        size_t idx_;
+        size_t idx_ = 0;
         size_t depth_;
 
         using StringSet = typename StringPtr::StringSet;
@@ -383,7 +383,7 @@ public:
 
         SeqSampleSortStep(Context& ctx, const StringPtr& strptr, size_t depth,
                           std::uint16_t* bktcache)
-            : strptr_(strptr), idx_(0), depth_(depth)
+            : strptr_(strptr), depth_(depth)
         {
             size_t n = strptr_.size();
 
@@ -811,14 +811,14 @@ public:
         StringPtr strptr_;
         key_type* cache_;
         size_t num_lt_, num_eq_, num_gt_, depth_;
-        size_t idx_;
+        size_t idx_ = 0;
         unsigned char eq_recurse_;
         // typename StringPtr::StringSet::Char dchar_eq_, dchar_gt_;
         std::uint8_t lcp_lt_, lcp_eq_, lcp_gt_;
 
         MKQSStep(Context& ctx, const StringPtr& strptr, key_type* cache,
                  size_t depth, bool CacheDirty)
-            : strptr_(strptr), cache_(cache), depth_(depth), idx_(0)
+            : strptr_(strptr), cache_(cache), depth_(depth)
         {
             size_t n = strptr_.size();
 

--- a/tlx/sort/strings/string_ptr.hpp
+++ b/tlx/sort/strings/string_ptr.hpp
@@ -49,7 +49,7 @@ public:
     typedef StringSet_ StringSet;
     typedef typename StringSet::String String;
 
-protected:
+private:
     //! strings (front) array
     StringSet active_;
 
@@ -112,7 +112,7 @@ public:
     typedef LcpType_ LcpType;
     typedef typename StringSet::String String;
 
-protected:
+private:
     //! strings (front) array
     StringSet active_;
 
@@ -195,7 +195,7 @@ public:
     typedef typename StringSet::String String;
     typedef typename StringSet::Iterator Iterator;
 
-protected:
+private:
     //! strings (front) and temporary shadow (back) array
     StringSet active_, shadow_;
 
@@ -294,7 +294,7 @@ public:
     typedef typename StringSet::String String;
     typedef typename StringSet::Iterator Iterator;
 
-protected:
+private:
     //! strings (front) and temporary shadow (back) array
     StringSet active_, shadow_;
 

--- a/tlx/sort/strings/string_set.hpp
+++ b/tlx/sort/strings/string_set.hpp
@@ -415,7 +415,7 @@ public:
         c.first = nullptr;
     }
 
-protected:
+private:
     //! array of string pointers
     Iterator begin_, end_;
 };
@@ -530,7 +530,7 @@ public:
         c.first = nullptr;
     }
 
-protected:
+private:
     //! pointers to std::string objects
     Iterator begin_, end_;
 };
@@ -652,7 +652,7 @@ public:
         }
     }
 
-protected:
+private:
     //! vector of std::string objects
     Iterator begin_, end_;
 };
@@ -779,7 +779,7 @@ public:
     {
     }
 
-protected:
+private:
     //! reference to base text
     const Text* text_;
 

--- a/tlx/thread_barrier_mutex.hpp
+++ b/tlx/thread_barrier_mutex.hpp
@@ -85,7 +85,7 @@ public:
         return step_;
     }
 
-protected:
+private:
     //! number of threads
     const size_t thread_count_;
 

--- a/tlx/thread_barrier_spin.hpp
+++ b/tlx/thread_barrier_spin.hpp
@@ -109,7 +109,7 @@ public:
         return step_.load(std::memory_order_acquire);
     }
 
-protected:
+private:
     //! number of threads, minus one due to comparison needed in loop
     const size_t thread_count_;
 


### PR DESCRIPTION
This PR enables `cppcoreguidelines-*` checks:
  - `cppcoreguidelines-prefer-member-initializer`
  - `cppcoreguidelines-use-default-member-init`
  - `cppcoreguidelines-virtual-class-destructor`
  - `cppcoreguidelines-non-private-member-variables-in-classes`