### PR TITLE
[string] add more `tlx::trim()` methods for `char`s and `string_view`s

### DIFF
--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -975,41 +975,110 @@ static void test_trim()
     die_unequal(tlx::trim("abc  "), "abc");
     die_unequal(tlx::trim("  abc"), "abc");
     die_unequal(tlx::trim("  "), "");
+    die_unequal(tlx::trim("abc  ", ' '), "abc");
 
     die_unequal(tlx::trim_left("  abc  "), "abc  ");
     die_unequal(tlx::trim_left("abc  "), "abc  ");
     die_unequal(tlx::trim_left("  "), "");
+    die_unequal(tlx::trim_left("   abc  ", ' '), "abc  ");
 
     die_unequal(tlx::trim_right("  abc  "), "  abc");
     die_unequal(tlx::trim_right("  abc"), "  abc");
     die_unequal(tlx::trim_right("  "), "");
+    die_unequal(tlx::trim_right("  abc   ", ' '), "  abc");
 
     // in-place functions
     std::string str1 = "  abc  ";
     std::string str2 = "abc  ";
     std::string str3 = "  ";
+    std::string str4 = "  abc  ";
 
     die_unequal(tlx::trim_left(&str1), "abc  ");
     die_unequal(tlx::trim_left(&str2), "abc  ");
     die_unequal(tlx::trim_left(&str3), "");
+    die_unequal(tlx::trim_left(&str4, ' '), "abc  ");
 
     str1 = "  abc  ";
     str2 = "  abc";
     str3 = "  ";
+    str4 = "  abc  ";
 
     die_unequal(tlx::trim_right(&str1), "  abc");
     die_unequal(tlx::trim_right(&str2), "  abc");
     die_unequal(tlx::trim_right(&str3), "");
+    die_unequal(tlx::trim_right(&str4, ' '), "  abc");
 
     str1 = "  abc  ";
     str2 = "  abc";
     str3 = "abc  ";
-    std::string str4 = "  ";
+    str4 = "  ";
+    std::string str5 = "  abc  ";
 
     die_unequal(tlx::trim(&str1), "abc");
     die_unequal(tlx::trim(&str2), "abc");
     die_unequal(tlx::trim(&str3), "abc");
     die_unequal(tlx::trim(&str4), "");
+    die_unequal(tlx::trim(&str5, ' '), "abc");
+}
+
+static void test_trim_string_view()
+{
+    // string_view-copy functions
+    tlx::string_view sv1("  abc  ");
+    tlx::string_view sv2("abc  ");
+    tlx::string_view sv3("  abc");
+    tlx::string_view sv4("  ");
+
+    die_unequal(tlx::trim(sv1), "abc");
+    die_unequal(tlx::trim(sv2), "abc");
+    die_unequal(tlx::trim(sv3), "abc");
+    die_unequal(tlx::trim(sv4), "");
+    die_unequal(tlx::trim(sv1, ' '), "abc");
+
+    die_unequal(tlx::trim_left(sv1), "abc  ");
+    die_unequal(tlx::trim_left(sv2), "abc  ");
+    die_unequal(tlx::trim_left(sv3), "abc");
+    die_unequal(tlx::trim_left(sv4), "");
+    die_unequal(tlx::trim_left(sv1, ' '), "abc  ");
+
+    die_unequal(tlx::trim_right(sv1), "  abc");
+    die_unequal(tlx::trim_right(sv2), "abc");
+    die_unequal(tlx::trim_right(sv3), "  abc");
+    die_unequal(tlx::trim_right(sv4), "");
+    die_unequal(tlx::trim_right(sv1, ' '), "  abc");
+
+    // in-place functions
+    tlx::string_view str1 = "  abc  ";
+    tlx::string_view str2 = "abc  ";
+    tlx::string_view str3 = "  ";
+    tlx::string_view str4 = "  abc  ";
+
+    die_unequal(tlx::trim_left(&str1), "abc  ");
+    die_unequal(tlx::trim_left(&str2), "abc  ");
+    die_unequal(tlx::trim_left(&str3), "");
+    die_unequal(tlx::trim_left(&str4, ' '), "abc  ");
+
+    str1 = "  abc  ";
+    str2 = "  abc";
+    str3 = "  ";
+    str4 = "  abc  ";
+
+    die_unequal(tlx::trim_right(&str1), "  abc");
+    die_unequal(tlx::trim_right(&str2), "  abc");
+    die_unequal(tlx::trim_right(&str3), "");
+    die_unequal(tlx::trim_right(&str4, ' '), "  abc");
+
+    str1 = "  abc  ";
+    str2 = "  abc";
+    str3 = "abc  ";
+    str4 = "  ";
+    tlx::string_view str5 = "  abc  ";
+
+    die_unequal(tlx::trim(&str1), "abc");
+    die_unequal(tlx::trim(&str2), "abc");
+    die_unequal(tlx::trim(&str3), "abc");
+    die_unequal(tlx::trim(&str4), "");
+    die_unequal(tlx::trim(&str5, ' '), "abc");
 }
 
 static void test_word_wrap()
