### PR TITLE
string: use `tlx::string_view` instead of `const std::string&`

### DIFF
--- a/tests/algorithm/multiway_merge_benchmark.cpp
+++ b/tests/algorithm/multiway_merge_benchmark.cpp
@@ -4,7 +4,7 @@
  * Part of tlx - http://panthema.net/tlx
  *
  * Copyright (C) 2014 Thomas Keh <thomas.keh@student.kit.edu>
- * Copyright (C) 2014-2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2014-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -13,6 +13,7 @@
 #include <tlx/algorithm/multiway_merge_splitting.hpp>
 #include <tlx/algorithm/parallel_multiway_merge.hpp>
 #include <tlx/cmdline_parser.hpp>
+#include <tlx/container/string_view.hpp>
 #include <tlx/die.hpp>
 #include <tlx/logger.hpp>
 #include <tlx/string/format_iec_units.hpp>
@@ -103,7 +104,7 @@ private:
 
 public:
     //! save message and start timer
-    explicit scoped_print_timer(const std::string& message,
+    explicit scoped_print_timer(tlx::string_view message,
                                 const std::uint64_t bytes = 0)
         : message_(message), bytes_(bytes), ts_(tlx::timestamp())
     {

--- a/tests/sort_strings_example.cpp
+++ b/tests/sort_strings_example.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <vector>
 
 int main(int argc, char* argv[])

--- a/tests/sort_strings_parallel_test.cpp
+++ b/tests/sort_strings_parallel_test.cpp
@@ -11,6 +11,7 @@
  ******************************************************************************/
 
 #include <tlx/container/simple_vector.hpp>
+#include <tlx/container/string_view.hpp>
 #include <tlx/logger.hpp>
 #include <tlx/sort/strings/parallel_sample_sort.hpp>
 #include <tlx/sort/strings/sample_sort_tools.hpp>
@@ -21,7 +22,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <random>
-#include <string>
 #include "sort_strings_test.hpp"
 
 /******************************************************************************/
@@ -49,7 +49,7 @@ void parallel_sample_sort_unroll_interleave(const StringPtr& strptr,
 /******************************************************************************/
 
 void TestFrontend(const size_t num_strings, const size_t num_chars,
-                  const std::string& letters)
+                  tlx::string_view letters)
 {
     std::default_random_engine rng(seed);
 

--- a/tests/sort_strings_test.cpp
+++ b/tests/sort_strings_test.cpp
@@ -5,13 +5,14 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2015-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2015-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
 #include "sort_strings_test.hpp"
 #include <tlx/container/simple_vector.hpp>
+#include <tlx/container/string_view.hpp>
 #include <tlx/logger.hpp>
 #include <tlx/sort/strings.hpp>
 #include <tlx/sort/strings/insertion_sort.hpp>
@@ -23,10 +24,9 @@
 #include <cstdint>
 #include <cstdlib>
 #include <random>
-#include <string>
 
 void TestFrontend(const size_t num_strings, const size_t num_chars,
-                  const std::string& letters)
+                  tlx::string_view letters)
 {
     std::default_random_engine rng(seed);
 

--- a/tests/sort_strings_test.hpp
+++ b/tests/sort_strings_test.hpp
@@ -5,7 +5,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2015-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2015-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -14,6 +14,7 @@
 #define TLX_TESTS_SORT_STRINGS_TEST_HEADER
 
 #include <tlx/container/simple_vector.hpp>
+#include <tlx/container/string_view.hpp>
 #include <tlx/logger.hpp>
 #include <tlx/sort/strings/string_ptr.hpp>
 #include <tlx/sort/strings/string_set.hpp>
@@ -44,7 +45,7 @@ using StringLcpSorter = void (*)(const StringLcpPtr<StringSet, LcpType>&,
                                  size_t, size_t);
 
 template <typename Random, typename Iterator>
-void fill_random(Random& rng, const std::string& letters, Iterator begin,
+void fill_random(Random& rng, tlx::string_view letters, Iterator begin,
                  Iterator end)
 {
     for (Iterator i = begin; i != end; ++i)
@@ -52,7 +53,7 @@ void fill_random(Random& rng, const std::string& letters, Iterator begin,
 }
 
 template <typename Random, typename Iterator>
-void fill_random_lognormal(Random& rng, const std::string& letters,
+void fill_random_lognormal(Random& rng, tlx::string_view letters,
                            Iterator begin, Iterator end)
 {
     std::lognormal_distribution<double> lognorm(0.0, 1.0);
@@ -99,7 +100,7 @@ static inline bool check_lcp(const StringSet& ss, LcpType* lcp)
 template <typename StringSet, StringSorter<StringSet> sorter, typename LcpType,
           StringLcpSorter<StringSet, LcpType> lcp_sorter>
 void TestUCharString(const char* name, const size_t num_strings,
-                     const size_t num_chars, const std::string& letters,
+                     const size_t num_chars, tlx::string_view letters,
                      bool with_lcp)
 {
     std::default_random_engine rng(seed);
@@ -177,7 +178,7 @@ void TestUCharString(const char* name, const size_t num_strings,
 template <typename StringSet, StringSorter<StringSet> sorter, typename LcpType,
           StringLcpSorter<StringSet, LcpType> lcp_sorter>
 void TestVectorStdString(const char* name, const size_t num_strings,
-                         const size_t num_chars, const std::string& letters,
+                         const size_t num_chars, tlx::string_view letters,
                          bool with_lcp)
 {
     std::default_random_engine rng(seed);
@@ -255,7 +256,7 @@ void TestVectorStdString(const char* name, const size_t num_strings,
 template <typename StringSet, StringSorter<StringSet> sorter, typename LcpType,
           StringLcpSorter<StringSet, LcpType> lcp_sorter>
 void TestUPtrStdString(const char* name, const size_t num_strings,
-                       const size_t num_chars, const std::string& letters,
+                       const size_t num_chars, tlx::string_view letters,
                        bool with_lcp)
 {
     std::default_random_engine rng(seed);
@@ -330,7 +331,7 @@ void TestUPtrStdString(const char* name, const size_t num_strings,
 
 template <typename StringSet, StringSorter<StringSet> sorter>
 void TestStringSuffixString(const char* name, const size_t num_chars,
-                            const std::string& letters)
+                            tlx::string_view letters)
 {
     std::default_random_engine rng(seed);
 

--- a/tlx/cmdline_parser.cpp
+++ b/tlx/cmdline_parser.cpp
@@ -3,12 +3,13 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2013-2015 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2013-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
 #include <tlx/cmdline_parser.hpp>
+#include <tlx/container/string_view.hpp>
 #include <tlx/define/visibility_hidden.hpp>
 #include <tlx/string/parse_si_iec_units.hpp>
 #include <tlx/unused.hpp>
@@ -48,8 +49,8 @@ public:
 
 public:
     //! contructor filling most attributes
-    Argument(char key, const std::string& longkey, const std::string& keytype,
-             const std::string& desc, bool required)
+    Argument(char key, tlx::string_view longkey, tlx::string_view keytype,
+             tlx::string_view desc, bool required)
         : key_(key),
           longkey_(longkey),
           keytype_(keytype),
@@ -103,9 +104,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentBool(char key, const std::string& longkey,
-                 const std::string& keytype, const std::string& desc,
-                 bool required, bool& dest)
+    ArgumentBool(char key, tlx::string_view longkey, tlx::string_view keytype,
+                 tlx::string_view desc, bool required, bool& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
     }
@@ -137,9 +137,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentInt(char key, const std::string& longkey,
-                const std::string& keytype, const std::string& desc,
-                bool required, int& dest)
+    ArgumentInt(char key, tlx::string_view longkey, tlx::string_view keytype,
+                tlx::string_view desc, bool required, int& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
     }
@@ -181,8 +180,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentUnsigned(char key, const std::string& longkey,
-                     const std::string& keytype, const std::string& desc,
+    ArgumentUnsigned(char key, tlx::string_view longkey,
+                     tlx::string_view keytype, tlx::string_view desc,
                      bool required, unsigned int& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
@@ -224,9 +223,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentSizeT(char key, const std::string& longkey,
-                  const std::string& keytype, const std::string& desc,
-                  bool required, size_t& dest)
+    ArgumentSizeT(char key, tlx::string_view longkey, tlx::string_view keytype,
+                  tlx::string_view desc, bool required, size_t& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
     }
@@ -267,9 +265,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentFloat(char key, const std::string& longkey,
-                  const std::string& keytype, const std::string& desc,
-                  bool required, float& dest)
+    ArgumentFloat(char key, tlx::string_view longkey, tlx::string_view keytype,
+                  tlx::string_view desc, bool required, float& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
     }
@@ -309,9 +306,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentDouble(char key, const std::string& longkey,
-                   const std::string& keytype, const std::string& desc,
-                   bool required, double& dest)
+    ArgumentDouble(char key, tlx::string_view longkey, tlx::string_view keytype,
+                   tlx::string_view desc, bool required, double& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
     }
@@ -352,8 +348,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentBytes32(char key, const std::string& longkey,
-                    const std::string& keytype, const std::string& desc,
+    ArgumentBytes32(char key, tlx::string_view longkey,
+                    tlx::string_view keytype, tlx::string_view desc,
                     bool required, std::uint32_t& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
@@ -396,8 +392,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentBytes64(char key, const std::string& longkey,
-                    const std::string& keytype, const std::string& desc,
+    ArgumentBytes64(char key, tlx::string_view longkey,
+                    tlx::string_view keytype, tlx::string_view desc,
                     bool required, std::uint64_t& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
@@ -436,9 +432,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentString(char key, const std::string& longkey,
-                   const std::string& keytype, const std::string& desc,
-                   bool required, std::string& dest)
+    ArgumentString(char key, tlx::string_view longkey, tlx::string_view keytype,
+                   tlx::string_view desc, bool required, std::string& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
     }
@@ -473,8 +468,8 @@ private:
 
 public:
     //! contructor filling most attributes
-    ArgumentStringlist(char key, const std::string& longkey,
-                       const std::string& keytype, const std::string& desc,
+    ArgumentStringlist(char key, tlx::string_view longkey,
+                       tlx::string_view keytype, tlx::string_view desc,
                        bool required, std::vector<std::string>& dest)
         : Argument(key, longkey, keytype, desc, required), dest_(dest)
     {
@@ -524,7 +519,7 @@ void CmdlineParser::calc_param_max(const Argument* arg)
 
 /******************************************************************************/
 
-void CmdlineParser::output_wrap(std::ostream& os, const std::string& text,
+void CmdlineParser::output_wrap(std::ostream& os, tlx::string_view text,
                                 size_t wraplen, size_t indent_first,
                                 size_t indent_rest, size_t current,
                                 size_t indent_newline)
@@ -583,14 +578,14 @@ CmdlineParser::~CmdlineParser()
     param_list_.clear();
 }
 
-void CmdlineParser::set_description(const std::string& description)
+void CmdlineParser::set_description(tlx::string_view description)
 {
-    description_ = description;
+    description_.assign(description.data(), description.size());
 }
 
-void CmdlineParser::set_author(const std::string& author)
+void CmdlineParser::set_author(tlx::string_view author)
 {
-    author_ = author;
+    author_.assign(author.data(), author.size());
 }
 
 void CmdlineParser::set_verbose_process(bool verbose_process)
@@ -600,105 +595,105 @@ void CmdlineParser::set_verbose_process(bool verbose_process)
 
 /******************************************************************************/
 
-void CmdlineParser::add_bool(char key, const std::string& longkey,
-                             const std::string& keytype, bool& dest,
-                             const std::string& desc)
+void CmdlineParser::add_bool(char key, tlx::string_view longkey,
+                             tlx::string_view keytype, bool& dest,
+                             tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentBool(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_flag(char key, const std::string& longkey,
-                             const std::string& keytype, bool& dest,
-                             const std::string& desc)
+void CmdlineParser::add_flag(char key, tlx::string_view longkey,
+                             tlx::string_view keytype, bool& dest,
+                             tlx::string_view desc)
 {
     return add_bool(key, longkey, keytype, dest, desc);
 }
 
-void CmdlineParser::add_int(char key, const std::string& longkey,
-                            const std::string& keytype, int& dest,
-                            const std::string& desc)
+void CmdlineParser::add_int(char key, tlx::string_view longkey,
+                            tlx::string_view keytype, int& dest,
+                            tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentInt(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_unsigned(char key, const std::string& longkey,
-                                 const std::string& keytype, unsigned int& dest,
-                                 const std::string& desc)
+void CmdlineParser::add_unsigned(char key, tlx::string_view longkey,
+                                 tlx::string_view keytype, unsigned int& dest,
+                                 tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentUnsigned(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_uint(char key, const std::string& longkey,
-                             const std::string& keytype, unsigned int& dest,
-                             const std::string& desc)
+void CmdlineParser::add_uint(char key, tlx::string_view longkey,
+                             tlx::string_view keytype, unsigned int& dest,
+                             tlx::string_view desc)
 {
     return add_unsigned(key, longkey, keytype, dest, desc);
 }
 
-void CmdlineParser::add_size_t(char key, const std::string& longkey,
-                               const std::string& keytype, size_t& dest,
-                               const std::string& desc)
+void CmdlineParser::add_size_t(char key, tlx::string_view longkey,
+                               tlx::string_view keytype, size_t& dest,
+                               tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentSizeT(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_float(char key, const std::string& longkey,
-                              const std::string& keytype, float& dest,
-                              const std::string& desc)
+void CmdlineParser::add_float(char key, tlx::string_view longkey,
+                              tlx::string_view keytype, float& dest,
+                              tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentFloat(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_double(char key, const std::string& longkey,
-                               const std::string& keytype, double& dest,
-                               const std::string& desc)
+void CmdlineParser::add_double(char key, tlx::string_view longkey,
+                               tlx::string_view keytype, double& dest,
+                               tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentDouble(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              const std::string& keytype, std::uint32_t& dest,
-                              const std::string& desc)
+void CmdlineParser::add_bytes(char key, tlx::string_view longkey,
+                              tlx::string_view keytype, std::uint32_t& dest,
+                              tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentBytes32(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              const std::string& keytype, std::uint64_t& dest,
-                              const std::string& desc)
+void CmdlineParser::add_bytes(char key, tlx::string_view longkey,
+                              tlx::string_view keytype, std::uint64_t& dest,
+                              tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentBytes64(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_string(char key, const std::string& longkey,
-                               const std::string& keytype, std::string& dest,
-                               const std::string& desc)
+void CmdlineParser::add_string(char key, tlx::string_view longkey,
+                               tlx::string_view keytype, std::string& dest,
+                               tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentString(key, longkey, keytype, desc, false, dest));
     calc_option_max(option_list_.back());
 }
 
-void CmdlineParser::add_stringlist(char key, const std::string& longkey,
-                                   const std::string& keytype,
+void CmdlineParser::add_stringlist(char key, tlx::string_view longkey,
+                                   tlx::string_view keytype,
                                    std::vector<std::string>& dest,
-                                   const std::string& desc)
+                                   tlx::string_view desc)
 {
     option_list_.emplace_back(
         new ArgumentStringlist(key, longkey, keytype, desc, false, dest));
@@ -707,227 +702,225 @@ void CmdlineParser::add_stringlist(char key, const std::string& longkey,
 
 /******************************************************************************/
 
-void CmdlineParser::add_bool(char key, const std::string& longkey, bool& dest,
-                             const std::string& desc)
+void CmdlineParser::add_bool(char key, tlx::string_view longkey, bool& dest,
+                             tlx::string_view desc)
 {
     return add_bool(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_flag(char key, const std::string& longkey, bool& dest,
-                             const std::string& desc)
+void CmdlineParser::add_flag(char key, tlx::string_view longkey, bool& dest,
+                             tlx::string_view desc)
 {
     return add_bool(key, longkey, dest, desc);
 }
 
-void CmdlineParser::add_int(char key, const std::string& longkey, int& dest,
-                            const std::string& desc)
+void CmdlineParser::add_int(char key, tlx::string_view longkey, int& dest,
+                            tlx::string_view desc)
 {
     return add_int(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_unsigned(char key, const std::string& longkey,
-                                 unsigned int& dest, const std::string& desc)
+void CmdlineParser::add_unsigned(char key, tlx::string_view longkey,
+                                 unsigned int& dest, tlx::string_view desc)
 {
     return add_unsigned(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_uint(char key, const std::string& longkey,
-                             unsigned int& dest, const std::string& desc)
+void CmdlineParser::add_uint(char key, tlx::string_view longkey,
+                             unsigned int& dest, tlx::string_view desc)
 {
     return add_unsigned(key, longkey, dest, desc);
 }
 
-void CmdlineParser::add_size_t(char key, const std::string& longkey,
-                               size_t& dest, const std::string& desc)
+void CmdlineParser::add_size_t(char key, tlx::string_view longkey, size_t& dest,
+                               tlx::string_view desc)
 {
     return add_size_t(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_float(char key, const std::string& longkey, float& dest,
-                              const std::string& desc)
+void CmdlineParser::add_float(char key, tlx::string_view longkey, float& dest,
+                              tlx::string_view desc)
 {
     return add_float(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_double(char key, const std::string& longkey,
-                               double& dest, const std::string& desc)
+void CmdlineParser::add_double(char key, tlx::string_view longkey, double& dest,
+                               tlx::string_view desc)
 {
     return add_double(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              std::uint32_t& dest, const std::string& desc)
+void CmdlineParser::add_bytes(char key, tlx::string_view longkey,
+                              std::uint32_t& dest, tlx::string_view desc)
 {
     return add_bytes(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_bytes(char key, const std::string& longkey,
-                              std::uint64_t& dest, const std::string& desc)
+void CmdlineParser::add_bytes(char key, tlx::string_view longkey,
+                              std::uint64_t& dest, tlx::string_view desc)
 {
     return add_bytes(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_string(char key, const std::string& longkey,
-                               std::string& dest, const std::string& desc)
+void CmdlineParser::add_string(char key, tlx::string_view longkey,
+                               std::string& dest, tlx::string_view desc)
 {
     return add_string(key, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_stringlist(char key, const std::string& longkey,
+void CmdlineParser::add_stringlist(char key, tlx::string_view longkey,
                                    std::vector<std::string>& dest,
-                                   const std::string& desc)
+                                   tlx::string_view desc)
 {
     return add_stringlist(key, longkey, "", dest, desc);
 }
 
 /******************************************************************************/
 
-void CmdlineParser::add_bool(const std::string& longkey, bool& dest,
-                             const std::string& desc)
+void CmdlineParser::add_bool(tlx::string_view longkey, bool& dest,
+                             tlx::string_view desc)
 {
     return add_bool(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_flag(const std::string& longkey, bool& dest,
-                             const std::string& desc)
+void CmdlineParser::add_flag(tlx::string_view longkey, bool& dest,
+                             tlx::string_view desc)
 {
     return add_bool(0, longkey, dest, desc);
 }
 
-void CmdlineParser::add_int(const std::string& longkey, int& dest,
-                            const std::string& desc)
+void CmdlineParser::add_int(tlx::string_view longkey, int& dest,
+                            tlx::string_view desc)
 {
     return add_int(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_unsigned(const std::string& longkey, unsigned int& dest,
-                                 const std::string& desc)
+void CmdlineParser::add_unsigned(tlx::string_view longkey, unsigned int& dest,
+                                 tlx::string_view desc)
 {
     return add_unsigned(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_uint(const std::string& longkey, unsigned int& dest,
-                             const std::string& desc)
+void CmdlineParser::add_uint(tlx::string_view longkey, unsigned int& dest,
+                             tlx::string_view desc)
 {
     return add_unsigned(0, longkey, dest, desc);
 }
 
-void CmdlineParser::add_size_t(const std::string& longkey, size_t& dest,
-                               const std::string& desc)
+void CmdlineParser::add_size_t(tlx::string_view longkey, size_t& dest,
+                               tlx::string_view desc)
 {
     return add_size_t(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_float(const std::string& longkey, float& dest,
-                              const std::string& desc)
+void CmdlineParser::add_float(tlx::string_view longkey, float& dest,
+                              tlx::string_view desc)
 {
     return add_float(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_double(const std::string& longkey, double& dest,
-                               const std::string& desc)
+void CmdlineParser::add_double(tlx::string_view longkey, double& dest,
+                               tlx::string_view desc)
 {
     return add_double(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_bytes(const std::string& longkey, std::uint32_t& dest,
-                              const std::string& desc)
+void CmdlineParser::add_bytes(tlx::string_view longkey, std::uint32_t& dest,
+                              tlx::string_view desc)
 {
     return add_bytes(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_bytes(const std::string& longkey, std::uint64_t& dest,
-                              const std::string& desc)
+void CmdlineParser::add_bytes(tlx::string_view longkey, std::uint64_t& dest,
+                              tlx::string_view desc)
 {
     return add_bytes(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_string(const std::string& longkey, std::string& dest,
-                               const std::string& desc)
+void CmdlineParser::add_string(tlx::string_view longkey, std::string& dest,
+                               tlx::string_view desc)
 {
     return add_string(0, longkey, "", dest, desc);
 }
 
-void CmdlineParser::add_stringlist(const std::string& longkey,
+void CmdlineParser::add_stringlist(tlx::string_view longkey,
                                    std::vector<std::string>& dest,
-                                   const std::string& desc)
+                                   tlx::string_view desc)
 {
     return add_stringlist(0, longkey, "", dest, desc);
 }
 
 /******************************************************************************/
 
-void CmdlineParser::add_param_int(const std::string& name, int& dest,
-                                  const std::string& desc)
+void CmdlineParser::add_param_int(tlx::string_view name, int& dest,
+                                  tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentInt(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_unsigned(const std::string& name,
+void CmdlineParser::add_param_unsigned(tlx::string_view name,
                                        unsigned int& dest,
-                                       const std::string& desc)
+                                       tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentUnsigned(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_uint(const std::string& name, unsigned int& dest,
-                                   const std::string& desc)
+void CmdlineParser::add_param_uint(tlx::string_view name, unsigned int& dest,
+                                   tlx::string_view desc)
 {
     add_param_unsigned(name, dest, desc);
 }
 
-void CmdlineParser::add_param_size_t(const std::string& name, size_t& dest,
-                                     const std::string& desc)
+void CmdlineParser::add_param_size_t(tlx::string_view name, size_t& dest,
+                                     tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentSizeT(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_float(const std::string& name, float& dest,
-                                    const std::string& desc)
+void CmdlineParser::add_param_float(tlx::string_view name, float& dest,
+                                    tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentFloat(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_double(const std::string& name, double& dest,
-                                     const std::string& desc)
+void CmdlineParser::add_param_double(tlx::string_view name, double& dest,
+                                     tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentDouble(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_bytes(const std::string& name,
-                                    std::uint32_t& dest,
-                                    const std::string& desc)
+void CmdlineParser::add_param_bytes(tlx::string_view name, std::uint32_t& dest,
+                                    tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentBytes32(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_bytes(const std::string& name,
-                                    std::uint64_t& dest,
-                                    const std::string& desc)
+void CmdlineParser::add_param_bytes(tlx::string_view name, std::uint64_t& dest,
+                                    tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentBytes64(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_string(const std::string& name, std::string& dest,
-                                     const std::string& desc)
+void CmdlineParser::add_param_string(tlx::string_view name, std::string& dest,
+                                     tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentString(0, name, "", desc, true, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_param_stringlist(const std::string& name,
+void CmdlineParser::add_param_stringlist(tlx::string_view name,
                                          std::vector<std::string>& dest,
-                                         const std::string& desc)
+                                         tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentStringlist(0, name, "", desc, true, dest));
@@ -936,81 +929,81 @@ void CmdlineParser::add_param_stringlist(const std::string& name,
 
 /******************************************************************************/
 
-void CmdlineParser::add_opt_param_int(const std::string& name, int& dest,
-                                      const std::string& desc)
+void CmdlineParser::add_opt_param_int(tlx::string_view name, int& dest,
+                                      tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentInt(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_unsigned(const std::string& name,
+void CmdlineParser::add_opt_param_unsigned(tlx::string_view name,
                                            unsigned int& dest,
-                                           const std::string& desc)
+                                           tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentUnsigned(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_uint(const std::string& name,
+void CmdlineParser::add_opt_param_uint(tlx::string_view name,
                                        unsigned int& dest,
-                                       const std::string& desc)
+                                       tlx::string_view desc)
 {
     return add_opt_param_unsigned(name, dest, desc);
 }
 
-void CmdlineParser::add_opt_param_size_t(const std::string& name, size_t& dest,
-                                         const std::string& desc)
+void CmdlineParser::add_opt_param_size_t(tlx::string_view name, size_t& dest,
+                                         tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentSizeT(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_float(const std::string& name, float& dest,
-                                        const std::string& desc)
+void CmdlineParser::add_opt_param_float(tlx::string_view name, float& dest,
+                                        tlx::string_view desc)
 {
     param_list_.emplace_back(new ArgumentFloat(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_double(const std::string& name, double& dest,
-                                         const std::string& desc)
+void CmdlineParser::add_opt_param_double(tlx::string_view name, double& dest,
+                                         tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentDouble(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_bytes(const std::string& name,
+void CmdlineParser::add_opt_param_bytes(tlx::string_view name,
                                         std::uint32_t& dest,
-                                        const std::string& desc)
+                                        tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentBytes32(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_bytes(const std::string& name,
+void CmdlineParser::add_opt_param_bytes(tlx::string_view name,
                                         std::uint64_t& dest,
-                                        const std::string& desc)
+                                        tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentBytes64(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_string(const std::string& name,
+void CmdlineParser::add_opt_param_string(tlx::string_view name,
                                          std::string& dest,
-                                         const std::string& desc)
+                                         tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentString(0, name, "", desc, false, dest));
     calc_param_max(param_list_.back());
 }
 
-void CmdlineParser::add_opt_param_stringlist(const std::string& name,
+void CmdlineParser::add_opt_param_stringlist(tlx::string_view name,
                                              std::vector<std::string>& dest,
-                                             const std::string& desc)
+                                             tlx::string_view desc)
 {
     param_list_.emplace_back(
         new ArgumentStringlist(0, name, "", desc, false, dest));

--- a/tlx/cmdline_parser.hpp
+++ b/tlx/cmdline_parser.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2013-2015 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2013-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_CMDLINE_PARSER_HEADER
 #define TLX_CMDLINE_PARSER_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>
@@ -134,7 +135,7 @@ public:
     //! Wrap a long string at spaces into lines. Prefix is added
     //! unconditionally to each line. Lines are wrapped after wraplen
     //! characters if possible.
-    static void output_wrap(std::ostream& os, const std::string& text,
+    static void output_wrap(std::ostream& os, tlx::string_view text,
                             size_t wraplen, size_t indent_first = 0,
                             size_t indent_rest = 0, size_t current = 0,
                             size_t indent_newline = 0);
@@ -147,10 +148,10 @@ public:
     ~CmdlineParser();
 
     //! Set description of program, text will be wrapped
-    void set_description(const std::string& description);
+    void set_description(tlx::string_view description);
 
     //! Set author of program, will be wrapped.
-    void set_author(const std::string& author);
+    void set_author(tlx::string_view author);
 
     //! Set verbose processing of command line arguments
     void set_verbose_process(bool verbose_process);
@@ -162,59 +163,58 @@ public:
 
     //! add boolean option flag -key, --longkey with description and store to
     //! dest
-    void add_bool(char key, const std::string& longkey, bool& dest,
-                  const std::string& desc);
+    void add_bool(char key, tlx::string_view longkey, bool& dest,
+                  tlx::string_view desc);
 
     //! add boolean option flag -key, --longkey with description and store to
     //! dest. identical to add_bool()
-    void add_flag(char key, const std::string& longkey, bool& dest,
-                  const std::string& desc);
+    void add_flag(char key, tlx::string_view longkey, bool& dest,
+                  tlx::string_view desc);
 
     //! add signed integer option -key, --longkey with description and store to
     //! dest
-    void add_int(char key, const std::string& longkey, int& dest,
-                 const std::string& desc);
+    void add_int(char key, tlx::string_view longkey, int& dest,
+                 tlx::string_view desc);
 
     //! add unsigned integer option -key, --longkey with description and store
     //! to dest
-    void add_unsigned(char key, const std::string& longkey, unsigned int& dest,
-                      const std::string& desc);
+    void add_unsigned(char key, tlx::string_view longkey, unsigned int& dest,
+                      tlx::string_view desc);
 
     //! add unsigned integer option -key, --longkey with description and store
     //! to dest. identical to add_unsigned()
-    void add_uint(char key, const std::string& longkey, unsigned int& dest,
-                  const std::string& desc);
+    void add_uint(char key, tlx::string_view longkey, unsigned int& dest,
+                  tlx::string_view desc);
 
     //! add size_t option -key, --longkey with description and store to dest
-    void add_size_t(char key, const std::string& longkey, size_t& dest,
-                    const std::string& desc);
+    void add_size_t(char key, tlx::string_view longkey, size_t& dest,
+                    tlx::string_view desc);
 
     //! add float option -key, --longkey with description and store to dest
-    void add_float(char key, const std::string& longkey, float& dest,
-                   const std::string& desc);
+    void add_float(char key, tlx::string_view longkey, float& dest,
+                   tlx::string_view desc);
 
     //! add double option -key, --longkey with description and store to dest
-    void add_double(char key, const std::string& longkey, double& dest,
-                    const std::string& desc);
+    void add_double(char key, tlx::string_view longkey, double& dest,
+                    tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size option -key, --longkey and store to 32-bit
     //! dest
-    void add_bytes(char key, const std::string& longkey, std::uint32_t& dest,
-                   const std::string& desc);
+    void add_bytes(char key, tlx::string_view longkey, std::uint32_t& dest,
+                   tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size option -key, --longkey and store to 64-bit
     //! dest
-    void add_bytes(char key, const std::string& longkey, std::uint64_t& dest,
-                   const std::string& desc);
+    void add_bytes(char key, tlx::string_view longkey, std::uint64_t& dest,
+                   tlx::string_view desc);
 
     //! add string option -key, --longkey and store to dest
-    void add_string(char key, const std::string& longkey, std::string& dest,
-                    const std::string& desc);
+    void add_string(char key, tlx::string_view longkey, std::string& dest,
+                    tlx::string_view desc);
 
     //! add string list option -key, --longkey and store to dest
-    void add_stringlist(char key, const std::string& longkey,
-                        std::vector<std::string>& dest,
-                        const std::string& desc);
+    void add_stringlist(char key, tlx::string_view longkey,
+                        std::vector<std::string>& dest, tlx::string_view desc);
 
     //! \}
 
@@ -224,55 +224,51 @@ public:
     //! \{
 
     //! add boolean option flag --longkey with description and store to dest
-    void add_bool(const std::string& longkey, bool& dest,
-                  const std::string& desc);
+    void add_bool(tlx::string_view longkey, bool& dest, tlx::string_view desc);
 
     //! add boolean option flag --longkey with description and store to
     //! dest. identical to add_bool()
-    void add_flag(const std::string& longkey, bool& dest,
-                  const std::string& desc);
+    void add_flag(tlx::string_view longkey, bool& dest, tlx::string_view desc);
 
     //! add signed integer option --longkey with description and store to dest
-    void add_int(const std::string& longkey, int& dest,
-                 const std::string& desc);
+    void add_int(tlx::string_view longkey, int& dest, tlx::string_view desc);
 
     //! add unsigned integer option --longkey with description and store to dest
-    void add_unsigned(const std::string& longkey, unsigned int& dest,
-                      const std::string& desc);
+    void add_unsigned(tlx::string_view longkey, unsigned int& dest,
+                      tlx::string_view desc);
 
     //! add unsigned integer option --longkey with description and store to
     //! dest. identical to add_unsigned()
-    void add_uint(const std::string& longkey, unsigned int& dest,
-                  const std::string& desc);
+    void add_uint(tlx::string_view longkey, unsigned int& dest,
+                  tlx::string_view desc);
 
     //! add size_t option --longkey with description and store to dest
-    void add_size_t(const std::string& longkey, size_t& dest,
-                    const std::string& desc);
+    void add_size_t(tlx::string_view longkey, size_t& dest,
+                    tlx::string_view desc);
 
     //! add float option --longkey with description and store to dest
-    void add_float(const std::string& longkey, float& dest,
-                   const std::string& desc);
+    void add_float(tlx::string_view longkey, float& dest,
+                   tlx::string_view desc);
 
     //! add double option --longkey with description and store to dest
-    void add_double(const std::string& longkey, double& dest,
-                    const std::string& desc);
+    void add_double(tlx::string_view longkey, double& dest,
+                    tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size option --longkey and store to 32-bit dest
-    void add_bytes(const std::string& longkey, std::uint32_t& dest,
-                   const std::string& desc);
+    void add_bytes(tlx::string_view longkey, std::uint32_t& dest,
+                   tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size option --longkey and store to 64-bit dest
-    void add_bytes(const std::string& longkey, std::uint64_t& dest,
-                   const std::string& desc);
+    void add_bytes(tlx::string_view longkey, std::uint64_t& dest,
+                   tlx::string_view desc);
 
     //! add string option --longkey and store to dest
-    void add_string(const std::string& longkey, std::string& dest,
-                    const std::string& desc);
+    void add_string(tlx::string_view longkey, std::string& dest,
+                    tlx::string_view desc);
 
     //! add string list option --longkey and store to dest
-    void add_stringlist(const std::string& longkey,
-                        std::vector<std::string>& dest,
-                        const std::string& desc);
+    void add_stringlist(tlx::string_view longkey,
+                        std::vector<std::string>& dest, tlx::string_view desc);
 
     //! \}
 
@@ -283,74 +279,66 @@ public:
 
     //! add boolean option flag -key, --longkey [keytype] with description and
     //! store to dest
-    void add_bool(char key, const std::string& longkey,
-                  const std::string& keytype, bool& dest,
-                  const std::string& desc);
+    void add_bool(char key, tlx::string_view longkey, tlx::string_view keytype,
+                  bool& dest, tlx::string_view desc);
 
     //! add boolean option flag -key, --longkey [keytype] with description and
     //! store to dest. identical to add_bool()
-    void add_flag(char key, const std::string& longkey,
-                  const std::string& keytype, bool& dest,
-                  const std::string& desc);
+    void add_flag(char key, tlx::string_view longkey, tlx::string_view keytype,
+                  bool& dest, tlx::string_view desc);
 
     //! add signed integer option -key, --longkey [keytype] with description
     //! and store to dest
-    void add_int(char key, const std::string& longkey,
-                 const std::string& keytype, int& dest,
-                 const std::string& desc);
+    void add_int(char key, tlx::string_view longkey, tlx::string_view keytype,
+                 int& dest, tlx::string_view desc);
 
     //! add unsigned integer option -key, --longkey [keytype] with description
     //! and store to dest
-    void add_unsigned(char key, const std::string& longkey,
-                      const std::string& keytype, unsigned int& dest,
-                      const std::string& desc);
+    void add_unsigned(char key, tlx::string_view longkey,
+                      tlx::string_view keytype, unsigned int& dest,
+                      tlx::string_view desc);
 
     //! add unsigned integer option -key, --longkey [keytype] with description
     //! and store to dest. identical to add_unsigned()
-    void add_uint(char key, const std::string& longkey,
-                  const std::string& keytype, unsigned int& dest,
-                  const std::string& desc);
+    void add_uint(char key, tlx::string_view longkey, tlx::string_view keytype,
+                  unsigned int& dest, tlx::string_view desc);
 
     //! add size_t option -key, --longkey [keytype] with description and store
     //! to dest
-    void add_size_t(char key, const std::string& longkey,
-                    const std::string& keytype, size_t& dest,
-                    const std::string& desc);
+    void add_size_t(char key, tlx::string_view longkey,
+                    tlx::string_view keytype, size_t& dest,
+                    tlx::string_view desc);
 
     //! add float option -key, --longkey [keytype] with description and store
     //! to dest
-    void add_float(char key, const std::string& longkey,
-                   const std::string& keytype, float& dest,
-                   const std::string& desc);
+    void add_float(char key, tlx::string_view longkey, tlx::string_view keytype,
+                   float& dest, tlx::string_view desc);
 
     //! add double option -key, --longkey [keytype] with description and store
     //! to dest
-    void add_double(char key, const std::string& longkey,
-                    const std::string& keytype, double& dest,
-                    const std::string& desc);
+    void add_double(char key, tlx::string_view longkey,
+                    tlx::string_view keytype, double& dest,
+                    tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size option -key, --longkey [keytype] and
     //! store to 64-bit dest
-    void add_bytes(char key, const std::string& longkey,
-                   const std::string& keytype, std::uint32_t& dest,
-                   const std::string& desc);
+    void add_bytes(char key, tlx::string_view longkey, tlx::string_view keytype,
+                   std::uint32_t& dest, tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size option -key, --longkey [keytype] and
     //! store to 64-bit dest
-    void add_bytes(char key, const std::string& longkey,
-                   const std::string& keytype, std::uint64_t& dest,
-                   const std::string& desc);
+    void add_bytes(char key, tlx::string_view longkey, tlx::string_view keytype,
+                   std::uint64_t& dest, tlx::string_view desc);
 
     //! add string option -key, --longkey [keytype] and store to dest
-    void add_string(char key, const std::string& longkey,
-                    const std::string& keytype, std::string& dest,
-                    const std::string& desc);
+    void add_string(char key, tlx::string_view longkey,
+                    tlx::string_view keytype, std::string& dest,
+                    tlx::string_view desc);
 
     //! add string list option -key, --longkey [keytype] and store to dest
-    void add_stringlist(char key, const std::string& longkey,
-                        const std::string& keytype,
-                        std::vector<std::string>& dest,
-                        const std::string& desc);
+    void add_stringlist(char key, tlx::string_view longkey,
+                        tlx::string_view keytype,
+                        std::vector<std::string>& dest, tlx::string_view desc);
 
     //! \}
 
@@ -360,50 +348,49 @@ public:
     //! \{
 
     //! add signed integer parameter [name] with description and store to dest
-    void add_param_int(const std::string& name, int& dest,
-                       const std::string& desc);
+    void add_param_int(tlx::string_view name, int& dest, tlx::string_view desc);
 
     //! add unsigned integer parameter [name] with description and store to dest
-    void add_param_unsigned(const std::string& name, unsigned int& dest,
-                            const std::string& desc);
+    void add_param_unsigned(tlx::string_view name, unsigned int& dest,
+                            tlx::string_view desc);
 
     //! add unsigned integer parameter [name] with description and store to
     //! dest. identical to add_unsigned()
-    void add_param_uint(const std::string& name, unsigned int& dest,
-                        const std::string& desc);
+    void add_param_uint(tlx::string_view name, unsigned int& dest,
+                        tlx::string_view desc);
 
     //! add size_t parameter [name] with description and store to dest
-    void add_param_size_t(const std::string& name, size_t& dest,
-                          const std::string& desc);
+    void add_param_size_t(tlx::string_view name, size_t& dest,
+                          tlx::string_view desc);
 
     //! add float parameter [name] with description and store to dest
-    void add_param_float(const std::string& name, float& dest,
-                         const std::string& desc);
+    void add_param_float(tlx::string_view name, float& dest,
+                         tlx::string_view desc);
 
     //! add double parameter [name] with description and store to dest
-    void add_param_double(const std::string& name, double& dest,
-                          const std::string& desc);
+    void add_param_double(tlx::string_view name, double& dest,
+                          tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size parameter [name] with description and
     //! store to dest
-    void add_param_bytes(const std::string& name, std::uint32_t& dest,
-                         const std::string& desc);
+    void add_param_bytes(tlx::string_view name, std::uint32_t& dest,
+                         tlx::string_view desc);
 
     //! add SI/IEC suffixes byte size parameter [name] with description and
     //! store to dest
-    void add_param_bytes(const std::string& name, std::uint64_t& dest,
-                         const std::string& desc);
+    void add_param_bytes(tlx::string_view name, std::uint64_t& dest,
+                         tlx::string_view desc);
 
     //! add string parameter [name] with description and store to dest
-    void add_param_string(const std::string& name, std::string& dest,
-                          const std::string& desc);
+    void add_param_string(tlx::string_view name, std::string& dest,
+                          tlx::string_view desc);
 
     //! add string list parameter [name] with description and store to dest.
     //! \warning this parameter must be last, as it will gobble all non-option
     //! arguments!
-    void add_param_stringlist(const std::string& name,
+    void add_param_stringlist(tlx::string_view name,
                               std::vector<std::string>& dest,
-                              const std::string& desc);
+                              tlx::string_view desc);
 
     //! \}
 
@@ -414,51 +401,51 @@ public:
 
     //! add optional signed integer parameter [name] with description and store
     //! to dest
-    void add_opt_param_int(const std::string& name, int& dest,
-                           const std::string& desc);
+    void add_opt_param_int(tlx::string_view name, int& dest,
+                           tlx::string_view desc);
 
     //! add optional unsigned integer parameter [name] with description and
     //! store to dest
-    void add_opt_param_unsigned(const std::string& name, unsigned int& dest,
-                                const std::string& desc);
+    void add_opt_param_unsigned(tlx::string_view name, unsigned int& dest,
+                                tlx::string_view desc);
 
     //! add optional unsigned integer parameter [name] with description and
     //! store to dest. identical to add_unsigned()
-    void add_opt_param_uint(const std::string& name, unsigned int& dest,
-                            const std::string& desc);
+    void add_opt_param_uint(tlx::string_view name, unsigned int& dest,
+                            tlx::string_view desc);
 
     //! add optional size_t parameter [name] with description and store to dest
-    void add_opt_param_size_t(const std::string& name, size_t& dest,
-                              const std::string& desc);
+    void add_opt_param_size_t(tlx::string_view name, size_t& dest,
+                              tlx::string_view desc);
 
     //! add optional float parameter [name] with description and store to dest
-    void add_opt_param_float(const std::string& name, float& dest,
-                             const std::string& desc);
+    void add_opt_param_float(tlx::string_view name, float& dest,
+                             tlx::string_view desc);
 
     //! add optional double parameter [name] with description and store to dest
-    void add_opt_param_double(const std::string& name, double& dest,
-                              const std::string& desc);
+    void add_opt_param_double(tlx::string_view name, double& dest,
+                              tlx::string_view desc);
 
     //! add optional SI/IEC suffixes byte size parameter [name] with
     //! description and store to dest
-    void add_opt_param_bytes(const std::string& name, std::uint32_t& dest,
-                             const std::string& desc);
+    void add_opt_param_bytes(tlx::string_view name, std::uint32_t& dest,
+                             tlx::string_view desc);
 
     //! add optional SI/IEC suffixes byte size parameter [name] with
     //! description and store to dest
-    void add_opt_param_bytes(const std::string& name, std::uint64_t& dest,
-                             const std::string& desc);
+    void add_opt_param_bytes(tlx::string_view name, std::uint64_t& dest,
+                             tlx::string_view desc);
 
     //! add optional string parameter [name] with description and store to dest
-    void add_opt_param_string(const std::string& name, std::string& dest,
-                              const std::string& desc);
+    void add_opt_param_string(tlx::string_view name, std::string& dest,
+                              tlx::string_view desc);
 
     //! add optional string parameter [name] with description and store to dest
     //! \warning this parameter must be last, as it will gobble all non-option
     //! arguments!
-    void add_opt_param_stringlist(const std::string& name,
+    void add_opt_param_stringlist(tlx::string_view name,
                                   std::vector<std::string>& dest,
-                                  const std::string& desc);
+                                  tlx::string_view desc);
 
     //! \}
 

--- a/tlx/die/core.cpp
+++ b/tlx/die/core.cpp
@@ -21,8 +21,7 @@ namespace tlx {
 
 /******************************************************************************/
 
-static std::atomic<bool> s_die_with_exception
-{
+static std::atomic<bool> s_die_with_exception{
 #if TLX_DIE_WITH_EXCEPTION
     true
 #else

--- a/tlx/digest/md5.cpp
+++ b/tlx/digest/md5.cpp
@@ -6,11 +6,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/digest/md5.hpp>
 #include <tlx/math/rol.hpp>
 #include <tlx/string/hexdump.hpp>
@@ -200,7 +201,7 @@ MD5::MD5(const void* data, std::uint32_t size) : MD5()
     process(data, size);
 }
 
-MD5::MD5(const std::string& str) : MD5()
+MD5::MD5(tlx::string_view str) : MD5()
 {
     process(str);
 }
@@ -241,7 +242,7 @@ void MD5::process(const void* data, std::uint32_t size)
     }
 }
 
-void MD5::process(const std::string& str)
+void MD5::process(tlx::string_view str)
 {
     return process(str.data(), str.size());
 }
@@ -307,7 +308,7 @@ std::string md5_hex(const void* data, std::uint32_t size)
     return MD5(data, size).digest_hex();
 }
 
-std::string md5_hex(const std::string& str)
+std::string md5_hex(tlx::string_view str)
 {
     return MD5(str).digest_hex();
 }
@@ -317,7 +318,7 @@ std::string md5_hex_uc(const void* data, std::uint32_t size)
     return MD5(data, size).digest_hex_uc();
 }
 
-std::string md5_hex_uc(const std::string& str)
+std::string md5_hex_uc(tlx::string_view str)
 {
     return MD5(str).digest_hex_uc();
 }

--- a/tlx/digest/md5.hpp
+++ b/tlx/digest/md5.hpp
@@ -6,7 +6,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_MD5_HEADER
 #define TLX_DIGEST_MD5_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -34,12 +35,12 @@ public:
     //! construct context and process data range
     MD5(const void* data, std::uint32_t size);
     //! construct context and process string
-    explicit MD5(const std::string& str);
+    explicit MD5(tlx::string_view str);
 
     //! process more data
     void process(const void* data, std::uint32_t size);
     //! process more data
-    void process(const std::string& str);
+    void process(tlx::string_view str);
 
     //! digest length in bytes
     static constexpr size_t kDigestLength = 16;
@@ -64,12 +65,12 @@ private:
 //! process data and return 16 byte (128 bit) digest hex encoded
 std::string md5_hex(const void* data, std::uint32_t size);
 //! process data and return 16 byte (128 bit) digest hex encoded
-std::string md5_hex(const std::string& str);
+std::string md5_hex(tlx::string_view str);
 
 //! process data and return 16 byte (128 bit) digest upper-case hex encoded
 std::string md5_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 16 byte (128 bit) digest upper-case hex encoded
-std::string md5_hex_uc(const std::string& str);
+std::string md5_hex_uc(tlx::string_view str);
 
 //! \}
 

--- a/tlx/digest/sha1.cpp
+++ b/tlx/digest/sha1.cpp
@@ -6,11 +6,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/digest/sha1.hpp>
 #include <tlx/math/rol.hpp>
 #include <tlx/string/hexdump.hpp>
@@ -151,7 +152,7 @@ SHA1::SHA1(const void* data, std::uint32_t size) : SHA1()
     process(data, size);
 }
 
-SHA1::SHA1(const std::string& str) : SHA1()
+SHA1::SHA1(tlx::string_view str) : SHA1()
 {
     process(str);
 }
@@ -192,7 +193,7 @@ void SHA1::process(const void* data, std::uint32_t size)
     }
 }
 
-void SHA1::process(const std::string& str)
+void SHA1::process(tlx::string_view str)
 {
     return process(str.data(), str.size());
 }
@@ -256,7 +257,7 @@ std::string sha1_hex(const void* data, std::uint32_t size)
     return SHA1(data, size).digest_hex();
 }
 
-std::string sha1_hex(const std::string& str)
+std::string sha1_hex(tlx::string_view str)
 {
     return SHA1(str).digest_hex();
 }
@@ -266,7 +267,7 @@ std::string sha1_hex_uc(const void* data, std::uint32_t size)
     return SHA1(data, size).digest_hex_uc();
 }
 
-std::string sha1_hex_uc(const std::string& str)
+std::string sha1_hex_uc(tlx::string_view str)
 {
     return SHA1(str).digest_hex_uc();
 }

--- a/tlx/digest/sha1.hpp
+++ b/tlx/digest/sha1.hpp
@@ -6,7 +6,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_SHA1_HEADER
 #define TLX_DIGEST_SHA1_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -34,12 +35,12 @@ public:
     //! construct context and process data range
     SHA1(const void* data, std::uint32_t size);
     //! construct context and process string
-    explicit SHA1(const std::string& str);
+    explicit SHA1(tlx::string_view str);
 
     //! process more data
     void process(const void* data, std::uint32_t size);
     //! process more data
-    void process(const std::string& str);
+    void process(tlx::string_view str);
 
     //! digest length in bytes
     static constexpr size_t kDigestLength = 20;
@@ -64,12 +65,12 @@ private:
 //! process data and return 20 byte (160 bit) digest hex encoded
 std::string sha1_hex(const void* data, std::uint32_t size);
 //! process data and return 20 byte (160 bit) digest hex encoded
-std::string sha1_hex(const std::string& str);
+std::string sha1_hex(tlx::string_view str);
 
 //! process data and return 20 byte (160 bit) digest upper-case hex encoded
 std::string sha1_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 20 byte (160 bit) digest upper-case hex encoded
-std::string sha1_hex_uc(const std::string& str);
+std::string sha1_hex_uc(tlx::string_view str);
 
 //! \}
 

--- a/tlx/digest/sha256.cpp
+++ b/tlx/digest/sha256.cpp
@@ -6,11 +6,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/digest/sha256.hpp>
 #include <tlx/math/ror.hpp>
 #include <tlx/string/hexdump.hpp>
@@ -164,7 +165,7 @@ SHA256::SHA256(const void* data, std::uint32_t size) : SHA256()
     process(data, size);
 }
 
-SHA256::SHA256(const std::string& str) : SHA256()
+SHA256::SHA256(tlx::string_view str) : SHA256()
 {
     process(str);
 }
@@ -201,7 +202,7 @@ void SHA256::process(const void* data, u32 size)
     }
 }
 
-void SHA256::process(const std::string& str)
+void SHA256::process(tlx::string_view str)
 {
     return process(str.data(), str.size());
 }
@@ -264,7 +265,7 @@ std::string sha256_hex(const void* data, std::uint32_t size)
     return SHA256(data, size).digest_hex();
 }
 
-std::string sha256_hex(const std::string& str)
+std::string sha256_hex(tlx::string_view str)
 {
     return SHA256(str).digest_hex();
 }
@@ -274,7 +275,7 @@ std::string sha256_hex_uc(const void* data, std::uint32_t size)
     return SHA256(data, size).digest_hex_uc();
 }
 
-std::string sha256_hex_uc(const std::string& str)
+std::string sha256_hex_uc(tlx::string_view str)
 {
     return SHA256(str).digest_hex_uc();
 }

--- a/tlx/digest/sha256.hpp
+++ b/tlx/digest/sha256.hpp
@@ -6,7 +6,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_SHA256_HEADER
 #define TLX_DIGEST_SHA256_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -34,12 +35,12 @@ public:
     //! construct context and process data range
     SHA256(const void* data, std::uint32_t size);
     //! construct context and process string
-    explicit SHA256(const std::string& str);
+    explicit SHA256(tlx::string_view str);
 
     //! process more data
     void process(const void* data, std::uint32_t size);
     //! process more data
-    void process(const std::string& str);
+    void process(tlx::string_view str);
 
     //! digest length in bytes
     static constexpr size_t kDigestLength = 32;
@@ -64,12 +65,12 @@ private:
 //! process data and return 32 byte (256 bit) digest hex encoded
 std::string sha256_hex(const void* data, std::uint32_t size);
 //! process data and return 32 byte (256 bit) digest hex encoded
-std::string sha256_hex(const std::string& str);
+std::string sha256_hex(tlx::string_view str);
 
 //! process data and return 32 byte (256 bit) digest upper-case hex encoded
 std::string sha256_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 32 byte (256 bit) digest upper-case hex encoded
-std::string sha256_hex_uc(const std::string& str);
+std::string sha256_hex_uc(tlx::string_view str);
 
 //! \}
 

--- a/tlx/digest/sha512.cpp
+++ b/tlx/digest/sha512.cpp
@@ -6,11 +6,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/digest/sha512.hpp>
 #include <tlx/math/ror.hpp>
 #include <tlx/string/hexdump.hpp>
@@ -177,7 +178,7 @@ SHA512::SHA512(const void* data, std::uint32_t size) : SHA512()
     process(data, size);
 }
 
-SHA512::SHA512(const std::string& str) : SHA512()
+SHA512::SHA512(tlx::string_view str) : SHA512()
 {
     process(str);
 }
@@ -218,7 +219,7 @@ void SHA512::process(const void* data, std::uint32_t size)
     }
 }
 
-void SHA512::process(const std::string& str)
+void SHA512::process(tlx::string_view str)
 {
     return process(str.data(), str.size());
 }
@@ -285,7 +286,7 @@ std::string sha512_hex(const void* data, std::uint32_t size)
     return SHA512(data, size).digest_hex();
 }
 
-std::string sha512_hex(const std::string& str)
+std::string sha512_hex(tlx::string_view str)
 {
     return SHA512(str).digest_hex();
 }
@@ -295,7 +296,7 @@ std::string sha512_hex_uc(const void* data, std::uint32_t size)
     return SHA512(data, size).digest_hex_uc();
 }
 
-std::string sha512_hex_uc(const std::string& str)
+std::string sha512_hex_uc(tlx::string_view str)
 {
     return SHA512(str).digest_hex_uc();
 }

--- a/tlx/digest/sha512.hpp
+++ b/tlx/digest/sha512.hpp
@@ -6,7 +6,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -14,6 +14,7 @@
 #ifndef TLX_DIGEST_SHA512_HEADER
 #define TLX_DIGEST_SHA512_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -34,12 +35,12 @@ public:
     //! construct context and process data range
     SHA512(const void* data, std::uint32_t size);
     //! construct context and process string
-    explicit SHA512(const std::string& str);
+    explicit SHA512(tlx::string_view str);
 
     //! process more data
     void process(const void* data, std::uint32_t size);
     //! process more data
-    void process(const std::string& str);
+    void process(tlx::string_view str);
 
     //! digest length in bytes
     static constexpr size_t kDigestLength = 64;
@@ -64,12 +65,12 @@ private:
 //! process data and return 64 byte (512 bit) digest hex encoded
 std::string sha512_hex(const void* data, std::uint32_t size);
 //! process data and return 64 byte (512 bit) digest hex encoded
-std::string sha512_hex(const std::string& str);
+std::string sha512_hex(tlx::string_view str);
 
 //! process data and return 64 byte (512 bit) digest upper-case hex encoded
 std::string sha512_hex_uc(const void* data, std::uint32_t size);
 //! process data and return 64 byte (512 bit) digest upper-case hex encoded
-std::string sha512_hex_uc(const std::string& str);
+std::string sha512_hex_uc(tlx::string_view str);
 
 //! \}
 

--- a/tlx/logger/core.cpp
+++ b/tlx/logger/core.cpp
@@ -10,6 +10,7 @@
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/logger/core.hpp>
 #include <atomic>
 #include <iostream>
@@ -27,12 +28,12 @@ class DefaultLoggerOutputCOut : public LoggerOutputHook
     std::mutex mutex_;
 
     //! method the receive log lines
-    void append_log_line(const std::string& line) final
+    void append_log_line(tlx::string_view line) final
     {
         // lock the global mutex of logger for serialized output in
         // multi-threaded programs.
         std::unique_lock<std::mutex> lock(mutex_);
-        (std::cout << line).flush();
+        std::cout.write(line.data(), line.size()).flush();
     }
 };
 
@@ -43,12 +44,12 @@ class DefaultLoggerOutputCErr : public LoggerOutputHook
     std::mutex mutex_;
 
     //! method the receive log lines
-    void append_log_line(const std::string& line) final
+    void append_log_line(tlx::string_view line) final
     {
         // lock the global mutex of logger for serialized output in
         // multi-threaded programs.
         std::unique_lock<std::mutex> lock(mutex_);
-        (std::cerr << line).flush();
+        std::cout.write(line.data(), line.size()).flush();
     }
 };
 
@@ -146,7 +147,7 @@ std::string LoggerCollectOutput::get()
     return oss_.str();
 }
 
-void LoggerCollectOutput::append_log_line(const std::string& line)
+void LoggerCollectOutput::append_log_line(tlx::string_view line)
 {
     oss_ << line;
     if (echo_)

--- a/tlx/logger/core.hpp
+++ b/tlx/logger/core.hpp
@@ -13,6 +13,7 @@
 #ifndef TLX_LOGGER_CORE_HEADER
 #define TLX_LOGGER_CORE_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -194,7 +195,7 @@ public:
     virtual ~LoggerOutputHook();
 
     //! method the receive log lines
-    virtual void append_log_line(const std::string& line) = 0;
+    virtual void append_log_line(tlx::string_view line) = 0;
 };
 
 //! set new LoggerOutputHook instance to receive global log lines. returns the
@@ -221,7 +222,7 @@ public:
     void clear();
 
     //! method the receive log lines
-    void append_log_line(const std::string& line) final;
+    void append_log_line(tlx::string_view line) final;
 
 private:
     //! previous logger, will be restored by destructor

--- a/tlx/siphash.hpp
+++ b/tlx/siphash.hpp
@@ -6,7 +6,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2017-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -14,12 +14,12 @@
 #ifndef TLX_SIPHASH_HEADER
 #define TLX_SIPHASH_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/define/attribute_fallthrough.hpp>
 #include <tlx/math/bswap_le.hpp>
 #include <tlx/math/rol.hpp>
 #include <cstdint>
 #include <cstdlib>
-#include <string>
 
 #if defined(_MSC_VER)
 
@@ -261,7 +261,7 @@ static inline std::uint64_t siphash(const char* msg, size_t size)
     return siphash(reinterpret_cast<const std::uint8_t*>(msg), size);
 }
 
-static inline std::uint64_t siphash(const std::string& str)
+static inline std::uint64_t siphash(tlx::string_view str)
 {
     return siphash(str.data(), str.size());
 }

--- a/tlx/string/base64.cpp
+++ b/tlx/string/base64.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/base64.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -106,7 +107,7 @@ std::string base64_encode(const void* data, size_t size, size_t line_break)
     }
 }
 
-std::string base64_encode(const std::string& str, size_t line_break)
+std::string base64_encode(tlx::string_view str, size_t line_break)
 {
     return base64_encode(str.data(), str.size(), line_break);
 }
@@ -217,7 +218,7 @@ std::string base64_decode(const void* data, size_t size, bool strict)
     }
 }
 
-std::string base64_decode(const std::string& str, bool strict)
+std::string base64_decode(tlx::string_view str, bool strict)
 {
     return base64_decode(str.data(), str.size(), strict);
 }

--- a/tlx/string/base64.hpp
+++ b/tlx/string/base64.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_BASE64_HEADER
 #define TLX_STRING_BASE64_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <string>
 
@@ -47,7 +48,7 @@ std::string base64_encode(const void* data, size_t size, size_t line_break = 0);
  * \param line_break  break the output string every n characters
  * \return            base64 encoded string
  */
-std::string base64_encode(const std::string& str, size_t line_break = 0);
+std::string base64_encode(tlx::string_view str, size_t line_break = 0);
 
 /*!
  * Decode a string in base64 representation as described in RFC 2045 or RFC 3548
@@ -74,7 +75,7 @@ std::string base64_decode(const void* data, size_t size, bool strict = true);
  * \param strict  throw exception on invalid character
  * \return        decoded binary data
  */
-std::string base64_decode(const std::string& str, bool strict = true);
+std::string base64_decode(tlx::string_view str, bool strict = true);
 
 //! \}
 //! \}

--- a/tlx/string/bitdump.cpp
+++ b/tlx/string/bitdump.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2019-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/bitdump.hpp>
 #include <cstddef>
 #include <string>
@@ -45,7 +46,7 @@ std::string bitdump_8_msb(const void* const data, size_t size)
     return out;
 }
 
-std::string bitdump_8_msb(const std::string& str)
+std::string bitdump_8_msb(tlx::string_view str)
 {
     return bitdump_8_msb(str.data(), str.size());
 }
@@ -55,7 +56,7 @@ std::string bitdump_le8(const void* const data, size_t size)
     return bitdump_8_msb(data, size);
 }
 
-std::string bitdump_le8(const std::string& str)
+std::string bitdump_le8(tlx::string_view str)
 {
     return bitdump_8_msb(str);
 }
@@ -91,7 +92,7 @@ std::string bitdump_8_lsb(const void* const data, size_t size)
     return out;
 }
 
-std::string bitdump_8_lsb(const std::string& str)
+std::string bitdump_8_lsb(tlx::string_view str)
 {
     return bitdump_8_lsb(str.data(), str.size());
 }
@@ -101,7 +102,7 @@ std::string bitdump_be8(const void* const data, size_t size)
     return bitdump_8_lsb(data, size);
 }
 
-std::string bitdump_be8(const std::string& str)
+std::string bitdump_be8(tlx::string_view str)
 {
     return bitdump_8_lsb(str);
 }

--- a/tlx/string/bitdump.hpp
+++ b/tlx/string/bitdump.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2019-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_BITDUMP_HEADER
 #define TLX_STRING_BITDUMP_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <string>
 
@@ -43,7 +44,7 @@ std::string bitdump_8_msb(const void* const data, size_t size);
  * \param str  binary data to output as bits
  * \return     string of binary digits
  */
-std::string bitdump_8_msb(const std::string& str);
+std::string bitdump_8_msb(tlx::string_view str);
 
 /*!
  * Dump a (binary) item of 8-bit bytes as a sequence of '0' and '1' characters,
@@ -65,7 +66,7 @@ std::string bitdump_8_msb_type(const Type& t)
 std::string bitdump_le8(const void* const data, size_t size);
 
 //! deprecated method: unclear naming and documentation.
-std::string bitdump_le8(const std::string& str);
+std::string bitdump_le8(tlx::string_view str);
 
 //! deprecated method: unclear naming and documentation.
 template <typename Type>
@@ -95,7 +96,7 @@ std::string bitdump_8_lsb(const void* const data, size_t size);
  * \param str  binary data to output as bits
  * \return     string of binary digits
  */
-std::string bitdump_8_lsb(const std::string& str);
+std::string bitdump_8_lsb(tlx::string_view str);
 
 /*!
  * Dump a (binary) item of 8-bit bytes as a sequence of '0' and '1' characters,
@@ -117,7 +118,7 @@ std::string bitdump_8_lsb_type(const Type& t)
 std::string bitdump_be8(const void* const data, size_t size);
 
 //! deprecated method: unclear naming and documentation.
-std::string bitdump_be8(const std::string& str);
+std::string bitdump_be8(tlx::string_view str);
 
 //! deprecated method: unclear naming and documentation.
 template <typename Type>

--- a/tlx/string/compare_icase.cpp
+++ b/tlx/string/compare_icase.cpp
@@ -3,14 +3,14 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/compare_icase.hpp>
 #include <tlx/string/to_lower.hpp>
-#include <string>
 
 namespace tlx {
 
@@ -35,9 +35,9 @@ int compare_icase(const char* a, const char* b)
     return 0;
 }
 
-int compare_icase(const char* a, const std::string& b)
+int compare_icase(const char* a, tlx::string_view b)
 {
-    std::string::const_iterator bi = b.begin();
+    tlx::string_view::const_iterator bi = b.begin();
 
     while (*a != 0 && bi != b.end())
     {
@@ -58,9 +58,9 @@ int compare_icase(const char* a, const std::string& b)
     return 0;
 }
 
-int compare_icase(const std::string& a, const char* b)
+int compare_icase(tlx::string_view a, const char* b)
 {
-    std::string::const_iterator ai = a.begin();
+    tlx::string_view::const_iterator ai = a.begin();
 
     while (ai != a.end() && *b != 0)
     {
@@ -81,10 +81,10 @@ int compare_icase(const std::string& a, const char* b)
     return 0;
 }
 
-int compare_icase(const std::string& a, const std::string& b)
+int compare_icase(tlx::string_view a, tlx::string_view b)
 {
-    std::string::const_iterator ai = a.begin();
-    std::string::const_iterator bi = b.begin();
+    tlx::string_view::const_iterator ai = a.begin();
+    tlx::string_view::const_iterator bi = b.begin();
 
     while (ai != a.end() && bi != b.end())
     {

--- a/tlx/string/compare_icase.hpp
+++ b/tlx/string/compare_icase.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_COMPARE_ICASE_HEADER
 #define TLX_STRING_COMPARE_ICASE_HEADER
 
-#include <string>
+#include <tlx/container/string_view.hpp>
 
 namespace tlx {
 
@@ -25,13 +25,13 @@ namespace tlx {
 int compare_icase(const char* a, const char* b);
 
 //! returns +1/0/-1 like strcmp(a, b) but without regard for letter case
-int compare_icase(const char* a, const std::string& b);
+int compare_icase(const char* a, tlx::string_view b);
 
 //! returns +1/0/-1 like strcmp(a, b) but without regard for letter case
-int compare_icase(const std::string& a, const char* b);
+int compare_icase(tlx::string_view a, const char* b);
 
 //! returns +1/0/-1 like strcmp(a, b) but without regard for letter case
-int compare_icase(const std::string& a, const std::string& b);
+int compare_icase(tlx::string_view a, tlx::string_view b);
 
 //! \}
 

--- a/tlx/string/contains.cpp
+++ b/tlx/string/contains.cpp
@@ -3,27 +3,23 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/contains.hpp>
 #include <string>
 
 namespace tlx {
 
-bool contains(const std::string& str, const std::string& pattern)
+bool contains(tlx::string_view str, tlx::string_view pattern)
 {
     return str.find(pattern) != std::string::npos;
 }
 
-bool contains(const std::string& str, const char* pattern)
-{
-    return str.find(pattern) != std::string::npos;
-}
-
-bool contains(const std::string& str, const char ch)
+bool contains(tlx::string_view str, const char ch)
 {
     return str.find(ch) != std::string::npos;
 }

--- a/tlx/string/contains.hpp
+++ b/tlx/string/contains.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_CONTAINS_HEADER
 #define TLX_STRING_CONTAINS_HEADER
 
-#include <string>
+#include <tlx/container/string_view.hpp>
 
 namespace tlx {
 
@@ -22,13 +22,10 @@ namespace tlx {
 // contains()
 
 //! Tests of string contains pattern
-bool contains(const std::string& str, const std::string& pattern);
-
-//! Tests of string contains pattern
-bool contains(const std::string& str, const char* pattern);
+bool contains(tlx::string_view str, tlx::string_view pattern);
 
 //! Tests of string contains character
-bool contains(const std::string& str, const char ch);
+bool contains(tlx::string_view str, const char ch);
 
 //! \}
 

--- a/tlx/string/contains_word.cpp
+++ b/tlx/string/contains_word.cpp
@@ -3,13 +3,13 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/contains_word.hpp>
-#include <string>
 
 namespace tlx {
 
@@ -18,56 +18,13 @@ static inline bool is_white(char c)
     return c == ' ' || c == '\n' || c == '\t' || c == '\r';
 }
 
-bool contains_word(const std::string& str, const char* word)
-{
-    // all strings contain the empty word
-    if (*word == 0)
-        return true;
-
-    std::string::const_iterator it = str.begin();
-
-    while (it != str.end())
-    {
-        // skip over whitespace
-        while (is_white(*it))
-        {
-            if (++it == str.end())
-                return false;
-        }
-
-        // check if this non-whitespace matches the string
-        const char* wi = word;
-        while (*it == *wi)
-        {
-            ++it, ++wi;
-            if (*wi == 0)
-            {
-                if (it == str.end() || is_white(*it))
-                    return true;
-                break;
-            }
-            if (it == str.end())
-                return false;
-        }
-
-        // skip over not matching whitespace
-        while (!is_white(*it))
-        {
-            if (++it == str.end())
-                return false;
-        }
-    }
-
-    return false;
-}
-
-bool contains_word(const std::string& str, const std::string& word)
+bool contains_word(tlx::string_view str, tlx::string_view word)
 {
     // all strings contain the empty word
     if (word.empty())
         return true;
 
-    std::string::const_iterator it = str.begin();
+    tlx::string_view::const_iterator it = str.begin();
 
     while (it != str.end())
     {
@@ -79,7 +36,7 @@ bool contains_word(const std::string& str, const std::string& word)
         }
 
         // check if this non-whitespace matches the string
-        std::string::const_iterator wi = word.begin();
+        tlx::string_view::const_iterator wi = word.begin();
         while (*it == *wi)
         {
             ++it, ++wi;

--- a/tlx/string/contains_word.hpp
+++ b/tlx/string/contains_word.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_CONTAINS_WORD_HEADER
 #define TLX_STRING_CONTAINS_WORD_HEADER
 
-#include <string>
+#include <tlx/container/string_view.hpp>
 
 namespace tlx {
 
@@ -31,19 +31,7 @@ namespace tlx {
  * \param word  word to find
  * \return      true if the word was found
  */
-bool contains_word(const std::string& str, const char* word);
-
-/*!
- * Search the given string for a whitespace-delimited word. It works as if the
- * str was split_words() and the resulting vector checked for a given
- * word. However this function does not create a vector, it scans the string
- * directly. Whitespace is space, tab, newline or carriage-return.
- *
- * \param str   whitespace-delimited string to check
- * \param word  word to find
- * \return      true if the word was found
- */
-bool contains_word(const std::string& str, const std::string& word);
+bool contains_word(tlx::string_view str, tlx::string_view word);
 
 //! \}
 

--- a/tlx/string/ends_with.cpp
+++ b/tlx/string/ends_with.cpp
@@ -3,16 +3,16 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/ends_with.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
 #include <cstring>
-#include <string>
 
 namespace tlx {
 
@@ -37,7 +37,7 @@ bool ends_with(const char* str, const char* match)
     return true;
 }
 
-bool ends_with(const char* str, const std::string& match)
+bool ends_with(const char* str, tlx::string_view match)
 {
     size_t str_size = 0, match_size = match.size();
     while (*str != 0)
@@ -45,7 +45,7 @@ bool ends_with(const char* str, const std::string& match)
     if (match_size > str_size)
         return false;
 
-    std::string::const_iterator m = match.end();
+    tlx::string_view::const_iterator m = match.end();
     while (m != match.begin())
     {
         --str, --m;
@@ -55,13 +55,13 @@ bool ends_with(const char* str, const std::string& match)
     return true;
 }
 
-bool ends_with(const std::string& str, const char* match)
+bool ends_with(tlx::string_view str, const char* match)
 {
-    size_t str_size = str.size(), match_size = strlen(match);
+    size_t str_size = str.size(), match_size = std::strlen(match);
     if (match_size > str_size)
         return false;
 
-    std::string::const_iterator s = str.end() - match_size;
+    tlx::string_view::const_iterator s = str.end() - match_size;
     while (*match != 0)
     {
         if (*s != *match)
@@ -71,7 +71,7 @@ bool ends_with(const std::string& str, const char* match)
     return true;
 }
 
-bool ends_with(const std::string& str, const std::string& match)
+bool ends_with(tlx::string_view str, tlx::string_view match)
 {
     if (match.size() > str.size())
         return false;
@@ -100,7 +100,7 @@ bool ends_with_icase(const char* str, const char* match)
     return true;
 }
 
-bool ends_with_icase(const char* str, const std::string& match)
+bool ends_with_icase(const char* str, tlx::string_view match)
 {
     size_t str_size = 0, match_size = match.size();
     while (*str != 0)
@@ -108,7 +108,7 @@ bool ends_with_icase(const char* str, const std::string& match)
     if (match_size > str_size)
         return false;
 
-    std::string::const_iterator m = match.end();
+    tlx::string_view::const_iterator m = match.end();
     while (m != match.begin())
     {
         --str, --m;
@@ -118,13 +118,13 @@ bool ends_with_icase(const char* str, const std::string& match)
     return true;
 }
 
-bool ends_with_icase(const std::string& str, const char* match)
+bool ends_with_icase(tlx::string_view str, const char* match)
 {
-    size_t str_size = str.size(), match_size = strlen(match);
+    size_t str_size = str.size(), match_size = std::strlen(match);
     if (match_size > str_size)
         return false;
 
-    std::string::const_iterator s = str.end() - match_size;
+    tlx::string_view::const_iterator s = str.end() - match_size;
     while (*match != 0)
     {
         if (to_lower(*s) != to_lower(*match))
@@ -134,7 +134,7 @@ bool ends_with_icase(const std::string& str, const char* match)
     return true;
 }
 
-bool ends_with_icase(const std::string& str, const std::string& match)
+bool ends_with_icase(tlx::string_view str, tlx::string_view match)
 {
     if (match.size() > str.size())
         return false;

--- a/tlx/string/ends_with.hpp
+++ b/tlx/string/ends_with.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_ENDS_WITH_HEADER
 #define TLX_STRING_ENDS_WITH_HEADER
 
-#include <string>
+#include <tlx/container/string_view.hpp>
 
 namespace tlx {
 
@@ -29,44 +29,44 @@ bool ends_with(const char* str, const char* match);
 /*!
  * Checks if the given match string is located at the end of this string.
  */
-bool ends_with(const char* str, const std::string& match);
+bool ends_with(const char* str, tlx::string_view match);
 
 /*!
  * Checks if the given match string is located at the end of this string.
  */
-bool ends_with(const std::string& str, const char* match);
+bool ends_with(tlx::string_view str, const char* match);
 
 /*!
  * Checks if the given match string is located at the end of this string.
  */
-bool ends_with(const std::string& str, const std::string& match);
+bool ends_with(tlx::string_view str, tlx::string_view match);
 
 /******************************************************************************/
 // ends_with_icase()
 
-// /*!
-//  * Checks if the given match string is located at the end of this
-//  * string. Compares the characters case-insensitively.
-//  */
-// bool ends_with_icase(const char* str, const char* match);
-
-// /*!
-//  * Checks if the given match string is located at the end of this
-//  * string. Compares the characters case-insensitively.
-//  */
-// bool ends_with_icase(const char* str, const std::string& match);
+/*!
+ * Checks if the given match string is located at the end of this
+ * string. Compares the characters case-insensitively.
+ */
+bool ends_with_icase(const char* str, const char* match);
 
 /*!
  * Checks if the given match string is located at the end of this
  * string. Compares the characters case-insensitively.
  */
-bool ends_with_icase(const std::string& str, const char* match);
+bool ends_with_icase(const char* str, tlx::string_view match);
 
 /*!
  * Checks if the given match string is located at the end of this
  * string. Compares the characters case-insensitively.
  */
-bool ends_with_icase(const std::string& str, const std::string& match);
+bool ends_with_icase(tlx::string_view str, const char* match);
+
+/*!
+ * Checks if the given match string is located at the end of this
+ * string. Compares the characters case-insensitively.
+ */
+bool ends_with_icase(tlx::string_view str, tlx::string_view match);
 
 /******************************************************************************/
 

--- a/tlx/string/equal_icase.cpp
+++ b/tlx/string/equal_icase.cpp
@@ -3,15 +3,15 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/equal_icase.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
-#include <string>
 
 namespace tlx {
 
@@ -23,9 +23,9 @@ bool equal_icase(const char* a, const char* b)
     return *a == 0 && *b == 0;
 }
 
-bool equal_icase(const char* a, const std::string& b)
+bool equal_icase(const char* a, tlx::string_view b)
 {
-    std::string::const_iterator bi = b.begin();
+    tlx::string_view::const_iterator bi = b.begin();
 
     while (*a != 0 && bi != b.end() && to_lower(*a) == to_lower(*bi))
         ++a, ++bi;
@@ -33,9 +33,9 @@ bool equal_icase(const char* a, const std::string& b)
     return *a == 0 && bi == b.end();
 }
 
-bool equal_icase(const std::string& a, const char* b)
+bool equal_icase(tlx::string_view a, const char* b)
 {
-    std::string::const_iterator ai = a.begin();
+    tlx::string_view::const_iterator ai = a.begin();
 
     while (ai != a.end() && *b != 0 && to_lower(*ai) == to_lower(*b))
         ++ai, ++b;
@@ -43,7 +43,7 @@ bool equal_icase(const std::string& a, const char* b)
     return ai == a.end() && *b != 0;
 }
 
-bool equal_icase(const std::string& a, const std::string& b)
+bool equal_icase(tlx::string_view a, tlx::string_view b)
 {
     if (a.size() != b.size())
         return false;

--- a/tlx/string/equal_icase.hpp
+++ b/tlx/string/equal_icase.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_EQUAL_ICASE_HEADER
 #define TLX_STRING_EQUAL_ICASE_HEADER
 
-#include <string>
+#include <tlx/container/string_view.hpp>
 
 namespace tlx {
 
@@ -25,13 +25,13 @@ namespace tlx {
 bool equal_icase(const char* a, const char* b);
 
 //! returns true if a == b without regard for letter case
-bool equal_icase(const char* a, const std::string& b);
+bool equal_icase(const char* a, tlx::string_view b);
 
 //! returns true if a == b without regard for letter case
-bool equal_icase(const std::string& a, const char* b);
+bool equal_icase(tlx::string_view a, const char* b);
 
 //! returns true if a == b without regard for letter case
-bool equal_icase(const std::string& a, const std::string& b);
+bool equal_icase(tlx::string_view a, tlx::string_view b);
 
 //! \}
 

--- a/tlx/string/erase_all.cpp
+++ b/tlx/string/erase_all.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/erase_all.hpp>
 #include <string>
 
@@ -18,7 +19,8 @@ namespace tlx {
 
 std::string& erase_all(std::string* str, char drop)
 {
-    std::string::size_type pos1 = std::string::npos, pos2;
+    std::string::size_type pos1 = std::string::npos;
+    std::string::size_type pos2{};
 
     while ((pos1 = str->find_last_of(drop, pos1)) != std::string::npos)
     {
@@ -35,13 +37,15 @@ std::string& erase_all(std::string* str, char drop)
     return *str;
 }
 
-std::string& erase_all(std::string* str, const char* drop)
+std::string& erase_all(std::string* str, tlx::string_view drop)
 {
-    std::string::size_type pos1 = std::string::npos, pos2;
+    std::string::size_type pos1 = std::string::npos;
+    std::string::size_type pos2{};
 
-    while ((pos1 = str->find_last_of(drop, pos1)) != std::string::npos)
+    while ((pos1 = str->find_last_of(drop.data(), pos1, drop.size())) !=
+           std::string::npos)
     {
-        pos2 = str->find_last_not_of(drop, pos1);
+        pos2 = str->find_last_not_of(drop.data(), pos1, drop.size());
         if (pos2 == std::string::npos)
         {
             str->erase(0, pos1 - pos2);
@@ -52,22 +56,17 @@ std::string& erase_all(std::string* str, const char* drop)
     }
 
     return *str;
-}
-
-std::string& erase_all(std::string* str, const std::string& drop)
-{
-    return erase_all(str, drop.c_str());
 }
 
 /******************************************************************************/
 // erase_all() copy
 
-std::string erase_all(const std::string& str, char drop)
+std::string erase_all(tlx::string_view str, char drop)
 {
     std::string out;
     out.reserve(str.size());
 
-    std::string::const_iterator si = str.begin();
+    tlx::string_view::const_iterator si = str.begin();
     while (si != str.end())
     {
         if (*si != drop)
@@ -78,34 +77,29 @@ std::string erase_all(const std::string& str, char drop)
     return out;
 }
 
-std::string erase_all(const std::string& str, const char* drop)
+std::string erase_all(tlx::string_view str, tlx::string_view drop)
 {
     std::string out;
     out.reserve(str.size());
 
-    std::string::const_iterator si = str.begin();
+    tlx::string_view::const_iterator si = str.begin();
     while (si != str.end())
     {
         // search for letter
-        const char* d = drop;
-        while (*d != 0)
+        const char* d = drop.begin();
+        while (d != drop.end())
         {
             if (*si == *d)
                 break;
             ++d;
         }
         // append if not found
-        if (*d == 0)
+        if (d == drop.end())
             out += *si;
         ++si;
     }
 
     return out;
-}
-
-std::string erase_all(const std::string& str, const std::string& drop)
-{
-    return erase_all(str, drop.c_str());
 }
 
 } // namespace tlx

--- a/tlx/string/erase_all.hpp
+++ b/tlx/string/erase_all.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_ERASE_ALL_HEADER
 #define TLX_STRING_ERASE_ALL_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -37,16 +38,7 @@ std::string& erase_all(std::string* str, char drop = ' ');
  * \param drop  remove these characters
  * \return      reference to the modified string
  */
-std::string& erase_all(std::string* str, const char* drop);
-
-/*!
- * Remove all occurrences of the given characters in-place.
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      reference to the modified string
- */
-std::string& erase_all(std::string* str, const std::string& drop);
+std::string& erase_all(std::string* str, tlx::string_view drop);
 
 /******************************************************************************/
 // erase_all() copy
@@ -58,7 +50,7 @@ std::string& erase_all(std::string* str, const std::string& drop);
  * \param drop  remove this character
  * \return      copy of string possibly with less characters
  */
-std::string erase_all(const std::string& str, char drop = ' ');
+std::string erase_all(tlx::string_view str, char drop = ' ');
 
 /*!
  * Remove all occurrences of the given characters, return copy of string.
@@ -67,16 +59,7 @@ std::string erase_all(const std::string& str, char drop = ' ');
  * \param drop  remove these characters
  * \return      copy of string possibly with less characters
  */
-std::string erase_all(const std::string& str, const char* drop);
-
-/*!
- * Remove all occurrences of the given characters, return copy of string.
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      copy of string possibly with less characters
- */
-std::string erase_all(const std::string& str, const std::string& drop);
+std::string erase_all(tlx::string_view str, tlx::string_view drop);
 
 //! \}
 

--- a/tlx/string/escape_html.cpp
+++ b/tlx/string/escape_html.cpp
@@ -3,46 +3,25 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/escape_html.hpp>
 #include <cstring>
 #include <string>
 
 namespace tlx {
 
-std::string escape_html(const std::string& str)
+std::string escape_html(tlx::string_view str)
 {
     std::string os;
     os.reserve(str.size() + str.size() / 16);
 
-    for (std::string::const_iterator si = str.begin(); si != str.end(); ++si)
-    {
-        if (*si == '&')
-            os += "&amp;";
-        else if (*si == '<')
-            os += "&lt;";
-        else if (*si == '>')
-            os += "&gt;";
-        else if (*si == '"')
-            os += "&quot;";
-        else
-            os += *si;
-    }
-
-    return os;
-}
-
-std::string escape_html(const char* str)
-{
-    size_t slen = strlen(str);
-    std::string os;
-    os.reserve(slen + slen / 16);
-
-    for (const char* si = str; *si != 0; ++si)
+    for (tlx::string_view::const_iterator si = str.begin(); si != str.end();
+         ++si)
     {
         if (*si == '&')
             os += "&amp;";

--- a/tlx/string/escape_html.hpp
+++ b/tlx/string/escape_html.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_ESCAPE_HTML_HEADER
 #define TLX_STRING_ESCAPE_HTML_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -22,13 +23,7 @@ namespace tlx {
  * Escape characters for inclusion in HTML documents: replaces the characters <,
  * >, & and " with HTML entities.
  */
-std::string escape_html(const std::string& str);
-
-/*!
- * Escape characters for inclusion in HTML documents: replaces the characters <,
- * >, & and " with HTML entities.
- */
-std::string escape_html(const char* str);
+std::string escape_html(tlx::string_view str);
 
 //! \}
 

--- a/tlx/string/escape_uri.cpp
+++ b/tlx/string/escape_uri.cpp
@@ -3,121 +3,25 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/escape_uri.hpp>
 #include <cstring>
 #include <string>
 
 namespace tlx {
 
-std::string escape_uri(const std::string& str)
+std::string escape_uri(tlx::string_view str)
 {
     std::string result;
     result.reserve(str.size() + str.size() / 16);
 
-    for (std::string::const_iterator it = str.begin(); it != str.end(); ++it)
-    {
-        switch (*it)
-        {
-        // alnum
-        case 'A':
-        case 'B':
-        case 'C':
-        case 'D':
-        case 'E':
-        case 'F':
-        case 'G':
-        case 'H':
-        case 'I':
-        case 'J':
-        case 'K':
-        case 'L':
-        case 'M':
-        case 'N':
-        case 'O':
-        case 'P':
-        case 'Q':
-        case 'R':
-        case 'S':
-        case 'T':
-        case 'U':
-        case 'V':
-        case 'W':
-        case 'X':
-        case 'Y':
-        case 'Z':
-        case 'a':
-        case 'b':
-        case 'c':
-        case 'd':
-        case 'e':
-        case 'f':
-        case 'g':
-        case 'h':
-        case 'i':
-        case 'j':
-        case 'k':
-        case 'l':
-        case 'm':
-        case 'n':
-        case 'o':
-        case 'p':
-        case 'q':
-        case 'r':
-        case 's':
-        case 't':
-        case 'u':
-        case 'v':
-        case 'w':
-        case 'x':
-        case 'y':
-        case 'z':
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-        // mark
-        case '-':
-        case '_':
-        case '.':
-        case '~':
-            result.append(1, *it);
-            break;
-        // escape
-        default: {
-            char first = (*it & 0xF0) / 16;
-            first += first > 9 ? 'A' - 10 : '0';
-            char second = *it & 0x0F;
-            second += second > 9 ? 'A' - 10 : '0';
-
-            result.append(1, '%');
-            result.append(1, first);
-            result.append(1, second);
-            break;
-        }
-        }
-    }
-
-    return result;
-}
-
-std::string escape_uri(const char* str)
-{
-    size_t slen = strlen(str);
-    std::string result;
-    result.reserve(slen + slen / 16);
-
-    for (const char* it = str; *it != 0; ++it)
+    for (tlx::string_view::const_iterator it = str.begin(); it != str.end();
+         ++it)
     {
         switch (*it)
         {

--- a/tlx/string/escape_uri.hpp
+++ b/tlx/string/escape_uri.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_ESCAPE_URI_HEADER
 #define TLX_STRING_ESCAPE_URI_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -22,13 +23,7 @@ namespace tlx {
  * Escape a string into a URI-encoding. This maps all non A-Z0-9 characters to
  * %HH hex representation.
  */
-std::string escape_uri(const std::string& str);
-
-/*!
- * Escape a string into a URI-encoding. This maps all non A-Z0-9 characters to
- * %HH hex representation.
- */
-std::string escape_uri(const char* str);
+std::string escape_uri(tlx::string_view str);
 
 //! \}
 

--- a/tlx/string/expand_environment_variables.cpp
+++ b/tlx/string/expand_environment_variables.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/expand_environment_variables.hpp>
 #include <cctype>
 #include <cstdlib>
@@ -81,9 +82,9 @@ std::string& expand_environment_variables(std::string* sp)
     return s;
 }
 
-std::string expand_environment_variables(const std::string& s)
+std::string expand_environment_variables(tlx::string_view s)
 {
-    std::string copy = s;
+    std::string copy(s.data(), s.size());
     expand_environment_variables(&copy);
     return copy;
 }

--- a/tlx/string/expand_environment_variables.hpp
+++ b/tlx/string/expand_environment_variables.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2018-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_EXPAND_ENVIRONMENT_VARIABLES_HEADER
 #define TLX_STRING_EXPAND_ENVIRONMENT_VARIABLES_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -30,7 +31,7 @@ std::string& expand_environment_variables(std::string* s);
  * variables. Matches all substrings "$[a-zA-Z_][a-zA-Z0-9_]*" and
  * "${[^}]*}". Returns a copy of the string with all substrings replaced.
  */
-std::string expand_environment_variables(const std::string& s);
+std::string expand_environment_variables(tlx::string_view s);
 
 /*!
  * Expand substrings $ABC_123 and ${ABC_123} into the corresponding environment

--- a/tlx/string/extract_between.cpp
+++ b/tlx/string/extract_between.cpp
@@ -3,59 +3,32 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/extract_between.hpp>
-#include <cstring>
 #include <string>
 
 namespace tlx {
 
-template <typename Separator1, typename Separator2>
-static inline std::string extract_between_template(const std::string& str,
-                                                   const Separator1& sep1,
-                                                   size_t sep1_size,
-                                                   const Separator2& sep2)
+std::string extract_between(tlx::string_view str, tlx::string_view sep1,
+                            tlx::string_view sep2)
 {
-    std::string::size_type start = str.find(sep1);
+    std::string::size_type start = str.find(sep1.data(), 0, sep1.size());
     if (start == std::string::npos)
         return std::string();
 
-    start += sep1_size;
+    start += sep1.size();
 
-    std::string::size_type limit = str.find(sep2, start);
+    std::string::size_type limit = str.find(sep2.data(), start, sep2.size());
 
     if (limit == std::string::npos)
         return std::string();
 
-    return str.substr(start, limit - start);
-}
-
-std::string extract_between(const std::string& str, const char* sep1,
-                            const char* sep2)
-{
-    return extract_between_template(str, sep1, std::strlen(sep1), sep2);
-}
-
-std::string extract_between(const std::string& str, const char* sep1,
-                            const std::string& sep2)
-{
-    return extract_between_template(str, sep1, std::strlen(sep1), sep2);
-}
-
-std::string extract_between(const std::string& str, const std::string& sep1,
-                            const char* sep2)
-{
-    return extract_between_template(str, sep1, sep1.size(), sep2);
-}
-
-std::string extract_between(const std::string& str, const std::string& sep1,
-                            const std::string& sep2)
-{
-    return extract_between_template(str, sep1, sep1.size(), sep2);
+    return std::string(str.data() + start, limit - start);
 }
 
 } // namespace tlx

--- a/tlx/string/extract_between.hpp
+++ b/tlx/string/extract_between.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_EXTRACT_BETWEEN_HEADER
 #define TLX_STRING_EXTRACT_BETWEEN_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -27,44 +28,8 @@ namespace tlx {
  * \param sep1  start boundary
  * \param sep2  end boundary
  */
-std::string extract_between(const std::string& str, const char* sep1,
-                            const char* sep2);
-
-/*!
- * Search the string for given start and end separators and extract all
- * characters between the both, if they are found. Otherwise return an empty
- * string.
- *
- * \param str   string to search in
- * \param sep1  start boundary
- * \param sep2  end boundary
- */
-std::string extract_between(const std::string& str, const char* sep1,
-                            const std::string& sep2);
-
-/*!
- * Search the string for given start and end separators and extract all
- * characters between the both, if they are found. Otherwise return an empty
- * string.
- *
- * \param str   string to search in
- * \param sep1  start boundary
- * \param sep2  end boundary
- */
-std::string extract_between(const std::string& str, const std::string& sep1,
-                            const char* sep2);
-
-/*!
- * Search the string for given start and end separators and extract all
- * characters between the both, if they are found. Otherwise return an empty
- * string.
- *
- * \param str   string to search in
- * \param sep1  start boundary
- * \param sep2  end boundary
- */
-std::string extract_between(const std::string& str, const std::string& sep1,
-                            const std::string& sep2);
+std::string extract_between(tlx::string_view str, tlx::string_view sep1,
+                            tlx::string_view sep2);
 
 //! \}
 

--- a/tlx/string/hash_djb2.hpp
+++ b/tlx/string/hash_djb2.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2019-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,9 +11,9 @@
 #ifndef TLX_STRING_HASH_DJB2_HEADER
 #define TLX_STRING_HASH_DJB2_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
-#include <string>
 
 namespace tlx {
 
@@ -73,7 +73,7 @@ static inline std::uint32_t hash_djb2(const char* str, size_t size)
  * Simple, fast, but "insecure" string hash method by Dan Bernstein from
  * http://www.cse.yorku.ca/~oz/hash.html
  */
-static inline std::uint32_t hash_djb2(const std::string& str)
+static inline std::uint32_t hash_djb2(tlx::string_view str)
 {
     return hash_djb2(str.data(), str.size());
 }

--- a/tlx/string/hash_sdbm.hpp
+++ b/tlx/string/hash_sdbm.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2019-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,9 +11,9 @@
 #ifndef TLX_STRING_HASH_SDBM_HEADER
 #define TLX_STRING_HASH_SDBM_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
-#include <string>
 
 namespace tlx {
 
@@ -72,7 +72,7 @@ static inline std::uint32_t hash_sdbm(const char* str, size_t size)
  * Simple, fast, but "insecure" string hash method by sdbm database from
  * http://www.cse.yorku.ca/~oz/hash.html
  */
-static inline std::uint32_t hash_sdbm(const std::string& str)
+static inline std::uint32_t hash_sdbm(tlx::string_view str)
 {
     return hash_sdbm(str.data(), str.size());
 }

--- a/tlx/string/hexdump.cpp
+++ b/tlx/string/hexdump.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/hexdump.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -41,7 +42,7 @@ std::string hexdump(const void* const data, size_t size)
     return out;
 }
 
-std::string hexdump(const std::string& str)
+std::string hexdump(tlx::string_view str)
 {
     return hexdump(str.data(), str.size());
 }
@@ -56,8 +57,7 @@ std::string hexdump(const std::vector<std::uint8_t>& data)
     return hexdump(data.data(), data.size());
 }
 
-std::string hexdump_sourcecode(const std::string& str,
-                               const std::string& var_name)
+std::string hexdump_sourcecode(tlx::string_view str, tlx::string_view var_name)
 {
     std::ostringstream header;
     header << "const std::uint8_t " << var_name << "[" << str.size()
@@ -73,7 +73,7 @@ std::string hexdump_sourcecode(const std::string& str,
 
     std::string::size_type ci = 0;
 
-    for (std::string::const_iterator si = str.begin(); si != str.end();
+    for (tlx::string_view::const_iterator si = str.begin(); si != str.end();
          ++si, ++ci)
     {
         out += "0x";
@@ -117,7 +117,7 @@ std::string hexdump_lc(const void* const data, size_t size)
     return out;
 }
 
-std::string hexdump_lc(const std::string& str)
+std::string hexdump_lc(tlx::string_view str)
 {
     return hexdump_lc(str.data(), str.size());
 }
@@ -135,11 +135,12 @@ std::string hexdump_lc(const std::vector<std::uint8_t>& data)
 /******************************************************************************/
 // Parser for Hex Digit Sequence
 
-std::string parse_hexdump(const std::string& str)
+std::string parse_hexdump(tlx::string_view str)
 {
     std::string out;
 
-    for (std::string::const_iterator si = str.begin(); si != str.end(); ++si)
+    for (tlx::string_view::const_iterator si = str.begin(); si != str.end();
+         ++si)
     {
         unsigned char c = 0;
 

--- a/tlx/string/hexdump.hpp
+++ b/tlx/string/hexdump.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_HEXDUMP_HEADER
 #define TLX_STRING_HEXDUMP_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -41,7 +42,7 @@ std::string hexdump(const void* const data, size_t size);
  * \param str  binary data to output in hex
  * \return     string of hexadecimal pairs
  */
-std::string hexdump(const std::string& str);
+std::string hexdump(tlx::string_view str);
 
 /*!
  * Dump a (binary) item as a sequence of uppercase hexadecimal pairs.
@@ -79,8 +80,8 @@ std::string hexdump(const std::vector<std::uint8_t>& data);
  * \param var_name  name of the array variable in the outputted code snippet
  * \return          string holding C source snippet
  */
-std::string hexdump_sourcecode(const std::string& str,
-                               const std::string& var_name = "name");
+std::string hexdump_sourcecode(tlx::string_view str,
+                               tlx::string_view var_name = "name");
 
 /******************************************************************************/
 // Lowercase Hexdump Methods
@@ -100,7 +101,7 @@ std::string hexdump_lc(const void* const data, size_t size);
  * \param str  binary data to output in hex
  * \return     string of hexadecimal pairs
  */
-std::string hexdump_lc(const std::string& str);
+std::string hexdump_lc(tlx::string_view str);
 
 /*!
  * Dump a (binary) item as a sequence of lowercase hexadecimal pairs.
@@ -141,7 +142,7 @@ std::string hexdump_lc(const std::vector<std::uint8_t>& data);
  * \param str  string to parse as hex digits
  * \return     string of read bytes
  */
-std::string parse_hexdump(const std::string& str);
+std::string parse_hexdump(tlx::string_view str);
 
 //! \}
 //! \}

--- a/tlx/string/index_of.cpp
+++ b/tlx/string/index_of.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/equal_icase.hpp>
 #include <tlx/string/index_of.hpp>
 #include <cstddef>
@@ -17,7 +18,7 @@
 
 namespace tlx {
 
-size_t index_of(const std::vector<std::string>& list, const char* str)
+size_t index_of(const std::vector<std::string>& list, tlx::string_view str)
 {
     for (size_t i = 0; i < list.size(); ++i)
     {
@@ -25,36 +26,12 @@ size_t index_of(const std::vector<std::string>& list, const char* str)
             return i;
     }
     std::string reason = "Could not find index_of() ";
-    reason += str;
-    throw std::runtime_error(reason);
-}
-
-size_t index_of(const std::vector<std::string>& list, const std::string& str)
-{
-    for (size_t i = 0; i < list.size(); ++i)
-    {
-        if (list[i] == str)
-            return i;
-    }
-    std::string reason = "Could not find index_of() ";
-    reason += str;
-    throw std::runtime_error(reason);
-}
-
-size_t index_of_icase(const std::vector<std::string>& list, const char* str)
-{
-    for (size_t i = 0; i < list.size(); ++i)
-    {
-        if (tlx::equal_icase(list[i], str))
-            return i;
-    }
-    std::string reason = "Could not find index_of_icase() ";
-    reason += str;
+    reason.append(str.begin(), str.end());
     throw std::runtime_error(reason);
 }
 
 size_t index_of_icase(const std::vector<std::string>& list,
-                      const std::string& str)
+                      tlx::string_view str)
 {
     for (size_t i = 0; i < list.size(); ++i)
     {
@@ -62,7 +39,7 @@ size_t index_of_icase(const std::vector<std::string>& list,
             return i;
     }
     std::string reason = "Could not find index_of_icase() ";
-    reason += str;
+    reason.append(str.begin(), str.end());
     throw std::runtime_error(reason);
 }
 

--- a/tlx/string/index_of.hpp
+++ b/tlx/string/index_of.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_INDEX_OF_HEADER
 #define TLX_STRING_INDEX_OF_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -24,26 +25,14 @@ namespace tlx {
  * Attempts to find str in the list and return the index. Throws a
  * std::runtime_error if it is not found.
  */
-size_t index_of(const std::vector<std::string>& list, const char* str);
-
-/*!
- * Attempts to find str in the list and return the index. Throws a
- * std::runtime_error if it is not found.
- */
-size_t index_of(const std::vector<std::string>& list, const std::string& str);
-
-/*!
- * Attempts to find str in the list and return the index using case-insensitive
- * comparisons. Throws a std::runtime_error if it is not found.
- */
-size_t index_of_icase(const std::vector<std::string>& list, const char* str);
+size_t index_of(const std::vector<std::string>& list, tlx::string_view str);
 
 /*!
  * Attempts to find str in the list and return the index using case-insensitive
  * comparisons. Throws a std::runtime_error if it is not found.
  */
 size_t index_of_icase(const std::vector<std::string>& list,
-                      const std::string& str);
+                      tlx::string_view str);
 
 //! \}
 

--- a/tlx/string/join.cpp
+++ b/tlx/string/join.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/join.hpp>
 #include <tlx/string/join_generic.hpp>
 #include <string>
@@ -25,7 +26,7 @@ std::string join(const char* glue, const std::vector<std::string>& parts)
     return join(glue, parts.begin(), parts.end());
 }
 
-std::string join(const std::string& glue, const std::vector<std::string>& parts)
+std::string join(tlx::string_view glue, const std::vector<std::string>& parts)
 {
     return join(glue, parts.begin(), parts.end());
 }

--- a/tlx/string/join.hpp
+++ b/tlx/string/join.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_JOIN_HEADER
 #define TLX_STRING_JOIN_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 #include <vector>
 
@@ -52,8 +53,7 @@ std::string join(const char* glue, const std::vector<std::string>& parts);
  * \param parts    the vector of strings to join
  * \return string  constructed from the vector with the glue between two strings
  */
-std::string join(const std::string& glue,
-                 const std::vector<std::string>& parts);
+std::string join(tlx::string_view glue, const std::vector<std::string>& parts);
 
 //! \}
 //! \}

--- a/tlx/string/join_generic.hpp
+++ b/tlx/string/join_generic.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_JOIN_GENERIC_HEADER
 #define TLX_STRING_JOIN_GENERIC_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <sstream>
 #include <string>
 
@@ -73,21 +74,7 @@ static inline std::string join(char glue, const Container& parts)
  * \return string  constructed from the vector with the glue between two strings
  */
 template <typename Container>
-static inline std::string join(const char* glue, const Container& parts)
-{
-    return join(glue, std::begin(parts), std::end(parts));
-}
-
-/*!
- * Join a Container of strings by some glue string between each pair from the
- * sequence.
- *
- * \param glue     string to glue
- * \param parts    the vector of strings to join
- * \return string  constructed from the vector with the glue between two strings
- */
-template <typename Container>
-static inline std::string join(const std::string& glue, const Container& parts)
+static inline std::string join(tlx::string_view glue, const Container& parts)
 {
     return join(glue, std::begin(parts), std::end(parts));
 }

--- a/tlx/string/less_icase.cpp
+++ b/tlx/string/less_icase.cpp
@@ -3,15 +3,15 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/less_icase.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
-#include <string>
 
 namespace tlx {
 
@@ -30,9 +30,9 @@ bool less_icase(const char* a, const char* b)
     return to_lower(*a) < to_lower(*b);
 }
 
-bool less_icase(const char* a, const std::string& b)
+bool less_icase(const char* a, tlx::string_view b)
 {
-    std::string::const_iterator bi = b.begin();
+    tlx::string_view::const_iterator bi = b.begin();
 
     while (*a != 0 && bi != b.end() && to_lower(*a) == to_lower(*bi))
         ++a, ++bi;
@@ -47,9 +47,9 @@ bool less_icase(const char* a, const std::string& b)
     return to_lower(*a) < to_lower(*bi);
 }
 
-bool less_icase(const std::string& a, const char* b)
+bool less_icase(tlx::string_view a, const char* b)
 {
-    std::string::const_iterator ai = a.begin();
+    tlx::string_view::const_iterator ai = a.begin();
 
     while (ai != a.end() && *b != 0 && to_lower(*ai) == to_lower(*b))
         ++ai, ++b;
@@ -64,7 +64,7 @@ bool less_icase(const std::string& a, const char* b)
     return to_lower(*ai) < to_lower(*b);
 }
 
-bool less_icase(const std::string& a, const std::string& b)
+bool less_icase(tlx::string_view a, tlx::string_view b)
 {
     return std::lexicographical_compare(
         a.begin(), a.end(), b.begin(), b.end(),

--- a/tlx/string/less_icase.hpp
+++ b/tlx/string/less_icase.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_LESS_ICASE_HEADER
 #define TLX_STRING_LESS_ICASE_HEADER
 
-#include <string>
+#include <tlx/container/string_view.hpp>
 
 namespace tlx {
 
@@ -25,13 +25,13 @@ namespace tlx {
 bool less_icase(const char* a, const char* b);
 
 //! returns true if a < b without regard for letter case
-bool less_icase(const char* a, const std::string& b);
+bool less_icase(const char* a, tlx::string_view b);
 
 //! returns true if a < b without regard for letter case
-bool less_icase(const std::string& a, const char* b);
+bool less_icase(tlx::string_view a, const char* b);
 
 //! returns true if a < b without regard for letter case
-bool less_icase(const std::string& a, const std::string& b);
+bool less_icase(tlx::string_view a, tlx::string_view b);
 
 /******************************************************************************/
 // order_less_icase: case-insensitive order relation functional classes
@@ -39,7 +39,7 @@ bool less_icase(const std::string& a, const std::string& b);
 //! Case-insensitive less order relation functional class for std::map, etc.
 struct less_icase_asc
 {
-    bool operator()(const std::string& a, const std::string& b) const
+    bool operator()(tlx::string_view a, tlx::string_view b) const
     {
         return less_icase(a, b);
     }
@@ -49,7 +49,7 @@ struct less_icase_asc
 //! std::map, etc.
 struct less_icase_desc
 {
-    bool operator()(const std::string& a, const std::string& b) const
+    bool operator()(tlx::string_view a, tlx::string_view b) const
     {
         return !less_icase(a, b);
     }

--- a/tlx/string/levenshtein.hpp
+++ b/tlx/string/levenshtein.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -12,10 +12,10 @@
 #define TLX_STRING_LEVENSHTEIN_HEADER
 
 #include <tlx/container/simple_vector.hpp>
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
 #include <cstring>
-#include <string>
 
 namespace tlx {
 
@@ -163,7 +163,7 @@ static inline size_t levenshtein_icase(const char* a, const char* b)
  * \param b     second string
  * \return      Levenshtein distance
  */
-static inline size_t levenshtein(const std::string& a, const std::string& b)
+static inline size_t levenshtein(tlx::string_view a, tlx::string_view b)
 {
     return levenshtein_algorithm<LevenshteinStandardParameters>(
         a.data(), a.size(), b.data(), b.size());
@@ -178,8 +178,7 @@ static inline size_t levenshtein(const std::string& a, const std::string& b)
  * \param b     second string
  * \return      Levenshtein distance
  */
-static inline size_t levenshtein_icase(const std::string& a,
-                                       const std::string& b)
+static inline size_t levenshtein_icase(tlx::string_view a, tlx::string_view b)
 {
     return levenshtein_algorithm<LevenshteinStandardICaseParameters>(
         a.data(), a.size(), b.data(), b.size());

--- a/tlx/string/pad.cpp
+++ b/tlx/string/pad.cpp
@@ -3,22 +3,26 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/pad.hpp>
+#include <algorithm>
 #include <cstddef>
 #include <string>
 
 namespace tlx {
 
-std::string pad(const std::string& s, size_t len, char pad_char)
+std::string pad(tlx::string_view str, size_t len, char pad_char)
 {
-    std::string str = s;
-    str.resize(len, pad_char);
-    return str;
+    std::string str_copy;
+    str_copy.reserve(len);
+    str_copy.assign(str.data(), std::min(str.size(), len));
+    str_copy.resize(len, pad_char);
+    return str_copy;
 }
 
 } // namespace tlx

--- a/tlx/string/pad.hpp
+++ b/tlx/string/pad.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_PAD_HEADER
 #define TLX_STRING_PAD_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstddef>
 #include <string>
 
@@ -21,8 +22,13 @@ namespace tlx {
 
 /*!
  * Truncate or pad string to exactly len characters.
+ *
+ * \param str      string to process
+ * \param len      length of the string to pad to
+ * \param pad_char character to pad string with
+ * \return         copy of the modified string
  */
-std::string pad(const std::string& s, size_t len, char pad_char = ' ');
+std::string pad(tlx::string_view str, size_t len, char pad_char = ' ');
 
 //! \}
 

--- a/tlx/string/parse_uri.hpp
+++ b/tlx/string/parse_uri.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2020 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2020-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -12,7 +12,6 @@
 #define TLX_STRING_PARSE_URI_HEADER
 
 #include <tlx/container/string_view.hpp>
-#include <string>
 
 namespace tlx {
 
@@ -24,18 +23,17 @@ namespace tlx {
  * parts path, query_string, and fragment. The parts are returned as
  * tlx::string_views to avoid copying data.
  */
-static inline void parse_uri(const char* uri, tlx::string_view* path,
+static inline void parse_uri(tlx::string_view uri, tlx::string_view* path,
                              tlx::string_view* query_string,
                              tlx::string_view* fragment)
 {
-    const char* c = uri;
+    tlx::string_view::const_iterator c = uri.begin(), e = uri.end();
 
     // find path part
-    const char* begin = c;
-    while (*c != '?' && *c != '#' && *c != 0)
-    {
+    tlx::string_view::const_iterator begin = c;
+    while (c != e && *c != '?' && *c != '#')
         ++c;
-    }
+
     *path = tlx::string_view(begin, c - begin);
 
     // find query string
@@ -43,10 +41,8 @@ static inline void parse_uri(const char* uri, tlx::string_view* path,
     if (*c == '?')
     {
         begin = ++c;
-        while (*c != '#' && *c != 0)
-        {
+        while (c != e && *c != '#')
             ++c;
-        }
     }
     *query_string = tlx::string_view(begin, c - begin);
 
@@ -55,24 +51,10 @@ static inline void parse_uri(const char* uri, tlx::string_view* path,
     if (*c == '#')
     {
         begin = ++c;
-        while (*c != 0)
-        {
+        while (c != e)
             ++c;
-        }
     }
     *fragment = tlx::string_view(begin, c - begin);
-}
-
-/*!
- * Parse a URI like "/path1/path2?query=string&submit=submit#fragment" into the
- * parts path, query_string, and fragment. The parts are returned as
- * tlx::string_views to avoid copying data.
- */
-static inline void parse_uri(const std::string& uri, tlx::string_view* path,
-                             tlx::string_view* query_string,
-                             tlx::string_view* fragment)
-{
-    return parse_uri(uri.c_str(), path, query_string, fragment);
 }
 
 //! \}

--- a/tlx/string/parse_uri_form_data.hpp
+++ b/tlx/string/parse_uri_form_data.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2020 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2020-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_PARSE_URI_FORM_DATA_HEADER
 #define TLX_STRING_PARSE_URI_FORM_DATA_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <cstring>
 #include <string>
 #include <utility>
@@ -25,20 +26,19 @@ namespace tlx {
  * Helper function to decode %20 and + in urlencoded form data like
  * "query=string+with+spaces&submit=yes%21&".
  */
-static inline std::string parse_uri_form_data_decode(const char* str,
-                                                     const char* end = nullptr)
+static inline std::string parse_uri_form_data_decode(tlx::string_view str)
 {
-    std::string out;
-    if (end == nullptr)
-        out.reserve(strlen(str));
-    else
-        out.reserve(end - str);
-    char a, b;
+    tlx::string_view::const_iterator s = str.begin();
+    const tlx::string_view::const_iterator end = str.end();
 
-    while (*str != 0 && str != end)
+    std::string out;
+    out.reserve(str.size());
+
+    while (s != end)
     {
-        if (*str == '%' && (a = str[1]) != 0 && (b = str[2]) != 0)
+        if (*s == '%' && s + 2 < end)
         {
+            char a = s[1], b = s[2];
             if (a >= '0' && a <= '9')
                 a -= '0';
             else if (a >= 'a' && a <= 'f')
@@ -48,7 +48,7 @@ static inline std::string parse_uri_form_data_decode(const char* str,
             else
             {
                 // invalid hex digits, copy '%' and continue
-                out += *str++;
+                out += *s++;
                 continue;
             }
 
@@ -61,21 +61,21 @@ static inline std::string parse_uri_form_data_decode(const char* str,
             else
             {
                 // invalid hex digits, copy '%' and continue
-                out += *str++;
+                out += *s++;
                 continue;
             }
 
             out += static_cast<char>(16 * a + b);
-            str += 3;
+            s += 3;
         }
-        else if (*str == '+')
+        else if (*s == '+')
         {
             out += ' ';
-            str++;
+            s++;
         }
         else
         {
-            out += *str++;
+            out += *s++;
         }
     }
     return out;
@@ -86,27 +86,26 @@ static inline std::string parse_uri_form_data_decode(const char* str,
  * into a list of keys and values. The keys and values are returned as pairs in
  * the two vectors, to avoid using std::pair or another struct.
  */
-static inline void parse_uri_form_data(const char* query_string,
+static inline void parse_uri_form_data(tlx::string_view query_string,
                                        std::vector<std::string>* key,
                                        std::vector<std::string>* value)
 {
     key->clear(), value->clear();
-    const char* c = query_string;
+    tlx::string_view::const_iterator c = query_string.begin(),
+                                     e = query_string.end();
 
-    while (*c != 0)
+    while (c != e)
     {
-        const char* begin = c;
-        while (*c != '=' && *c != 0)
-        {
+        tlx::string_view::const_iterator begin = c;
+        while (c != e && *c != '=')
             ++c;
-        }
 
         if (c == begin)
             return;
 
-        std::string k = parse_uri_form_data_decode(begin, c);
+        std::string k = parse_uri_form_data_decode(tlx::string_view(begin, c));
 
-        if (*c == 0)
+        if (c == e)
         {
             key->emplace_back(std::move(k));
             value->emplace_back(std::string());
@@ -114,12 +113,10 @@ static inline void parse_uri_form_data(const char* query_string,
         }
 
         begin = ++c;
-        while (*c != '&' && *c != 0)
-        {
+        while (c != e && *c != '&')
             ++c;
-        }
 
-        std::string v = parse_uri_form_data_decode(begin, c);
+        std::string v = parse_uri_form_data_decode(tlx::string_view(begin, c));
 
         key->emplace_back(std::move(k));
         value->emplace_back(std::move(v));
@@ -128,18 +125,6 @@ static inline void parse_uri_form_data(const char* query_string,
             break;
         ++c;
     }
-}
-
-/*!
- * Parse a urlencoded form data like "query=string+with+spaces&submit=yes%21&"
- * into a list of keys and values. The keys and values are returned as pairs in
- * the two vectors, to avoid using std::pair or another struct.
- */
-static inline void parse_uri_form_data(const std::string& query_string,
-                                       std::vector<std::string>* key,
-                                       std::vector<std::string>* value)
-{
-    return parse_uri_form_data(query_string.c_str(), key, value);
 }
 
 //! \}

--- a/tlx/string/replace.cpp
+++ b/tlx/string/replace.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/replace.hpp>
 #include <cstring>
 #include <string>
@@ -17,46 +18,14 @@ namespace tlx {
 /******************************************************************************/
 // replace_first() in-place
 
-std::string& replace_first(std::string* str, const std::string& needle,
-                           const std::string& instead)
+std::string& replace_first(std::string* str, tlx::string_view needle,
+                           tlx::string_view instead)
 {
-    std::string::size_type firstpos = str->find(needle);
+    std::string::size_type firstpos =
+        str->find(needle.data(), 0, needle.size());
 
     if (firstpos != std::string::npos)
-        str->replace(firstpos, needle.size(), instead);
-
-    return *str;
-}
-
-std::string& replace_first(std::string* str, const std::string& needle,
-                           const char* instead)
-{
-    std::string::size_type firstpos = str->find(needle);
-
-    if (firstpos != std::string::npos)
-        str->replace(firstpos, needle.size(), instead);
-
-    return *str;
-}
-
-std::string& replace_first(std::string* str, const char* needle,
-                           const std::string& instead)
-{
-    std::string::size_type firstpos = str->find(needle);
-
-    if (firstpos != std::string::npos)
-        str->replace(firstpos, strlen(needle), instead);
-
-    return *str;
-}
-
-std::string& replace_first(std::string* str, const char* needle,
-                           const char* instead)
-{
-    std::string::size_type firstpos = str->find(needle);
-
-    if (firstpos != std::string::npos)
-        str->replace(firstpos, strlen(needle), instead);
+        str->replace(firstpos, needle.size(), instead.data(), instead.size());
 
     return *str;
 }
@@ -74,57 +43,22 @@ std::string& replace_first(std::string* str, char needle, char instead)
 /******************************************************************************/
 // replace_first() copy
 
-std::string replace_first(const std::string& str, const std::string& needle,
-                          const std::string& instead)
+std::string replace_first(tlx::string_view str, tlx::string_view needle,
+                          tlx::string_view instead)
 {
-    std::string newstr = str;
-    std::string::size_type firstpos = newstr.find(needle);
+    std::string newstr(str.data(), str.size());
+    std::string::size_type firstpos =
+        newstr.find(needle.data(), 0, needle.size());
 
     if (firstpos != std::string::npos)
-        newstr.replace(firstpos, needle.size(), instead);
+        newstr.replace(firstpos, needle.size(), instead.data(), instead.size());
 
     return newstr;
 }
 
-std::string replace_first(const std::string& str, const std::string& needle,
-                          const char* instead)
+std::string replace_first(tlx::string_view str, char needle, char instead)
 {
-    std::string newstr = str;
-    std::string::size_type firstpos = newstr.find(needle);
-
-    if (firstpos != std::string::npos)
-        newstr.replace(firstpos, needle.size(), instead);
-
-    return newstr;
-}
-
-std::string replace_first(const std::string& str, const char* needle,
-                          const std::string& instead)
-{
-    std::string newstr = str;
-    std::string::size_type firstpos = newstr.find(needle);
-
-    if (firstpos != std::string::npos)
-        newstr.replace(firstpos, strlen(needle), instead);
-
-    return newstr;
-}
-
-std::string replace_first(const std::string& str, const char* needle,
-                          const char* instead)
-{
-    std::string newstr = str;
-    std::string::size_type firstpos = newstr.find(needle);
-
-    if (firstpos != std::string::npos)
-        newstr.replace(firstpos, strlen(needle), instead);
-
-    return newstr;
-}
-
-std::string replace_first(const std::string& str, char needle, char instead)
-{
-    std::string newstr = str;
+    std::string newstr(str.data(), str.size());
     std::string::size_type firstpos = newstr.find(needle);
 
     if (firstpos != std::string::npos)
@@ -136,58 +70,16 @@ std::string replace_first(const std::string& str, char needle, char instead)
 /******************************************************************************/
 // replace_all() in-place
 
-std::string& replace_all(std::string* str, const std::string& needle,
-                         const std::string& instead)
+std::string& replace_all(std::string* str, tlx::string_view needle,
+                         tlx::string_view instead)
 {
     std::string::size_type lastpos = 0, thispos;
 
-    while ((thispos = str->find(needle, lastpos)) != std::string::npos)
+    while ((thispos = str->find(needle.data(), lastpos, needle.size())) !=
+           std::string::npos)
     {
-        str->replace(thispos, needle.size(), instead);
+        str->replace(thispos, needle.size(), instead.data(), instead.size());
         lastpos = thispos + instead.size();
-    }
-    return *str;
-}
-
-std::string& replace_all(std::string* str, const std::string& needle,
-                         const char* instead)
-{
-    std::string::size_type lastpos = 0, thispos;
-    size_t instead_size = strlen(instead);
-
-    while ((thispos = str->find(needle, lastpos)) != std::string::npos)
-    {
-        str->replace(thispos, needle.size(), instead);
-        lastpos = thispos + instead_size;
-    }
-    return *str;
-}
-
-std::string& replace_all(std::string* str, const char* needle,
-                         const std::string& instead)
-{
-    std::string::size_type lastpos = 0, thispos;
-    size_t needle_size = strlen(needle);
-
-    while ((thispos = str->find(needle, lastpos)) != std::string::npos)
-    {
-        str->replace(thispos, needle_size, instead);
-        lastpos = thispos + instead.size();
-    }
-    return *str;
-}
-
-std::string& replace_all(std::string* str, const char* needle,
-                         const char* instead)
-{
-    std::string::size_type lastpos = 0, thispos;
-    size_t needle_size = strlen(needle);
-    size_t instead_size = strlen(instead);
-
-    while ((thispos = str->find(needle, lastpos)) != std::string::npos)
-    {
-        str->replace(thispos, needle_size, instead);
-        lastpos = thispos + instead_size;
     }
     return *str;
 }
@@ -207,69 +99,24 @@ std::string& replace_all(std::string* str, char needle, char instead)
 /******************************************************************************/
 // replace_all() copy
 
-std::string replace_all(const std::string& str, const std::string& needle,
-                        const std::string& instead)
+std::string replace_all(tlx::string_view str, tlx::string_view needle,
+                        tlx::string_view instead)
 {
-    std::string newstr = str;
+    std::string newstr(str.data(), str.size());
     std::string::size_type lastpos = 0, thispos;
 
-    while ((thispos = newstr.find(needle, lastpos)) != std::string::npos)
+    while ((thispos = newstr.find(needle.data(), lastpos, needle.size())) !=
+           std::string::npos)
     {
-        newstr.replace(thispos, needle.size(), instead);
+        newstr.replace(thispos, needle.size(), instead.data(), instead.size());
         lastpos = thispos + instead.size();
     }
     return newstr;
 }
 
-std::string replace_all(const std::string& str, const std::string& needle,
-                        const char* instead)
+std::string replace_all(tlx::string_view str, char needle, char instead)
 {
-    std::string newstr = str;
-    std::string::size_type lastpos = 0, thispos;
-    size_t instead_size = strlen(instead);
-
-    while ((thispos = newstr.find(needle, lastpos)) != std::string::npos)
-    {
-        newstr.replace(thispos, needle.size(), instead);
-        lastpos = thispos + instead_size;
-    }
-    return newstr;
-}
-
-std::string replace_all(const std::string& str, const char* needle,
-                        const std::string& instead)
-{
-    std::string newstr = str;
-    std::string::size_type lastpos = 0, thispos;
-    size_t needle_size = strlen(needle);
-
-    while ((thispos = newstr.find(needle, lastpos)) != std::string::npos)
-    {
-        newstr.replace(thispos, needle_size, instead);
-        lastpos = thispos + instead.size();
-    }
-    return newstr;
-}
-
-std::string replace_all(const std::string& str, const char* needle,
-                        const char* instead)
-{
-    std::string newstr = str;
-    std::string::size_type lastpos = 0, thispos;
-    size_t needle_size = strlen(needle);
-    size_t instead_size = strlen(instead);
-
-    while ((thispos = newstr.find(needle, lastpos)) != std::string::npos)
-    {
-        newstr.replace(thispos, needle_size, instead);
-        lastpos = thispos + instead_size;
-    }
-    return newstr;
-}
-
-std::string replace_all(const std::string& str, char needle, char instead)
-{
-    std::string newstr = str;
+    std::string newstr(str.data(), str.size());
     std::string::size_type lastpos = 0, thispos;
 
     while ((thispos = newstr.find(needle, lastpos)) != std::string::npos)

--- a/tlx/string/replace.hpp
+++ b/tlx/string/replace.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_REPLACE_HEADER
 #define TLX_STRING_REPLACE_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -33,47 +34,8 @@ namespace tlx {
  * \param instead       replace needle with instead
  * \return              reference to str
  */
-std::string& replace_first(std::string* str, const std::string& needle,
-                           const std::string& instead);
-
-/*!
- * Replace only the first occurrence of needle in str. The needle will be
- * replaced with instead, if found. The replacement is done in the given string
- * and a reference to the same is returned.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              reference to str
- */
-std::string& replace_first(std::string* str, const std::string& needle,
-                           const char* instead);
-
-/*!
- * Replace only the first occurrence of needle in str. The needle will be
- * replaced with instead, if found. The replacement is done in the given string
- * and a reference to the same is returned.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              reference to str
- */
-std::string& replace_first(std::string* str, const char* needle,
-                           const std::string& instead);
-
-/*!
- * Replace only the first occurrence of needle in str. The needle will be
- * replaced with instead, if found. The replacement is done in the given string
- * and a reference to the same is returned.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              reference to str
- */
-std::string& replace_first(std::string* str, const char* needle,
-                           const char* instead);
+std::string& replace_first(std::string* str, tlx::string_view needle,
+                           tlx::string_view instead);
 
 /*!
  * Replace only the first occurrence of needle in str. The needle will be
@@ -100,47 +62,8 @@ std::string& replace_first(std::string* str, char needle, char instead);
  * \param instead       replace needle with instead
  * \return              copy of string possibly with replacement
  */
-std::string replace_first(const std::string& str, const std::string& needle,
-                          const std::string& instead);
-
-/*!
- * Replace only the first occurrence of needle in str. The needle will be
- * replaced with instead, if found. Returns a copy of the string with the
- * possible replacement.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              copy of string possibly with replacement
- */
-std::string replace_first(const std::string& str, const std::string& needle,
-                          const char* instead);
-
-/*!
- * Replace only the first occurrence of needle in str. The needle will be
- * replaced with instead, if found. Returns a copy of the string with the
- * possible replacement.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              copy of string possibly with replacement
- */
-std::string replace_first(const std::string& str, const char* needle,
-                          const std::string& instead);
-
-/*!
- * Replace only the first occurrence of needle in str. The needle will be
- * replaced with instead, if found. Returns a copy of the string with the
- * possible replacement.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              copy of string possibly with replacement
- */
-std::string replace_first(const std::string& str, const char* needle,
-                          const char* instead);
+std::string replace_first(tlx::string_view str, tlx::string_view needle,
+                          tlx::string_view instead);
 
 /*!
  * Replace only the first occurrence of needle in str. The needle will be
@@ -152,7 +75,7 @@ std::string replace_first(const std::string& str, const char* needle,
  * \param instead       replace needle with instead
  * \return              copy of string possibly with replacement
  */
-std::string replace_first(const std::string& str, char needle, char instead);
+std::string replace_first(tlx::string_view str, char needle, char instead);
 
 /******************************************************************************/
 // replace_all() in-place
@@ -167,47 +90,8 @@ std::string replace_first(const std::string& str, char needle, char instead);
  * \param instead       replace needle with instead
  * \return              reference to str
  */
-std::string& replace_all(std::string* str, const std::string& needle,
-                         const std::string& instead);
-
-/*!
- * Replace all occurrences of needle in str. Each needle will be replaced with
- * instead, if found. The replacement is done in the given string and a
- * reference to the same is returned.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              reference to str
- */
-std::string& replace_all(std::string* str, const std::string& needle,
-                         const char* instead);
-
-/*!
- * Replace all occurrences of needle in str. Each needle will be replaced with
- * instead, if found. The replacement is done in the given string and a
- * reference to the same is returned.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              reference to str
- */
-std::string& replace_all(std::string* str, const char* needle,
-                         const std::string& instead);
-
-/*!
- * Replace all occurrences of needle in str. Each needle will be replaced with
- * instead, if found. The replacement is done in the given string and a
- * reference to the same is returned.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              reference to str
- */
-std::string& replace_all(std::string* str, const char* needle,
-                         const char* instead);
+std::string& replace_all(std::string* str, tlx::string_view needle,
+                         tlx::string_view instead);
 
 /*!
  * Replace all occurrences of needle in str. Each needle will be replaced with
@@ -233,44 +117,8 @@ std::string& replace_all(std::string* str, char needle, char instead);
  * \param instead       replace needle with instead
  * \return              copy of string possibly with replacements
  */
-std::string replace_all(const std::string& str, const std::string& needle,
-                        const std::string& instead);
-
-/*!
- * Replace all occurrences of needle in str. Each needle will be replaced with
- * instead, if found. Returns a copy of the string with possible replacements.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              copy of string possibly with replacements
- */
-std::string replace_all(const std::string& str, const std::string& needle,
-                        const char* instead);
-
-/*!
- * Replace all occurrences of needle in str. Each needle will be replaced with
- * instead, if found. Returns a copy of the string with possible replacements.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              copy of string possibly with replacements
- */
-std::string replace_all(const std::string& str, const char* needle,
-                        const std::string& instead);
-
-/*!
- * Replace all occurrences of needle in str. Each needle will be replaced with
- * instead, if found. Returns a copy of the string with possible replacements.
- *
- * \param str           the string to process
- * \param needle        string to search for in str
- * \param instead       replace needle with instead
- * \return              copy of string possibly with replacements
- */
-std::string replace_all(const std::string& str, const char* needle,
-                        const char* instead);
+std::string replace_all(tlx::string_view str, tlx::string_view needle,
+                        tlx::string_view instead);
 
 /*!
  * Replace all occurrences of needle in str. Each needle will be replaced with
@@ -281,7 +129,7 @@ std::string replace_all(const std::string& str, const char* needle,
  * \param instead       replace needle with instead
  * \return              copy of string possibly with replacements
  */
-std::string replace_all(const std::string& str, char needle, char instead);
+std::string replace_all(tlx::string_view str, char needle, char instead);
 
 //! \}
 //! \}

--- a/tlx/string/split.cpp
+++ b/tlx/string/split.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/split.hpp>
 #include <algorithm>
 #include <cstring>
@@ -19,7 +20,7 @@ namespace tlx {
 /******************************************************************************/
 // split() returning std::vector<std::string>
 
-std::vector<std::string> split(char sep, const std::string& str,
+std::vector<std::string> split(char sep, tlx::string_view str,
                                std::string::size_type limit)
 {
     // call base method with new std::vector
@@ -28,16 +29,7 @@ std::vector<std::string> split(char sep, const std::string& str,
     return out;
 }
 
-std::vector<std::string> split(const char* sep, const std::string& str,
-                               std::string::size_type limit)
-{
-    // call base method with new std::vector
-    std::vector<std::string> out;
-    split(&out, sep, str, limit);
-    return out;
-}
-
-std::vector<std::string> split(const std::string& sep, const std::string& str,
+std::vector<std::string> split(tlx::string_view sep, tlx::string_view str,
                                std::string::size_type limit)
 {
     // call base method with new std::vector
@@ -49,7 +41,7 @@ std::vector<std::string> split(const std::string& sep, const std::string& str,
 /******************************************************************************/
 // split() returning std::vector<std::string> with minimum fields
 
-std::vector<std::string> split(char sep, const std::string& str,
+std::vector<std::string> split(char sep, tlx::string_view str,
                                std::string::size_type min_fields,
                                std::string::size_type limit)
 {
@@ -59,17 +51,7 @@ std::vector<std::string> split(char sep, const std::string& str,
     return out;
 }
 
-std::vector<std::string> split(const char* sep, const std::string& str,
-                               std::string::size_type min_fields,
-                               std::string::size_type limit)
-{
-    // call base method with new std::vector
-    std::vector<std::string> out;
-    split(&out, sep, str, min_fields, limit);
-    return out;
-}
-
-std::vector<std::string> split(const std::string& sep, const std::string& str,
+std::vector<std::string> split(tlx::string_view sep, tlx::string_view str,
                                std::string::size_type min_fields,
                                std::string::size_type limit)
 {
@@ -83,14 +65,14 @@ std::vector<std::string> split(const std::string& sep, const std::string& str,
 // split() into std::vector<std::string>
 
 std::vector<std::string>& split(std::vector<std::string>* into, char sep,
-                                const std::string& str,
+                                tlx::string_view str,
                                 std::string::size_type limit)
 {
     into->clear();
     if (limit == 0)
         return *into;
 
-    std::string::const_iterator it = str.begin(), last = it;
+    tlx::string_view::const_iterator it = str.begin(), last = it;
 
     for (; it != str.end(); ++it)
     {
@@ -112,18 +94,17 @@ std::vector<std::string>& split(std::vector<std::string>* into, char sep,
     return *into;
 }
 
-static inline std::vector<std::string>& split(std::vector<std::string>* into,
-                                              const char* sep, size_t sep_size,
-                                              const std::string& str,
-                                              std::string::size_type limit)
+std::vector<std::string>& split(std::vector<std::string>* into,
+                                tlx::string_view sep, tlx::string_view str,
+                                std::string::size_type limit)
 {
     into->clear();
     if (limit == 0)
         return *into;
 
-    if (sep_size == 0)
+    if (sep.empty())
     {
-        std::string::const_iterator it = str.begin();
+        tlx::string_view::const_iterator it = str.begin();
         while (it != str.end())
         {
             into->emplace_back(it, it + 1);
@@ -132,11 +113,11 @@ static inline std::vector<std::string>& split(std::vector<std::string>* into,
         return *into;
     }
 
-    std::string::const_iterator it = str.begin(), last = it;
+    tlx::string_view::const_iterator it = str.begin(), last = it;
 
-    for (; it + sep_size < str.end(); ++it)
+    for (; it + sep.size() < str.end(); ++it)
     {
-        if (std::equal(sep, sep + sep_size, it))
+        if (std::equal(sep.begin(), sep.begin() + sep.size(), it))
         {
             if (into->size() + 1 >= limit)
             {
@@ -145,7 +126,7 @@ static inline std::vector<std::string>& split(std::vector<std::string>* into,
             }
 
             into->emplace_back(last, it);
-            last = it + sep_size;
+            last = it + sep.size();
         }
     }
 
@@ -154,41 +135,11 @@ static inline std::vector<std::string>& split(std::vector<std::string>* into,
     return *into;
 }
 
-std::vector<std::string>& split(std::vector<std::string>* into, const char* sep,
-                                const std::string& str,
-                                std::string::size_type limit)
-{
-    // call base method
-    return split(into, sep, strlen(sep), str, limit);
-}
-
-std::vector<std::string>& split(std::vector<std::string>* into,
-                                const std::string& sep, const std::string& str,
-                                std::string::size_type limit)
-{
-    // call base method
-    return split(into, sep.data(), sep.size(), str, limit);
-}
-
 /******************************************************************************/
 // split() into std::vector<std::string> with minimum fields
 
 std::vector<std::string>& split(std::vector<std::string>* into, char sep,
-                                const std::string& str,
-                                std::string::size_type min_fields,
-                                std::string::size_type limit)
-{
-    // call base method
-    split(into, sep, str, limit);
-
-    if (into->size() < min_fields)
-        into->resize(min_fields);
-
-    return *into;
-}
-
-std::vector<std::string>& split(std::vector<std::string>* into, const char* sep,
-                                const std::string& str,
+                                tlx::string_view str,
                                 std::string::size_type min_fields,
                                 std::string::size_type limit)
 {
@@ -202,7 +153,7 @@ std::vector<std::string>& split(std::vector<std::string>* into, const char* sep,
 }
 
 std::vector<std::string>& split(std::vector<std::string>* into,
-                                const std::string& sep, const std::string& str,
+                                tlx::string_view sep, tlx::string_view str,
                                 std::string::size_type min_fields,
                                 std::string::size_type limit)
 {

--- a/tlx/string/split.hpp
+++ b/tlx/string/split.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_SPLIT_HEADER
 #define TLX_STRING_SPLIT_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,7 @@ namespace tlx {
  * \return       vector containing each split substring
  */
 std::vector<std::string> split(
-    char sep, const std::string& str,
+    char sep, tlx::string_view str,
     std::string::size_type limit = std::string::npos);
 
 /*!
@@ -49,21 +50,7 @@ std::vector<std::string> split(
  * \return       vector containing each split substring
  */
 std::vector<std::string> split(
-    const char* sep, const std::string& str,
-    std::string::size_type limit = std::string::npos);
-
-/*!
- * Split the given string at each separator string into distinct substrings.
- * Multiple consecutive separators are considered individually and will result
- * in empty split substrings.
- *
- * \param sep    separator string
- * \param str    string to split
- * \param limit  maximum number of parts returned
- * \return       vector containing each split substring
- */
-std::vector<std::string> split(
-    const std::string& sep, const std::string& str,
+    tlx::string_view sep, tlx::string_view str,
     std::string::size_type limit = std::string::npos);
 
 /******************************************************************************/
@@ -81,7 +68,7 @@ std::vector<std::string> split(
  * \param limit       maximum number of parts returned
  * \return            vector containing each split substring
  */
-std::vector<std::string> split(char sep, const std::string& str,
+std::vector<std::string> split(char sep, tlx::string_view str,
                                std::string::size_type min_fields,
                                std::string::size_type limit);
 
@@ -97,23 +84,7 @@ std::vector<std::string> split(char sep, const std::string& str,
  * \param limit       maximum number of parts returned
  * \return            vector containing each split substring
  */
-std::vector<std::string> split(const char* sep, const std::string& str,
-                               std::string::size_type min_fields,
-                               std::string::size_type limit);
-
-/*!
- * Split the given string at each separator string into distinct substrings.
- * Multiple consecutive separators are considered individually and will result
- * in empty split substrings.  Returns a vector of strings with at least
- * min_fields and at most limit_fields, empty fields are added if needed.
- *
- * \param sep         separator string
- * \param str         string to split
- * \param min_fields  minimum number of parts returned
- * \param limit       maximum number of parts returned
- * \return            vector containing each split substring
- */
-std::vector<std::string> split(const std::string& sep, const std::string& str,
+std::vector<std::string> split(tlx::string_view sep, tlx::string_view str,
                                std::string::size_type min_fields,
                                std::string::size_type limit);
 
@@ -132,7 +103,7 @@ std::vector<std::string> split(const std::string& sep, const std::string& str,
  * \return       vector containing each split substring
  */
 std::vector<std::string>& split(
-    std::vector<std::string>* into, char sep, const std::string& str,
+    std::vector<std::string>* into, char sep, tlx::string_view str,
     std::string::size_type limit = std::string::npos);
 
 /*!
@@ -147,23 +118,8 @@ std::vector<std::string>& split(
  * \return       vector containing each split substring
  */
 std::vector<std::string>& split(
-    std::vector<std::string>* into, const char* sep, const std::string& str,
+    std::vector<std::string>* into, tlx::string_view sep, tlx::string_view str,
     std::string::size_type limit = std::string::npos);
-
-/*!
- * Split the given string at each separator string into distinct substrings.
- * Multiple consecutive separators are considered individually and will result
- * in empty split substrings.
- *
- * \param into   destination std::vector
- * \param sep    separator string
- * \param str    string to split
- * \param limit  maximum number of parts returned
- * \return       vector containing each split substring
- */
-std::vector<std::string>& split(
-    std::vector<std::string>* into, const std::string& sep,
-    const std::string& str, std::string::size_type limit = std::string::npos);
 
 /******************************************************************************/
 // split() into std::vector<std::string> with minimum fields
@@ -182,25 +138,7 @@ std::vector<std::string>& split(
  * \return            vector containing each split substring
  */
 std::vector<std::string>& split(std::vector<std::string>* into, char sep,
-                                const std::string& str,
-                                std::string::size_type min_fields,
-                                std::string::size_type limit);
-
-/*!
- * Split the given string at each separator string into distinct substrings.
- * Multiple consecutive separators are considered individually and will result
- * in empty split substrings.  Returns a vector of strings with at least
- * min_fields and at most limit_fields, empty fields are added if needed.
- *
- * \param into        destination std::vector
- * \param sep         separator string
- * \param str         string to split
- * \param min_fields  minimum number of parts returned
- * \param limit       maximum number of parts returned
- * \return            vector containing each split substring
- */
-std::vector<std::string>& split(std::vector<std::string>* into, const char* sep,
-                                const std::string& str,
+                                tlx::string_view str,
                                 std::string::size_type min_fields,
                                 std::string::size_type limit);
 
@@ -218,7 +156,7 @@ std::vector<std::string>& split(std::vector<std::string>* into, const char* sep,
  * \return            vector containing each split substring
  */
 std::vector<std::string>& split(std::vector<std::string>* into,
-                                const std::string& sep, const std::string& str,
+                                tlx::string_view sep, tlx::string_view str,
                                 std::string::size_type min_fields,
                                 std::string::size_type limit);
 

--- a/tlx/string/split_quoted.cpp
+++ b/tlx/string/split_quoted.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/split_quoted.hpp>
 #include <stdexcept>
 #include <string>
@@ -16,12 +17,12 @@
 
 namespace tlx {
 
-std::vector<std::string> split_quoted(const std::string& str, char sep,
+std::vector<std::string> split_quoted(tlx::string_view str, char sep,
                                       char quote, char escape)
 {
     std::vector<std::string> out;
 
-    std::string::const_iterator it = str.begin();
+    tlx::string_view::const_iterator it = str.begin();
     std::string entry;
 
     for (; it != str.end();)
@@ -140,7 +141,7 @@ std::vector<std::string> split_quoted(const std::string& str, char sep,
     return out;
 }
 
-std::vector<std::string> split_quoted(const std::string& str)
+std::vector<std::string> split_quoted(tlx::string_view str)
 {
     return split_quoted(str, ' ', '"', '\\');
 }

--- a/tlx/string/split_quoted.hpp
+++ b/tlx/string/split_quoted.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2018 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_SPLIT_QUOTED_HEADER
 #define TLX_STRING_SPLIT_QUOTED_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 #include <vector>
 
@@ -27,7 +28,7 @@ namespace tlx {
  * substrings. Quoted fields extend to the next quote. Quoted fields may
  * containg escaped quote, and \\n \\r \\t \\\\ sequences.
  */
-std::vector<std::string> split_quoted(const std::string& str, char sep,
+std::vector<std::string> split_quoted(tlx::string_view str, char sep,
                                       char quote, char escape);
 
 /*!
@@ -36,7 +37,7 @@ std::vector<std::string> split_quoted(const std::string& str, char sep,
  * fields extend to the next quote. Quoted fields may containg escaped quote,
  * and \\n \\r \\t \\\\ sequences.
  */
-std::vector<std::string> split_quoted(const std::string& str);
+std::vector<std::string> split_quoted(tlx::string_view str);
 
 //! \}
 //! \}

--- a/tlx/string/split_view.hpp
+++ b/tlx/string/split_view.hpp
@@ -5,7 +5,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -35,7 +35,7 @@ namespace tlx {
  * \param limit     maximum number of parts returned
  */
 template <typename Functor>
-static inline void split_view(char sep, const std::string& str,
+static inline void split_view(char sep, tlx::string_view str,
                               Functor&& callback,
                               std::string::size_type limit = std::string::npos)
 {
@@ -45,8 +45,8 @@ static inline void split_view(char sep, const std::string& str,
         return;
     }
 
-    std::string::size_type count = 0;
-    auto it = str.begin(), last = it;
+    tlx::string_view::size_type count = 0;
+    tlx::string_view::const_iterator it = str.begin(), last = it;
 
     for (; it != str.end(); ++it)
     {

--- a/tlx/string/split_words.cpp
+++ b/tlx/string/split_words.cpp
@@ -3,25 +3,26 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/split_words.hpp>
 #include <string>
 #include <vector>
 
 namespace tlx {
 
-std::vector<std::string> split_words(const std::string& str,
+std::vector<std::string> split_words(tlx::string_view str,
                                      std::string::size_type limit)
 {
     std::vector<std::string> out;
     if (limit == 0)
         return out;
 
-    std::string::const_iterator it = str.begin(), last = it;
+    tlx::string_view::const_iterator it = str.begin(), last = it;
 
     for (; it != str.end(); ++it)
     {

--- a/tlx/string/split_words.hpp
+++ b/tlx/string/split_words.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_SPLIT_WORDS_HEADER
 #define TLX_STRING_SPLIT_WORDS_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ namespace tlx {
  * \return      vector containing each split substring
  */
 std::vector<std::string> split_words(
-    const std::string& str, std::string::size_type limit = std::string::npos);
+    tlx::string_view str, std::string::size_type limit = std::string::npos);
 
 //! \}
 

--- a/tlx/string/starts_with.cpp
+++ b/tlx/string/starts_with.cpp
@@ -3,56 +3,21 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/starts_with.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
-#include <string>
 
 namespace tlx {
 
 /******************************************************************************/
 
-bool starts_with(const char* str, const char* match)
-{
-    while (*match != 0)
-    {
-        if (*str == 0 || *str != *match)
-            return false;
-        ++str, ++match;
-    }
-    return true;
-}
-
-bool starts_with(const char* str, const std::string& match)
-{
-    std::string::const_iterator m = match.begin();
-    while (m != match.end())
-    {
-        if (*str == 0 || *str != *m)
-            return false;
-        ++str, ++m;
-    }
-    return true;
-}
-
-bool starts_with(const std::string& str, const char* match)
-{
-    std::string::const_iterator s = str.begin();
-    while (*match != 0)
-    {
-        if (s == str.end() || *s != *match)
-            return false;
-        ++s, ++match;
-    }
-    return true;
-}
-
-bool starts_with(const std::string& str, const std::string& match)
+bool starts_with(tlx::string_view str, tlx::string_view match)
 {
     if (match.size() > str.size())
         return false;
@@ -61,42 +26,7 @@ bool starts_with(const std::string& str, const std::string& match)
 
 /******************************************************************************/
 
-bool starts_with_icase(const char* str, const char* match)
-{
-    while (*match != 0)
-    {
-        if (*str == 0 || to_lower(*str) != to_lower(*match))
-            return false;
-        ++str, ++match;
-    }
-    return true;
-}
-
-bool starts_with_icase(const char* str, const std::string& match)
-{
-    std::string::const_iterator m = match.begin();
-    while (m != match.end())
-    {
-        if (*str == 0 || to_lower(*str) != to_lower(*m))
-            return false;
-        ++str, ++m;
-    }
-    return true;
-}
-
-bool starts_with_icase(const std::string& str, const char* match)
-{
-    std::string::const_iterator s = str.begin();
-    while (*match != 0)
-    {
-        if (s == str.end() || to_lower(*s) != to_lower(*match))
-            return false;
-        ++s, ++match;
-    }
-    return true;
-}
-
-bool starts_with_icase(const std::string& str, const std::string& match)
+bool starts_with_icase(tlx::string_view str, tlx::string_view match)
 {
     if (match.size() > str.size())
         return false;

--- a/tlx/string/starts_with.hpp
+++ b/tlx/string/starts_with.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2019 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,7 +11,7 @@
 #ifndef TLX_STRING_STARTS_WITH_HEADER
 #define TLX_STRING_STARTS_WITH_HEADER
 
-#include <string>
+#include <tlx/container/string_view.hpp>
 
 namespace tlx {
 
@@ -23,22 +23,7 @@ namespace tlx {
 /*!
  * Checks if the given match string is located at the start of this string.
  */
-bool starts_with(const char* str, const char* match);
-
-/*!
- * Checks if the given match string is located at the start of this string.
- */
-bool starts_with(const char* str, const std::string& match);
-
-/*!
- * Checks if the given match string is located at the start of this string.
- */
-bool starts_with(const std::string& str, const char* match);
-
-/*!
- * Checks if the given match string is located at the start of this string.
- */
-bool starts_with(const std::string& str, const std::string& match);
+bool starts_with(tlx::string_view str, tlx::string_view match);
 
 /******************************************************************************/
 
@@ -46,25 +31,7 @@ bool starts_with(const std::string& str, const std::string& match);
  * Checks if the given match string is located at the start of this
  * string. Compares the characters case-insensitively.
  */
-bool starts_with_icase(const char* str, const char* match);
-
-/*!
- * Checks if the given match string is located at the start of this
- * string. Compares the characters case-insensitively.
- */
-bool starts_with_icase(const char* str, const std::string& match);
-
-/*!
- * Checks if the given match string is located at the start of this
- * string. Compares the characters case-insensitively.
- */
-bool starts_with_icase(const std::string& str, const char* match);
-
-/*!
- * Checks if the given match string is located at the start of this
- * string. Compares the characters case-insensitively.
- */
-bool starts_with_icase(const std::string& str, const std::string& match);
+bool starts_with_icase(tlx::string_view str, tlx::string_view match);
 
 /******************************************************************************/
 

--- a/tlx/string/to_lower.cpp
+++ b/tlx/string/to_lower.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/to_lower.hpp>
 #include <algorithm>
 #include <string>
@@ -28,7 +29,7 @@ std::string& to_lower(std::string* str)
     return *str;
 }
 
-std::string to_lower(const std::string& str)
+std::string to_lower(tlx::string_view str)
 {
     std::string str_copy(str.size(), 0);
     std::transform(str.begin(), str.end(), str_copy.begin(),

--- a/tlx/string/to_lower.hpp
+++ b/tlx/string/to_lower.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_TO_LOWER_HEADER
 #define TLX_STRING_TO_LOWER_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -35,7 +36,7 @@ std::string& to_lower(std::string* str);
  * \param str   string to process
  * \return      new string lowercased
  */
-std::string to_lower(const std::string& str);
+std::string to_lower(tlx::string_view str);
 
 //! \}
 

--- a/tlx/string/to_upper.cpp
+++ b/tlx/string/to_upper.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/to_upper.hpp>
 #include <algorithm>
 #include <string>
@@ -28,7 +29,7 @@ std::string& to_upper(std::string* str)
     return *str;
 }
 
-std::string to_upper(const std::string& str)
+std::string to_upper(tlx::string_view str)
 {
     std::string str_copy(str.size(), 0);
     std::transform(str.begin(), str.end(), str_copy.begin(),

--- a/tlx/string/to_upper.hpp
+++ b/tlx/string/to_upper.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_TO_UPPER_HEADER
 #define TLX_STRING_TO_UPPER_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -35,7 +36,7 @@ std::string& to_upper(std::string* str);
  * \param str   string to process
  * \return      new string uppercased
  */
-std::string to_upper(const std::string& str);
+std::string to_upper(tlx::string_view str);
 
 //! \}
 

--- a/tlx/string/trim.cpp
+++ b/tlx/string/trim.cpp
@@ -3,13 +3,13 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/trim.hpp>
-#include <algorithm>
 #include <cstring>
 #include <string>
 
@@ -22,13 +22,14 @@ std::string& trim(std::string* str)
     return trim(str, " \r\n\t");
 }
 
-std::string& trim(std::string* str, const char* drop)
+std::string& trim(std::string* str, tlx::string_view drop)
 {
-    std::string::size_type pos = str->find_last_not_of(drop);
+    std::string::size_type pos =
+        str->find_last_not_of(drop.data(), std::string::npos, drop.size());
     if (pos != std::string::npos)
     {
         str->erase(pos + 1);
-        pos = str->find_first_not_of(drop);
+        pos = str->find_first_not_of(drop.data(), 0, drop.size());
         if (pos != std::string::npos)
             str->erase(0, pos);
     }
@@ -38,63 +39,26 @@ std::string& trim(std::string* str, const char* drop)
     return *str;
 }
 
-std::string& trim(std::string* str, const std::string& drop)
-{
-    std::string::size_type pos = str->find_last_not_of(drop);
-    if (pos != std::string::npos)
-    {
-        str->erase(pos + 1);
-        pos = str->find_first_not_of(drop);
-        if (pos != std::string::npos)
-            str->erase(0, pos);
-    }
-    else
-        str->erase(str->begin(), str->end());
-
-    return *str;
-}
-
-std::string trim(const std::string& str)
+tlx::string_view trim(tlx::string_view str)
 {
     return trim(str, " \r\n\t");
 }
 
-std::string trim(const std::string& str, const char* drop)
+tlx::string_view trim(tlx::string_view str, tlx::string_view drop)
 {
-    // trim beginning
-    std::string::size_type pos1 = str.find_first_not_of(drop);
-    if (pos1 == std::string::npos)
-        return std::string();
-
-    // copy middle and end
-    std::string out = str.substr(pos1, std::string::npos);
-
-    // trim end
-    std::string::size_type pos2 = out.find_last_not_of(drop);
-    if (pos2 != std::string::npos)
-        out.erase(pos2 + 1);
-
-    return out;
-}
-
-std::string trim(const std::string& str, const std::string& drop)
-{
-    std::string out;
-    out.reserve(str.size());
+    tlx::string_view out = str;
 
     // trim beginning
-    std::string::const_iterator it = str.begin();
-    while (it != str.end() && drop.find(*it) != std::string::npos)
-        ++it;
-
-    // copy middle and end
-    out.resize(str.end() - it);
-    std::copy(it, str.end(), out.begin());
+    tlx::string_view::size_type pos =
+        out.find_first_not_of(drop.data(), 0, drop.size());
+    if (pos == tlx::string_view::npos)
+        return tlx::string_view();
+    out.remove_prefix(pos);
 
     // trim end
-    std::string::size_type pos = out.find_last_not_of(drop);
-    if (pos != std::string::npos)
-        out.erase(pos + 1);
+    pos = out.find_last_not_of(drop.data(), out.size(), drop.size());
+    if (pos != tlx::string_view::npos)
+        out.remove_suffix(out.size() - pos - 1);
 
     return out;
 }
@@ -106,37 +70,26 @@ std::string& trim_right(std::string* str)
     return trim_right(str, " \r\n\t");
 }
 
-std::string& trim_right(std::string* str, const char* drop)
+std::string& trim_right(std::string* str, tlx::string_view drop)
 {
-    str->erase(str->find_last_not_of(drop) + 1, std::string::npos);
+    str->erase(str->find_last_not_of(drop.data(), tlx::string_view::npos,
+                                     drop.size()) +
+                   1,
+               std::string::npos);
     return *str;
 }
 
-std::string& trim_right(std::string* str, const std::string& drop)
-{
-    str->erase(str->find_last_not_of(drop) + 1, std::string::npos);
-    return *str;
-}
-
-std::string trim_right(const std::string& str)
+tlx::string_view trim_right(tlx::string_view str)
 {
     return trim_right(str, " \r\n\t");
 }
 
-std::string trim_right(const std::string& str, const char* drop)
+tlx::string_view trim_right(tlx::string_view str, tlx::string_view drop)
 {
-    std::string::size_type pos = str.find_last_not_of(drop);
-    if (pos == std::string::npos)
-        return std::string();
-
-    return str.substr(0, pos + 1);
-}
-
-std::string trim_right(const std::string& str, const std::string& drop)
-{
-    std::string::size_type pos = str.find_last_not_of(drop);
-    if (pos == std::string::npos)
-        return std::string();
+    tlx::string_view::size_type pos =
+        str.find_last_not_of(drop.data(), tlx::string_view::npos, drop.size());
+    if (pos == tlx::string_view::npos)
+        return tlx::string_view();
 
     return str.substr(0, pos + 1);
 }
@@ -148,37 +101,23 @@ std::string& trim_left(std::string* str)
     return trim_left(str, " \r\n\t");
 }
 
-std::string& trim_left(std::string* str, const char* drop)
+std::string& trim_left(std::string* str, tlx::string_view drop)
 {
-    str->erase(0, str->find_first_not_of(drop));
+    str->erase(0, str->find_first_not_of(drop.data(), 0, drop.size()));
     return *str;
 }
 
-std::string& trim_left(std::string* str, const std::string& drop)
-{
-    str->erase(0, str->find_first_not_of(drop));
-    return *str;
-}
-
-std::string trim_left(const std::string& str)
+tlx::string_view trim_left(tlx::string_view str)
 {
     return trim_left(str, " \r\n\t");
 }
 
-std::string trim_left(const std::string& str, const char* drop)
+tlx::string_view trim_left(tlx::string_view str, tlx::string_view drop)
 {
-    std::string::size_type pos = str.find_first_not_of(drop);
-    if (pos == std::string::npos)
-        return std::string();
-
-    return str.substr(pos, std::string::npos);
-}
-
-std::string trim_left(const std::string& str, const std::string& drop)
-{
-    std::string::size_type pos = str.find_first_not_of(drop);
-    if (pos == std::string::npos)
-        return std::string();
+    tlx::string_view::size_type pos =
+        str.find_first_not_of(drop.data(), 0, drop.size());
+    if (pos == tlx::string_view::npos)
+        return tlx::string_view();
 
     return str.substr(pos, std::string::npos);
 }

--- a/tlx/string/trim.hpp
+++ b/tlx/string/trim.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2007-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_TRIM_HEADER
 #define TLX_STRING_TRIM_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -39,7 +40,16 @@ std::string& trim(std::string* str);
  * \param drop  remove these characters
  * \return      reference to the modified string
  */
-std::string& trim(std::string* str, const char* drop);
+std::string& trim(std::string* str, tlx::string_view drop);
+
+/*!
+ * Trims the given string in-place on the left and right. Removes all
+ * characters in the given drop array, which defaults to " \r\n\t".
+ *
+ * \param str   string to process
+ * \return      reference to the modified string
+ */
+tlx::string_view trim(tlx::string_view str);
 
 /*!
  * Trims the given string in-place on the left and right. Removes all
@@ -49,36 +59,7 @@ std::string& trim(std::string* str, const char* drop);
  * \param drop  remove these characters
  * \return      reference to the modified string
  */
-std::string& trim(std::string* str, const std::string& drop);
-
-/*!
- * Trims the given string in-place on the left and right. Removes all
- * characters in the given drop array, which defaults to " \r\n\t".
- *
- * \param str   string to process
- * \return      reference to the modified string
- */
-std::string trim(const std::string& str);
-
-/*!
- * Trims the given string in-place on the left and right. Removes all
- * characters in the given drop array, which defaults to " \r\n\t".
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      reference to the modified string
- */
-std::string trim(const std::string& str, const char* drop);
-
-/*!
- * Trims the given string in-place on the left and right. Removes all
- * characters in the given drop array, which defaults to " \r\n\t".
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      reference to the modified string
- */
-std::string trim(const std::string& str, const std::string& drop);
+tlx::string_view trim(tlx::string_view str, tlx::string_view drop);
 
 /******************************************************************************/
 
@@ -99,17 +80,7 @@ std::string& trim_right(std::string* str);
  * \param drop  remove these characters
  * \return      reference to the modified string
  */
-std::string& trim_right(std::string* str, const char* drop);
-
-/*!
- * Trims the given string in-place only on the right. Removes all characters in
- * the given drop array, which defaults to " \r\n\t".
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      reference to the modified string
- */
-std::string& trim_right(std::string* str, const std::string& drop);
+std::string& trim_right(std::string* str, tlx::string_view drop);
 
 /*!
  * Trims the given string only on the right. Removes all characters in the
@@ -118,7 +89,7 @@ std::string& trim_right(std::string* str, const std::string& drop);
  * \param str   string to process
  * \return      new trimmed string
  */
-std::string trim_right(const std::string& str);
+tlx::string_view trim_right(tlx::string_view str);
 
 /*!
  * Trims the given string only on the right. Removes all characters in the
@@ -128,17 +99,7 @@ std::string trim_right(const std::string& str);
  * \param drop  remove these characters
  * \return      new trimmed string
  */
-std::string trim_right(const std::string& str, const char* drop);
-
-/*!
- * Trims the given string only on the right. Removes all characters in the
- * given drop array, which defaults to " \r\n\t". Returns a copy of the string.
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      new trimmed string
- */
-std::string trim_right(const std::string& str, const std::string& drop);
+tlx::string_view trim_right(tlx::string_view str, tlx::string_view drop);
 
 /******************************************************************************/
 
@@ -159,17 +120,7 @@ std::string& trim_left(std::string* str);
  * \param drop  remove these characters
  * \return      reference to the modified string
  */
-std::string& trim_left(std::string* str, const char* drop);
-
-/*!
- * Trims the given string in-place only on the left. Removes all characters in
- * the given drop array, which defaults to " \r\n\t".
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      reference to the modified string
- */
-std::string& trim_left(std::string* str, const std::string& drop);
+std::string& trim_left(std::string* str, tlx::string_view drop);
 
 /*!
  * Trims the given string only on the left. Removes all characters in the given
@@ -178,7 +129,7 @@ std::string& trim_left(std::string* str, const std::string& drop);
  * \param str   string to process
  * \return      new trimmed string
  */
-std::string trim_left(const std::string& str);
+tlx::string_view trim_left(tlx::string_view str);
 
 /*!
  * Trims the given string only on the left. Removes all characters in the given
@@ -188,17 +139,7 @@ std::string trim_left(const std::string& str);
  * \param drop  remove these characters
  * \return      new trimmed string
  */
-std::string trim_left(const std::string& str, const char* drop);
-
-/*!
- * Trims the given string only on the left. Removes all characters in the given
- * drop array, which defaults to " \r\n\t". Returns a copy of the string.
- *
- * \param str   string to process
- * \param drop  remove these characters
- * \return      new trimmed string
- */
-std::string trim_left(const std::string& str, const std::string& drop);
+tlx::string_view trim_left(tlx::string_view str, tlx::string_view drop);
 
 //! \}
 //! \}

--- a/tlx/string/union_words.cpp
+++ b/tlx/string/union_words.cpp
@@ -3,22 +3,23 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/contains_word.hpp>
 #include <tlx/string/union_words.hpp>
 #include <string>
 
 namespace tlx {
 
-std::string union_words(const std::string& wordsA, const std::string& wordsB)
+std::string union_words(tlx::string_view wordsA, tlx::string_view wordsB)
 {
-    std::string words = wordsA;
+    std::string words(wordsA.data(), wordsA.size());
 
-    std::string::const_iterator it = wordsB.begin();
+    tlx::string_view::const_iterator it = wordsB.begin();
 
     while (it != wordsB.end())
     {
@@ -29,20 +30,20 @@ std::string union_words(const std::string& wordsA, const std::string& wordsB)
                 break;
         }
 
-        std::string::const_iterator i1 = it;
+        tlx::string_view::const_iterator i1 = it;
 
         // find first non-whitespace
         while (it != wordsB.end() && *it != ' ' && *it != '\n' && *it != '\t' &&
                *it != '\r')
             ++it;
 
-        std::string w(i1, it);
+        tlx::string_view w(i1, it);
 
         if (!contains_word(words, w))
         {
             if (!words.empty())
                 words += ' ';
-            words += w;
+            words.append(w.data(), w.size());
         }
     }
 

--- a/tlx/string/union_words.hpp
+++ b/tlx/string/union_words.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_UNION_WORDS_HEADER
 #define TLX_STRING_UNION_WORDS_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -21,7 +22,7 @@ namespace tlx {
 /*!
  * Return union of two keyword sets.
  */
-std::string union_words(const std::string& wordsA, const std::string& wordsB);
+std::string union_words(tlx::string_view wordsA, tlx::string_view wordsB);
 
 //! \}
 

--- a/tlx/string/word_wrap.cpp
+++ b/tlx/string/word_wrap.cpp
@@ -3,11 +3,12 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
 
+#include <tlx/container/string_view.hpp>
 #include <tlx/string/word_wrap.hpp>
 #include <cctype>
 #include <string>
@@ -20,7 +21,7 @@ bool is_space(char ch)
            ch == '\v';
 }
 
-std::string word_wrap(const std::string& str, unsigned int wrap)
+std::string word_wrap(tlx::string_view str, unsigned int wrap)
 {
     std::string out;
     out.resize(str.size());

--- a/tlx/string/word_wrap.hpp
+++ b/tlx/string/word_wrap.hpp
@@ -3,7 +3,7 @@
  *
  * Part of tlx - http://panthema.net/tlx
  *
- * Copyright (C) 2016-2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2016-2024 Timo Bingmann <tb@panthema.net>
  *
  * All rights reserved. Published under the Boost Software License, Version 1.0
  ******************************************************************************/
@@ -11,6 +11,7 @@
 #ifndef TLX_STRING_WORD_WRAP_HEADER
 #define TLX_STRING_WORD_WRAP_HEADER
 
+#include <tlx/container/string_view.hpp>
 #include <string>
 
 namespace tlx {
@@ -23,7 +24,7 @@ namespace tlx {
  * kept, new newline characters are inserted only at spaces, hence, words are
  * never split. If words longer than 80 columns occur they are NOT broken.
  */
-std::string word_wrap(const std::string& str, unsigned int wrap = 80);
+std::string word_wrap(tlx::string_view str, unsigned int wrap = 80);
 
 //! \}
 


### PR DESCRIPTION
This PR changes the interface of all functions which take a `const std::string&` to take a `tlx::string_view` which is an identical portable version of `std::string_view`.