### PR TITLE
[ci] remove ubuntu-14.04 and use ubuntu-16.04-1 with cmake version 3.7.2

### DIFF
--- a/.woodpecker/build-test.yaml
+++ b/.woodpecker/build-test.yaml
@@ -7,20 +7,6 @@ when:
 
 matrix:
   include:
-    - IMAGE:        ubuntu-14.04
-      BUILD_TYPE:   Debug
-      C_COMPILER:   gcc
-      CXX_COMPILER: g++
-      CXX_FLAGS:
-      CMAKE_FLAGS:
-
-    - IMAGE:        ubuntu-14.04
-      BUILD_TYPE:   Release
-      C_COMPILER:   gcc
-      CXX_COMPILER: g++
-      CXX_FLAGS:
-      CMAKE_FLAGS:
-
     - IMAGE:        ubuntu-16.04
       BUILD_TYPE:   Debug
       C_COMPILER:   gcc

--- a/.woodpecker/build-test.yaml
+++ b/.woodpecker/build-test.yaml
@@ -7,28 +7,28 @@ when:
 
 matrix:
   include:
-    - IMAGE:        ubuntu-16.04
+    - IMAGE:        ubuntu-16.04-1
       BUILD_TYPE:   Debug
       C_COMPILER:   gcc
       CXX_COMPILER: g++
       CXX_FLAGS:
       CMAKE_FLAGS:
 
-    - IMAGE:        ubuntu-16.04
+    - IMAGE:        ubuntu-16.04-1
       BUILD_TYPE:   Release
       C_COMPILER:   gcc
       CXX_COMPILER: g++
       CXX_FLAGS:
       CMAKE_FLAGS:
 
-    - IMAGE:        ubuntu-16.04
+    - IMAGE:        ubuntu-16.04-1
       BUILD_TYPE:   Debug
       C_COMPILER:   clang
       CXX_COMPILER: clang++
       CXX_FLAGS:
       CMAKE_FLAGS:
 
-    - IMAGE:        ubuntu-16.04
+    - IMAGE:        ubuntu-16.04-1
       BUILD_TYPE:   Release
       C_COMPILER:   clang
       CXX_COMPILER: clang++


### PR DESCRIPTION
Change Woodpecker CI, preparing for newer cmake version checks:
- remove ubuntu-14.04
- use ubuntu-16.04-1 with cmake version 3.7.2