@@ -1162,6 +1231,7 @@ int main()
     test_starts_with_ends_with();
     test_toupper_tolower();
     test_trim();
+    test_trim_string_view();
     test_word_wrap();
 
     return 0;

--- a/tlx/string/trim.cpp
+++ b/tlx/string/trim.cpp
@@ -39,6 +39,66 @@ std::string& trim(std::string* str, tlx::string_view drop)
     return *str;
 }
 
+std::string& trim(std::string* str, char drop)
+{
+    std::string::size_type pos = str->find_last_not_of(drop);
+    if (pos != std::string::npos)
+    {
+        str->erase(pos + 1);
+        pos = str->find_first_not_of(drop);
+        if (pos != std::string::npos)
+            str->erase(0, pos);
+    }
+    else
+        str->erase(str->begin(), str->end());
+
+    return *str;
+}
+
+tlx::string_view& trim(tlx::string_view* str)
+{
+    return trim(str, " \r\n\t");
+}
+
+tlx::string_view& trim(tlx::string_view* str, tlx::string_view drop)
+{
+    tlx::string_view::size_type pos =
+        str->find_last_not_of(drop.data(), std::string::npos, drop.size());
+    if (pos == std::string::npos)
+        str->clear();
+    else
+    {
+        str->remove_suffix(str->size() - pos - 1);
+
+        pos = str->find_first_not_of(drop.data(), 0, drop.size());
+        if (pos != std::string::npos)
+            str->remove_prefix(pos);
+        else
+            str->clear();
+    }
+
+    return *str;
+}
+
+tlx::string_view& trim(tlx::string_view* str, char drop)
+{
+    tlx::string_view::size_type pos = str->find_last_not_of(drop);
+    if (pos == std::string::npos)
+        str->clear();
+    else
+    {
+        str->remove_suffix(str->size() - pos - 1);
+
+        pos = str->find_first_not_of(drop);
+        if (pos != std::string::npos)
+            str->remove_prefix(pos);
+        else
+            str->clear();
+    }
+
+    return *str;
+}
+
 tlx::string_view trim(tlx::string_view str)
 {
     return trim(str, " \r\n\t");
@@ -63,6 +123,24 @@ tlx::string_view trim(tlx::string_view str, tlx::string_view drop)
     return out;
 }
 
+tlx::string_view trim(tlx::string_view str, char drop)
+{
+    tlx::string_view out = str;
+
+    // trim beginning
+    tlx::string_view::size_type pos = out.find_first_not_of(drop);
+    if (pos == tlx::string_view::npos)
+        return tlx::string_view();
+    out.remove_prefix(pos);
+
+    // trim end
+    pos = out.find_last_not_of(drop);
+    if (pos != tlx::string_view::npos)
+        out.remove_suffix(out.size() - pos - 1);
+
+    return out;
+}
+
 /******************************************************************************/
 
 std::string& trim_right(std::string* str)
@@ -79,6 +157,40 @@ std::string& trim_right(std::string* str, tlx::string_view drop)
     return *str;
 }
 
