### PR TITLE
string: add `split_view` and `split_words_view` with string_view

### DIFF
--- a/tests/container/string_view_test.cpp
+++ b/tests/container/string_view_test.cpp
@@ -51,7 +51,7 @@ void split_view()
 {
     std::string input = "This is a string.";
     size_t i = 0;
-    tlx::split_view(' ', input, [&](const tlx::string_view& sv) {
+    tlx::split_callback(' ', input, [&](const tlx::string_view& sv) {
         if (i == 0)
             die_unequal(sv, "This");
         if (i == 1)

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -39,6 +39,7 @@
 #include <tlx/string/replace.hpp>
 #include <tlx/string/split.hpp>
 #include <tlx/string/split_quoted.hpp>
+#include <tlx/string/split_view.hpp>
 #include <tlx/string/split_words.hpp>
 #include <tlx/string/ssprintf.hpp>
 #include <tlx/string/ssprintf_generic.hpp>
@@ -564,6 +565,102 @@ static void test_split()
     die_unequal(sv[4], "");
 }
 
+static void test_split_view()
+{
+    // simple char split
+    std::vector<tlx::string_view> sv = tlx::split_view('/', "/usr/bin/test/");
+
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "");
+    die_unequal(sv[1], "usr");
+    die_unequal(sv[2], "bin");
+    die_unequal(sv[3], "test");
+    die_unequal(sv[4], "");
+
+    sv = tlx::split_view('/', "/usr/bin/test", 3);
+
+    die_unequal(sv.size(), 3U);
+    die_unequal(sv[0], "");
+    die_unequal(sv[1], "usr");
+    die_unequal(sv[2], "bin/test");
+
+    // char split with some strange limits
+    sv = tlx::split_view('/', "/usr//bin/test", 0);
+    die_unequal(sv.size(), 0U);
+
+    sv = tlx::split_view('/', "/usr//bin/test", 1);
+    die_unequal(sv.size(), 1U);
+    die_unequal(sv[0], "/usr//bin/test");
+
+    // simple str split
+    sv = tlx::split_view("/", "/usr/bin/test");
+
+    die_unequal(sv.size(), 4U);
+    die_unequal(sv[0], "");
+    die_unequal(sv[1], "usr");
+    die_unequal(sv[2], "bin");
+    die_unequal(sv[3], "test");
+
+    sv = tlx::split_view("/", "/usr/bin/test", 3);
+
+    die_unequal(sv.size(), 3U);
+    die_unequal(sv[0], "");
+    die_unequal(sv[1], "usr");
+    die_unequal(sv[2], "bin/test");
+
+    // str split with some strange limits
+    sv = tlx::split_view("/", "/usr//bin/test", 0);
+    die_unequal(sv.size(), 0U);
+
+    sv = tlx::split_view("/", "/usr//bin/test", 1);
+    die_unequal(sv.size(), 1U);
+    die_unequal(sv[0], "/usr//bin/test");
+
+    // str split with parital needle at end
+    sv = tlx::split_view("abc", "testabcblahabcabcab");
+    die_unequal(sv.size(), 4U);
+    die_unequal(sv[0], "test");
+    die_unequal(sv[1], "blah");
+    die_unequal(sv[2], "");
+    die_unequal(sv[3], "ab");
+
+    // str split with "" separator
+    sv = tlx::split_view("", "abcdef");
+    die_unequal(sv.size(), 6U);
+    die_unequal(sv[0], "a");
+    die_unequal(sv[1], "b");
+    die_unequal(sv[2], "c");
+    die_unequal(sv[3], "d");
+    die_unequal(sv[4], "e");
+    die_unequal(sv[5], "f");
+
+    /**************************************************************************/
+
+    // str split with min-limit
+    sv = tlx::split_view('/', "/usr/bin/test", 2, 2);
+    die_unequal(sv.size(), 2U);
+    die_unequal(sv[0], "");
+    die_unequal(sv[1], "usr/bin/test");
+
+    // str split with min-limit
+    sv = tlx::split_view('/', "/usr/bin/test", 5, 5);
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "");
+    die_unequal(sv[1], "usr");
+    die_unequal(sv[2], "bin");
+    die_unequal(sv[3], "test");
+    die_unequal(sv[4], "");
+
+    // str split with min-limit
+    sv = tlx::split_view("/", "/usr/bin/test", 5, 5);
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "");
+    die_unequal(sv[1], "usr");
+    die_unequal(sv[2], "bin");
+    die_unequal(sv[3], "test");
+    die_unequal(sv[4], "");
+}
+
 static void test_split_join_quoted()
 {
     // simple whitespace split
@@ -692,6 +789,81 @@ static void test_split_words()
 
     // whitespace split with limit at exactly the end
     sv = tlx::split_words("  ab  c  df  fdlk f  ", 5);
+
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "ab");
+    die_unequal(sv[1], "c");
+    die_unequal(sv[2], "df");
+    die_unequal(sv[3], "fdlk");
+    die_unequal(sv[4], "f  ");
+}
+
+static void test_split_words_view()
+{
+    // simple whitespace split
+    std::vector<tlx::string_view> sv =
+        tlx::split_words_view("  ab c df  fdlk f  ");
+
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "ab");
+    die_unequal(sv[1], "c");
+    die_unequal(sv[2], "df");
+    die_unequal(sv[3], "fdlk");
+    die_unequal(sv[4], "f");
+
+    sv = tlx::split_words_view("ab c df  fdlk f  ");
+
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "ab");
+    die_unequal(sv[1], "c");
+    die_unequal(sv[2], "df");
+    die_unequal(sv[3], "fdlk");
+    die_unequal(sv[4], "f");
+
+    sv = tlx::split_words_view("ab c df  fdlk f");
+
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "ab");
+    die_unequal(sv[1], "c");
+    die_unequal(sv[2], "df");
+    die_unequal(sv[3], "fdlk");
+    die_unequal(sv[4], "f");
+
+    sv = tlx::split_words_view("");
+    die_unequal(sv.size(), 0U);
+
+    sv = tlx::split_words_view("    ");
+    die_unequal(sv.size(), 0U);
+
+    // whitespace split with limit
+    sv = tlx::split_words_view("  ab c   df  fdlk f  ", 3);
+
+    die_unequal(sv.size(), 3U);
+    die_unequal(sv[0], "ab");
+    die_unequal(sv[1], "c");
+    die_unequal(sv[2], "df  fdlk f  ");
+
+    // whitespace split with some strange limits
+    sv = tlx::split_words_view("  ab c df  fdlk f  ", 0);
+    die_unequal(sv.size(), 0U);
+
+    sv = tlx::split_words_view("  ab c df  fdlk f  ", 1);
+
+    die_unequal(sv.size(), 1U);
+    die_unequal(sv[0], "ab c df  fdlk f  ");
+
+    // whitespace split with large limit
+    sv = tlx::split_words_view("  ab  c  df  fdlk f  ", 10);
+
+    die_unequal(sv.size(), 5U);
+    die_unequal(sv[0], "ab");
+    die_unequal(sv[1], "c");
+    die_unequal(sv[2], "df");
+    die_unequal(sv[3], "fdlk");
+    die_unequal(sv[4], "f");
+
+    // whitespace split with limit at exactly the end
+    sv = tlx::split_words_view("  ab  c  df  fdlk f  ", 5);
 
     die_unequal(sv.size(), 5U);
     die_unequal(sv[0], "ab");
