### PR TITLE
[string] add implicit construction and conversion to tlx::StringView

### DIFF
--- a/tlx/container/string_view.hpp
+++ b/tlx/container/string_view.hpp
@@ -119,9 +119,13 @@ public:
     }
 
 #if __cplusplus >= 201703L
+    //! implicit construction from a std::string_view
     StringView(std::string_view sv) noexcept : StringView(sv.data(), sv.size())
     {
     }
+
+    //! implicit conversion to std::string_view
+    operator std::string_view() const { return std::string_view(data(), size()); }
 #endif
 
     //! \name iterators


### PR DESCRIPTION
This PR adds an implicit constructor and implicit conversion cast to/from `std::string_view` for `tlx::StringView`.