+std::string& trim_right(std::string* str, char drop)
+{
+    str->erase(str->find_last_not_of(drop) + 1, std::string::npos);
+    return *str;
+}
+
+tlx::string_view& trim_right(tlx::string_view* str)
+{
+    return trim_right(str, " \r\n\t");
+}
+
+tlx::string_view& trim_right(tlx::string_view* str, tlx::string_view drop)
+{
+    tlx::string_view::size_type pos =
+        str->find_last_not_of(drop.data(), tlx::string_view::npos, drop.size());
+    if (pos != tlx::string_view::npos)
+        str->remove_suffix(str->size() - pos - 1);
+    else
+        str->clear();
+
+    return *str;
+}
+
+tlx::string_view& trim_right(tlx::string_view* str, char drop)
+{
+    tlx::string_view::size_type pos = str->find_last_not_of(drop);
+    if (pos != tlx::string_view::npos)
+        str->remove_suffix(str->size() - pos - 1);
+    else
+        str->clear();
+
+    return *str;
+}
+
 tlx::string_view trim_right(tlx::string_view str)
 {
     return trim_right(str, " \r\n\t");
@@ -88,6 +200,15 @@ tlx::string_view trim_right(tlx::string_view str, tlx::string_view drop)
 {
     tlx::string_view::size_type pos =
         str.find_last_not_of(drop.data(), tlx::string_view::npos, drop.size());
+    if (pos == tlx::string_view::npos)
+        return tlx::string_view();
+
+    return str.substr(0, pos + 1);
+}
+
+tlx::string_view trim_right(tlx::string_view str, char drop)
+{
+    tlx::string_view::size_type pos = str.find_last_not_of(drop);
     if (pos == tlx::string_view::npos)
         return tlx::string_view();
 
@@ -107,6 +228,40 @@ std::string& trim_left(std::string* str, tlx::string_view drop)
     return *str;
 }
 
+std::string& trim_left(std::string* str, char drop)
+{
+    str->erase(0, str->find_first_not_of(drop));
+    return *str;
+}
+
+tlx::string_view& trim_left(tlx::string_view* str)
+{
+    return trim_left(str, " \r\n\t");
+}
+
+tlx::string_view& trim_left(tlx::string_view* str, tlx::string_view drop)
+{
+    tlx::string_view::size_type pos =
+        str->find_first_not_of(drop.data(), 0, drop.size());
+    if (pos != tlx::string_view::npos)
+        str->remove_prefix(pos);
+    else
+        str->clear();
+
+    return *str;
+}
+
+tlx::string_view& trim_left(tlx::string_view* str, char drop)
+{
+    tlx::string_view::size_type pos = str->find_first_not_of(drop);
+    if (pos != tlx::string_view::npos)
+        str->remove_prefix(pos);
+    else
+        str->clear();
+
+    return *str;
+}
+
 tlx::string_view trim_left(tlx::string_view str)
 {
     return trim_left(str, " \r\n\t");
@@ -116,6 +271,15 @@ tlx::string_view trim_left(tlx::string_view str, tlx::string_view drop)
 {
     tlx::string_view::size_type pos =
         str.find_first_not_of(drop.data(), 0, drop.size());
+    if (pos == tlx::string_view::npos)
+        return tlx::string_view();
+
+    return str.substr(pos, std::string::npos);
+}
+
+tlx::string_view trim_left(tlx::string_view str, char drop)
+{
+    tlx::string_view::size_type pos = str.find_first_not_of(drop);
     if (pos == tlx::string_view::npos)
         return tlx::string_view();
 

--- a/tlx/string/trim.hpp
+++ b/tlx/string/trim.hpp
@@ -44,6 +44,45 @@ std::string& trim(std::string* str, tlx::string_view drop);
 
 /*!
  * Trims the given string in-place on the left and right. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      reference to the modified string
+ */
+std::string& trim(std::string* str, char drop);
+
+/*!
+ * Trims the given string in-place on the left and right. Removes all
+ * characters in the given drop array, which defaults to " \r\n\t".
+ *
+ * \param str   string to process
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim(tlx::string_view* str);
+
+/*!
+ * Trims the given string in-place on the left and right. Removes all
+ * characters in the given drop array, which defaults to " \r\n\t".
+ *
+ * \param str   string to process
+ * \param drop  remove these characters
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim(tlx::string_view* str, tlx::string_view drop);
+
+/*!
+ * Trims the given string in-place on the left and right. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim(tlx::string_view* str, char drop);
+
+/*!
+ * Trims the given string in-place on the left and right. Removes all
  * characters in the given drop array, which defaults to " \r\n\t".
  *
  * \param str   string to process
@@ -60,6 +99,16 @@ tlx::string_view trim(tlx::string_view str);
  * \return      reference to the modified string
  */
 tlx::string_view trim(tlx::string_view str, tlx::string_view drop);
+
+/*!
+ * Trims the given string in-place on the left and right. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      reference to the modified string
+ */
+tlx::string_view trim(tlx::string_view str, char drop);
 
 /******************************************************************************/
 
@@ -83,6 +132,45 @@ std::string& trim_right(std::string* str);
 std::string& trim_right(std::string* str, tlx::string_view drop);
 
 /*!
+ * Trims the given string in-place only on the right. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      reference to the modified string
+ */
+std::string& trim_right(std::string* str, char drop);
+
+/*!
+ * Trims the given string in-place only on the right. Removes all characters in
+ * the given drop array, which defaults to " \r\n\t".
+ *
+ * \param str   string to process
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim_right(tlx::string_view* str);
+
+/*!
+ * Trims the given string in-place only on the right. Removes all characters in
+ * the given drop array, which defaults to " \r\n\t".
+ *
+ * \param str   string to process
+ * \param drop  remove these characters
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim_right(tlx::string_view* str, tlx::string_view drop);
+
+/*!
+ * Trims the given string in-place only on the right. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim_right(tlx::string_view* str, char drop);
+
+/*!
  * Trims the given string only on the right. Removes all characters in the
  * given drop array, which defaults to " \r\n\t". Returns a copy of the string.
  *
@@ -100,6 +188,16 @@ tlx::string_view trim_right(tlx::string_view str);
  * \return      new trimmed string
  */
 tlx::string_view trim_right(tlx::string_view str, tlx::string_view drop);
+
+/*!
+ * Trims the given string only on the right. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      new trimmed string
+ */
+tlx::string_view trim_right(tlx::string_view str, char drop);
 
 /******************************************************************************/
 
@@ -123,6 +221,45 @@ std::string& trim_left(std::string* str);
 std::string& trim_left(std::string* str, tlx::string_view drop);
 
 /*!
+ * Trims the given string in-place only on the left. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      reference to the modified string
+ */
+std::string& trim_left(std::string* str, char drop);
+
+/*!
+ * Trims the given string in-place only on the left. Removes all characters in
+ * the given drop array, which defaults to " \r\n\t".
+ *
+ * \param str   string to process
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim_left(tlx::string_view* str);
+
+/*!
+ * Trims the given string in-place only on the left. Removes all characters in
+ * the given drop array, which defaults to " \r\n\t".
+ *
+ * \param str   string to process
+ * \param drop  remove these characters
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim_left(tlx::string_view* str, tlx::string_view drop);
+
+/*!
+ * Trims the given string in-place only on the left. Removes all
+ * characters equal to the given drop character.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      reference to the modified string
+ */
+tlx::string_view& trim_left(tlx::string_view* str, char drop);
+
+/*!
  * Trims the given string only on the left. Removes all characters in the given
  * drop array, which defaults to " \r\n\t". Returns a copy of the string.
  *
@@ -140,6 +277,16 @@ tlx::string_view trim_left(tlx::string_view str);
  * \return      new trimmed string
  */
 tlx::string_view trim_left(tlx::string_view str, tlx::string_view drop);
+
+/*!
+ * Trims the given string only on the left. Removes all characters equal to the
+ * given drop character. Returns a copy of the string.
+ *
+ * \param str   string to process
+ * \param drop  remove this character
+ * \return      new trimmed string
+ */
+tlx::string_view trim_left(tlx::string_view str, char drop);
 
 //! \}
 //! \}


### PR DESCRIPTION
Add more `tlx::trim()` methods:
- `std::string& trim(std::string* str, char drop);`
- `tlx::string_view& trim(tlx::string_view* str);`
- `tlx::string_view& trim(tlx::string_view* str, tlx::string_view drop);`
- `tlx::string_view& trim(tlx::string_view* str, char drop);`
- `tlx::string_view trim(tlx::string_view str, char drop);`
- `std::string& trim_right(std::string* str, char drop);`
- `tlx::string_view& trim_right(tlx::string_view* str);`
- `tlx::string_view& trim_right(tlx::string_view* str, tlx::string_view drop);`
- `tlx::string_view& trim_right(tlx::string_view* str, char drop);`
- `tlx::string_view trim_right(tlx::string_view str, char drop);`
- `std::string& trim_left(std::string* str, char drop);`
- `tlx::string_view& trim_left(tlx::string_view* str);`
- `tlx::string_view& trim_left(tlx::string_view* str, tlx::string_view drop);`
- `tlx::string_view& trim_left(tlx::string_view* str, char drop);`
- `tlx::string_view trim_left(tlx::string_view str, char drop);`