### PR TITLE
Insert instead of resize in push of heap

### DIFF
--- a/tests/container/d_ary_heap_speedtest.cpp
+++ b/tests/container/d_ary_heap_speedtest.cpp
@@ -50,7 +50,7 @@ public:
         HeapType heap;
 
         for (size_t i = 0; i < items; i++)
-            heap.push(items - i);
+            heap.push(i);
 
         die_unless(heap.size() == items);
     }

--- a/tests/container/d_ary_heap_speedtest.cpp
+++ b/tests/container/d_ary_heap_speedtest.cpp
@@ -24,7 +24,7 @@
 // *** Settings
 
 //! starting number of items to insert
-const size_t min_items = 125;
+const size_t min_items = 500;
 
 //! maximum number of items to insert
 const size_t max_items = 1024000 * 128;

--- a/tlx/container/d_ary_addressable_int_heap.hpp
+++ b/tlx/container/d_ary_addressable_int_heap.hpp
@@ -122,8 +122,9 @@ public:
     {
         // Avoid to add the key that we use to mark non present keys.
         assert(new_key != not_present());
-        if (new_key >= handles_.size())
-            handles_.resize(new_key + 1, not_present());
+        if (auto current_size = handles_.size(); new_key >= current_size)
+            handles_.insert(handles_.end(), new_key + 1 - current_size,
+                            not_present());
         else
             assert(handles_[new_key] == not_present());
 
@@ -138,8 +139,9 @@ public:
     {
         // Avoid to add the key that we use to mark non present keys.
         assert(new_key != not_present());
-        if (new_key >= handles_.size())
-            handles_.resize(new_key + 1, not_present());
+        if (auto current_size = handles_.size(); new_key >= current_size)
+            handles_.insert(handles_.end(), new_key + 1 - current_size,
+                            not_present());
         else
             assert(handles_[new_key] == not_present());
 


### PR DESCRIPTION
The current implementation for push in the d_ary_heap uses resize when the new key is to large for the `handle_` vector.
Afaik resize has not guarantees on the way the vector grows. This may result in a preformance bug, if keys get pushed in increasing order.
[cppreference](https://en.cppreference.com/w/cpp/container/vector/reserve#:~:text=When%20inserting%20a%20range%2C%20the%20range%20version%20of%20insert()%20is%20generally%20preferable%20as%20it%20preserves%20the%20correct%20capacity%20growth%20behavior%2C%20unlike%20reserve()%20followed%20by%20a%20series%20of%20push_back()s.) suggests the use of `.insert` in such cases:

> When inserting a range, the range version of [insert()](https://en.cppreference.com/w/cpp/container/vector/insert) is generally preferable as it preserves the correct capacity growth behavior, unlike reserve() followed by a series of [push_back()](https://en.cppreference.com/w/cpp/container/vector/push_back)s.