@@ -982,8 +1154,10 @@ int main()
     test_parse_uri_form_data();
     test_replace();
     test_split();
+    test_split_view();
     test_split_join_quoted();
     test_split_words();
+    test_split_words_view();
     test_ssprintf();
     test_starts_with_ends_with();
     test_toupper_tolower();

--- a/tlx/CMakeLists.txt
+++ b/tlx/CMakeLists.txt
@@ -45,6 +45,7 @@ set(LIBTLX_SOURCES
   string/replace.cpp
   string/split.cpp
   string/split_quoted.cpp
+  string/split_view.cpp
   string/split_words.cpp
   string/ssprintf.cpp
   string/starts_with.cpp

--- a/tlx/string/split_view.cpp
+++ b/tlx/string/split_view.cpp
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * tlx/string/split_view.cpp
+ *
+ * Part of tlx - http://panthema.net/tlx
+ *
+ * Copyright (C) 2007-2024 Timo Bingmann <tb@panthema.net>
+ *
+ * All rights reserved. Published under the Boost Software License, Version 1.0
+ ******************************************************************************/
+
+#include <tlx/container/string_view.hpp>
+#include <tlx/string/split_view.hpp>
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+namespace tlx {
+
+/******************************************************************************/
+// split_view() returning std::vector<tlx::string_view>
+
+std::vector<tlx::string_view> split_view(char sep, tlx::string_view str,
+                                         tlx::string_view::size_type limit)
+{
+    // call base method with new std::vector
+    std::vector<tlx::string_view> out;
+    split_view(&out, sep, str, limit);
+    return out;
+}
+
+std::vector<tlx::string_view> split_view(tlx::string_view sep,
+                                         tlx::string_view str,
+                                         tlx::string_view::size_type limit)
+{
+    // call base method with new std::vector
+    std::vector<tlx::string_view> out;
+    split_view(&out, sep, str, limit);
+    return out;
+}
+
+/******************************************************************************/
+// split_view() returning std::vector<tlx::string_view> with minimum fields
+
+std::vector<tlx::string_view> split_view(char sep, tlx::string_view str,
+                                         tlx::string_view::size_type min_fields,
+                                         tlx::string_view::size_type limit)
+{
+    // call base method with new std::vector
+    std::vector<tlx::string_view> out;
+    split_view(&out, sep, str, min_fields, limit);
+    return out;
+}
+
+std::vector<tlx::string_view> split_view(tlx::string_view sep,
+                                         tlx::string_view str,
+                                         tlx::string_view::size_type min_fields,
+                                         tlx::string_view::size_type limit)
+{
+    // call base method with new std::vector
+    std::vector<tlx::string_view> out;
+    split_view(&out, sep, str, min_fields, limit);
+    return out;
+}
+
+/******************************************************************************/
+// split_view() into std::vector<tlx::string_view>
+
+std::vector<tlx::string_view>& split_view(std::vector<tlx::string_view>* into,
+                                          char sep, tlx::string_view str,
+                                          tlx::string_view::size_type limit)
+{
+    into->clear();
+    if (limit == 0)
+        return *into;
+
+    tlx::string_view::const_iterator it = str.begin(), last = it;
+
+    for (; it != str.end(); ++it)
+    {
+        if (*it == sep)
+        {
+            if (into->size() + 1 >= limit)
+            {
+                into->emplace_back(last, str.end());
+                return *into;
+            }
+
+            into->emplace_back(last, it);
+            last = it + 1;
+        }
+    }
+
+    into->emplace_back(last, it);
+
+    return *into;
+}
+
+std::vector<tlx::string_view>& split_view(std::vector<tlx::string_view>* into,
+                                          tlx::string_view sep,
+                                          tlx::string_view str,
+                                          tlx::string_view::size_type limit)
+{
+    into->clear();
+    if (limit == 0)
+        return *into;
+
+    if (sep.empty())
+    {
+        tlx::string_view::const_iterator it = str.begin();
+        while (it != str.end())
+        {
+            into->emplace_back(it, it + 1);
+            ++it;
+        }
+        return *into;
+    }
+
+    tlx::string_view::const_iterator it = str.begin(), last = it;
+
+    for (; it + sep.size() < str.end(); ++it)
+    {
+        if (std::equal(sep.begin(), sep.begin() + sep.size(), it))
+        {
+            if (into->size() + 1 >= limit)
+            {
+                into->emplace_back(last, str.end());
+                return *into;
+            }
+
+            into->emplace_back(last, it);
+            last = it + sep.size();
+        }
+    }
+
+    into->emplace_back(last, str.end());
+
+    return *into;
+}
+
+/******************************************************************************/
+// split_view() into std::vector<tlx::string_view> with minimum fields
+
+std::vector<tlx::string_view>& split_view(
+    std::vector<tlx::string_view>* into, char sep, tlx::string_view str,
+    tlx::string_view::size_type min_fields, tlx::string_view::size_type limit)
+{
+    // call base method
+    split_view(into, sep, str, limit);
+
+    if (into->size() < min_fields)
+        into->resize(min_fields);
+
+    return *into;
+}
+
+std::vector<tlx::string_view>& split_view(
+    std::vector<tlx::string_view>* into, tlx::string_view sep,
+    tlx::string_view str, tlx::string_view::size_type min_fields,
+    tlx::string_view::size_type limit)
+{
+    // call base method
+    split_view(into, sep, str, limit);
+
+    if (into->size() < min_fields)
+        into->resize(min_fields);
+
+    return *into;
+}
+
+} // namespace tlx
+
+/******************************************************************************/

--- a/tlx/string/split_view.hpp
+++ b/tlx/string/split_view.hpp
@@ -15,6 +15,7 @@
 
 #include <tlx/container/string_view.hpp>
 #include <string>
+#include <vector>
 
 namespace tlx {
 
@@ -22,6 +23,9 @@ namespace tlx {
 //! \{
 //! \name Split and Join
 //! \{
+
+/******************************************************************************/
+// split_callback() with a Functor receiving string views
 
 /*!
  * Split the given string at each separator character into distinct substrings,
@@ -35,9 +39,9 @@ namespace tlx {
  * \param limit     maximum number of parts returned
  */
 template <typename Functor>
-static inline void split_view(char sep, tlx::string_view str,
-                              Functor&& callback,
-                              std::string::size_type limit = std::string::npos)
+static inline void split_callback(
+    char sep, tlx::string_view str, Functor&& callback,
+    std::string::size_type limit = std::string::npos)
 {
     if (limit == 0)
     {
@@ -64,6 +68,145 @@ static inline void split_view(char sep, tlx::string_view str,
     }
     callback(StringView(last, it));
 }
+
+/******************************************************************************/
+// split_view() returning std::vector<tlx::string_view>
+
+/*!
+ * Split the given string at each separator character into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.
+ *
+ * \param sep    separator character
+ * \param str    string to split
+ * \param limit  maximum number of parts returned
+ * \return       vector containing each split substring
+ */
+std::vector<tlx::string_view> split_view(
+    char sep, tlx::string_view str,
+    tlx::string_view::size_type limit = tlx::string_view::npos);
+
+/*!
+ * Split the given string at each separator string into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.
+ *
+ * \param sep    separator string
+ * \param str    string to split
+ * \param limit  maximum number of parts returned
+ * \return       vector containing each split substring
+ */
+std::vector<tlx::string_view> split_view(
+    tlx::string_view sep, tlx::string_view str,
+    tlx::string_view::size_type limit = tlx::string_view::npos);
+
+/******************************************************************************/
+// split_view() returning std::vector<tlx::string_view> with minimum fields
+
+/*!
+ * Split the given string at each separator character into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.  Returns a vector of strings with at least
+ * min_fields and at most limit_fields, empty fields are added if needed.
+ *
+ * \param sep         separator string
+ * \param str         string to split
+ * \param min_fields  minimum number of parts returned
+ * \param limit       maximum number of parts returned
+ * \return            vector containing each split substring
+ */
+std::vector<tlx::string_view> split_view(char sep, tlx::string_view str,
+                                         tlx::string_view::size_type min_fields,
+                                         tlx::string_view::size_type limit);
+
+/*!
+ * Split the given string at each separator string into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.  Returns a vector of strings with at least
+ * min_fields and at most limit_fields, empty fields are added if needed.
+ *
+ * \param sep         separator string
+ * \param str         string to split
+ * \param min_fields  minimum number of parts returned
+ * \param limit       maximum number of parts returned
+ * \return            vector containing each split substring
+ */
+std::vector<tlx::string_view> split_view(tlx::string_view sep,
+                                         tlx::string_view str,
+                                         tlx::string_view::size_type min_fields,
+                                         tlx::string_view::size_type limit);
+
+/******************************************************************************/
+// split_view() into std::vector<tlx::string_view>
+
+/*!
+ * Split the given string at each separator character into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.
+ *
+ * \param into   destination std::vector
+ * \param sep    separator character
+ * \param str    string to split
+ * \param limit  maximum number of parts returned
+ * \return       vector containing each split substring
+ */
+std::vector<tlx::string_view>& split_view(
+    std::vector<tlx::string_view>* into, char sep, tlx::string_view str,
+    tlx::string_view::size_type limit = tlx::string_view::npos);
+
+/*!
+ * Split the given string at each separator string into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.
+ *
+ * \param into   destination std::vector
+ * \param sep    separator string
+ * \param str    string to split
+ * \param limit  maximum number of parts returned
+ * \return       vector containing each split substring
+ */
+std::vector<tlx::string_view>& split_view(
+    std::vector<tlx::string_view>* into, tlx::string_view sep,
+    tlx::string_view str,
+    tlx::string_view::size_type limit = tlx::string_view::npos);
+
+/******************************************************************************/
+// split_view() into std::vector<tlx::string_view> with minimum fields
+
+/*!
+ * Split the given string at each separator character into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.  Returns a vector of strings with at least
+ * min_fields and at most limit_fields, empty fields are added if needed.
+ *
+ * \param into        destination std::vector
+ * \param sep         separator character
+ * \param str         string to split
+ * \param min_fields  minimum number of parts returned
+ * \param limit       maximum number of parts returned
+ * \return            vector containing each split substring
+ */
+std::vector<tlx::string_view>& split_view(
+    std::vector<tlx::string_view>* into, char sep, tlx::string_view str,
+    tlx::string_view::size_type min_fields, tlx::string_view::size_type limit);
+
+/*!
+ * Split the given string at each separator string into distinct substrings.
+ * Multiple consecutive separators are considered individually and will result
+ * in empty split substrings.  Returns a vector of strings with at least
+ * min_fields and at most limit_fields, empty fields are added if needed.
+ *
+ * \param into        destination std::vector
+ * \param sep         separator string
+ * \param str         string to split
+ * \param min_fields  minimum number of parts returned
+ * \param limit       maximum number of parts returned
+ * \return            vector containing each split substring
+ */
+std::vector<tlx::string_view>& split_view(
+    std::vector<tlx::string_view>* into, tlx::string_view sep,
+    tlx::string_view str, tlx::string_view::size_type min_fields,
+    tlx::string_view::size_type limit);
 
 //! \}
 //! \}

--- a/tlx/string/split_words.cpp
+++ b/tlx/string/split_words.cpp
@@ -51,6 +51,42 @@ std::vector<std::string> split_words(tlx::string_view str,
     return out;
 }
 
+std::vector<tlx::string_view> split_words_view(tlx::string_view str,
+                                               std::string::size_type limit)
+{
+    std::vector<tlx::string_view> out;
+    if (limit == 0)
+        return out;
+
+    tlx::string_view::const_iterator it = str.begin(), last = it;
+
+    for (; it != str.end(); ++it)
+    {
+        if (*it == ' ' || *it == '\n' || *it == '\t' || *it == '\r')
+        {
+            if (it == last)
+            { // skip over empty split substrings
+                last = it + 1;
+                continue;
+            }
+
+            if (out.size() + 1 >= limit)
+            {
+                out.emplace_back(last, str.end());
+                return out;
+            }
+
+            out.emplace_back(last, it);
+            last = it + 1;
+        }
+    }
+
+    if (last != it)
+        out.emplace_back(last, it);
+
+    return out;
+}
+
 } // namespace tlx
 
 /******************************************************************************/

--- a/tlx/string/split_words.hpp
+++ b/tlx/string/split_words.hpp
@@ -32,6 +32,18 @@ namespace tlx {
 std::vector<std::string> split_words(
     tlx::string_view str, std::string::size_type limit = std::string::npos);
 
+/*!
+ * Split the given string by whitespaces into distinct words. Multiple
+ * consecutive whitespaces are considered as one split point. Whitespaces are
+ * space, tab, newline and carriage-return.
+ *
+ * \param str   string to split
+ * \param limit maximum number of parts returned
+ * \return      vector containing each split substring
+ */
+std::vector<tlx::string_view> split_words_view(
+    tlx::string_view str, std::string::size_type limit = std::string::npos);
+
 //! \}
 
 } // namespace tlx


### PR DESCRIPTION
This PR creates `split_view` and `split_words_view` which return vectors of `string_view`s instead of copying the data.

Also rename old `split_view` to `split_callback`. This is a breaking change, however, it also indicates that the old string_view usages can be replaced.