### PR TITLE
[ci] bump MacOS versions on github workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,12 +49,16 @@ jobs:
           gcc_install: "13"
           cxx_flags: "-D_GLIBCXX_DEBUG"
 
-        - name: "macOS 12 clang 14 Debug"
-          os: macos-12
-          build_type: "Debug"
-
         - name: "macOS 13 clang 15 Release"
           os: macos-13
+          build_type: "Release"
+
+        - name: "macOS 14 Debug"
+          os: macos-14
+          build_type: "Debug"
+
+        - name: "macOS 15 Release"
+          os: macos-15
           build_type: "Release"
 
         # - name: "Window Latest"


### PR DESCRIPTION
This PR bumps the MacOS versions to 14 and 15 on the Github workflows